### PR TITLE
Call the app `new_relic_agent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You need to set a few required configuration keys so we can authenticate properl
 #### Via Application config
 
 ```elixir
-config :new_relic,
+config :new_relic_agent,
   app_name: "My App",
   license_key: "license_key"
 ```
@@ -48,6 +48,6 @@ You can also configure these attributes via `ENV` vars, which helps keep secrets
 The agent will log important events. By default they will go to `tmp/new_relic.log`. You can also configure it to go to `STDOUT` or any other writable file location:
 
 ```elixir
-config :new_relic,
+config :new_relic_agent,
   log: "stdout"
 ```

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :logger, level: :warn
 
-config :new_relic,
+config :new_relic_agent,
   harvest_enabled: false,
   app_name: "ElixirAgentTest",
   automatic_attributes: [test_attribute: "test_value"],

--- a/lib/new_relic/aggregate/reporter.ex
+++ b/lib/new_relic/aggregate/reporter.ex
@@ -46,5 +46,5 @@ defmodule NewRelic.Aggregate.Reporter do
   end
 
   def aggregate_event_type,
-    do: Application.get_env(:new_relic, :aggregate_event_type, "ElixirAggregate")
+    do: Application.get_env(:new_relic_agent, :aggregate_event_type, "ElixirAggregate")
 end

--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -7,15 +7,17 @@ defmodule NewRelic.Config do
 
   @doc "Configure your application name. **Required**"
   def app_name,
-    do: System.get_env("NEW_RELIC_APP_NAME") || Application.get_env(:new_relic, :app_name)
+    do: System.get_env("NEW_RELIC_APP_NAME") || Application.get_env(:new_relic_agent, :app_name)
 
   @doc "Configure your New Relic License Key. **Required**"
   def license_key,
-    do: System.get_env("NEW_RELIC_LICENSE_KEY") || Application.get_env(:new_relic, :license_key)
+    do:
+      System.get_env("NEW_RELIC_LICENSE_KEY") ||
+        Application.get_env(:new_relic_agent, :license_key)
 
   @doc "Configure the host to report to. Most customers have no need to set this."
   def host,
-    do: System.get_env("NEW_RELIC_HOST") || Application.get_env(:new_relic, :host)
+    do: System.get_env("NEW_RELIC_HOST") || Application.get_env(:new_relic_agent, :host)
 
   @doc """
   Configure the Agent logging mechanism. Defaults to `"tmp/new_relic.log"`
@@ -26,7 +28,7 @@ defmodule NewRelic.Config do
   - `"file_name.log"`
   """
   def logger,
-    do: System.get_env("NEW_RELIC_LOG") || Application.get_env(:new_relic, :log)
+    do: System.get_env("NEW_RELIC_LOG") || Application.get_env(:new_relic_agent, :log)
 
   @doc """
   An optional list of key/value pairs that will be automatic custom attributes
@@ -40,7 +42,7 @@ defmodule NewRelic.Config do
   Example:
 
   ```
-  config :new_relic,
+  config :new_relic_agent,
     automatic_attributes: [
       environment: {:system, "APP_ENV"},
       node_name: {Node, :self, []},
@@ -49,7 +51,7 @@ defmodule NewRelic.Config do
   ```
   """
   def automatic_attributes do
-    Application.get_env(:new_relic, :automatic_attributes, [])
+    Application.get_env(:new_relic_agent, :automatic_attributes, [])
     |> Enum.into(%{}, fn
       {name, {:system, env_var}} -> {name, System.get_env(env_var)}
       {name, {m, f, a}} -> {name, apply(m, f, a)}
@@ -63,7 +65,7 @@ defmodule NewRelic.Config do
   defp harvest_enabled?,
     do:
       System.get_env("NEW_RELIC_HARVEST_ENABLED") ||
-        Application.get_env(:new_relic, :harvest_enabled, true)
+        Application.get_env(:new_relic_agent, :harvest_enabled, true)
 
   @external_resource "VERSION"
   @agent_version "VERSION" |> File.read!() |> String.trim()

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -22,7 +22,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
           :ignore
 
         %{"redirect_host" => redirect_host} ->
-          Application.put_env(:new_relic, :collector_instance_host, redirect_host)
+          Application.put_env(:new_relic_agent, :collector_instance_host, redirect_host)
           send(self(), :connect)
       end
     end
@@ -123,7 +123,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
   end
 
   def lookup(key) do
-    Application.get_env(:new_relic, key) ||
+    Application.get_env(:new_relic_agent, key) ||
       case :ets.lookup(__MODULE__, key) do
         [{^key, value}] -> value
         [] -> nil

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -56,12 +56,12 @@ defmodule NewRelic.Harvest.Collector.Protocol do
 
     %URI{
       host:
-        Application.get_env(:new_relic, :collector_instance_host) ||
-          Application.get_env(:new_relic, :collector_host),
+        Application.get_env(:new_relic_agent, :collector_instance_host) ||
+          Application.get_env(:new_relic_agent, :collector_host),
       path: "/agent_listener/invoke_raw_method",
       query: URI.encode_query(params),
-      scheme: Application.get_env(:new_relic, :scheme, "https"),
-      port: Application.get_env(:new_relic, :port, 443)
+      scheme: Application.get_env(:new_relic_agent, :scheme, "https"),
+      port: Application.get_env(:new_relic_agent, :port, 443)
     }
     |> URI.to_string()
   end
@@ -92,7 +92,7 @@ defmodule NewRelic.Harvest.Collector.Protocol do
             ] do
     NewRelic.log(:error, exception["message"])
     NewRelic.log(:error, "Disabling agent harvest")
-    Application.put_env(:new_relic, :harvest_enabled, false)
+    Application.put_env(:new_relic_agent, :harvest_enabled, false)
     {:error, :license_exception}
   end
 

--- a/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
@@ -122,10 +122,12 @@ defmodule NewRelic.Harvest.Collector.TransactionTrace.Harvester do
   def collect_traces(%{slowest_traces: slowest_traces, traces_by_name: traces_by_name}),
     do: (slowest_traces ++ Map.values(traces_by_name)) |> List.flatten() |> Enum.uniq()
 
-  defp min_duration, do: Application.get_env(:new_relic, :transaction_trace_min_duration, 50)
+  defp min_duration,
+    do: Application.get_env(:new_relic_agent, :transaction_trace_min_duration, 50)
 
   defp max_named_traces,
-    do: Application.get_env(:new_relic, :transaction_trace_max_named_traces, 2)
+    do: Application.get_env(:new_relic_agent, :transaction_trace_max_named_traces, 2)
 
-  defp max_slow_traces, do: Application.get_env(:new_relic, :transaction_trace_max_slow_traces, 5)
+  defp max_slow_traces,
+    do: Application.get_env(:new_relic_agent, :transaction_trace_max_slow_traces, 5)
 end

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -6,7 +6,7 @@ defmodule NewRelic.Init do
   end
 
   def init_collector_host() do
-    Application.put_env(:new_relic, :collector_host, determine_collector_host())
+    Application.put_env(:new_relic_agent, :collector_host, determine_collector_host())
   end
 
   def determine_collector_host() do

--- a/lib/new_relic/sampler/reporter.ex
+++ b/lib/new_relic/sampler/reporter.ex
@@ -5,7 +5,7 @@ defmodule NewRelic.Sampler.Reporter do
     do: NewRelic.report_custom_event(sampler_event_type(), Map.put(sample, :category, category))
 
   def sampler_event_type,
-    do: Application.get_env(:new_relic, :sample_event_type, "ElixirSample")
+    do: Application.get_env(:new_relic_agent, :sample_event_type, "ElixirSample")
 
-  def sample_cycle, do: Application.get_env(:new_relic, :sample_cycle, 15_000)
+  def sample_cycle, do: Application.get_env(:new_relic_agent, :sample_cycle, 15_000)
 end

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -115,7 +115,7 @@ defmodule NewRelic.Transaction.Reporter do
     Process.send_after(
       __MODULE__,
       {:purge, AttrStore.find_root(__MODULE__, pid)},
-      Application.get_env(:new_relic, :tx_pid_expire, 2_000)
+      Application.get_env(:new_relic_agent, :tx_pid_expire, 2_000)
     )
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule NewRelic.Mixfile do
 
   def project do
     [
-      app: :new_relic,
+      app: :new_relic_agent,
       description: "New Relic's Open-Source Elixir Agent",
       version: agent_version(),
       elixir: "~> 1.7",
@@ -26,7 +26,6 @@ defmodule NewRelic.Mixfile do
 
   defp package do
     [
-      name: "new_relic_agent",
       files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "VERSION"],
       maintainers: ["Vince Foley"],
       licenses: ["Apache 2.0"],

--- a/test/collector_stub_test.exs
+++ b/test/collector_stub_test.exs
@@ -68,15 +68,17 @@ defmodule CollectorStubTest do
   end
 
   def with_config(env, fun) do
-    original_env = env |> Enum.map(fn {key, _} -> {key, Application.get_env(:new_relic, key)} end)
-    env |> Enum.each(fn {key, value} -> Application.put_env(:new_relic, key, value) end)
+    original_env =
+      env |> Enum.map(fn {key, _} -> {key, Application.get_env(:new_relic_agent, key)} end)
+
+    env |> Enum.each(fn {key, value} -> Application.put_env(:new_relic_agent, key, value) end)
 
     fun.()
 
     original_env
     |> Enum.each(fn
-      {key, nil} -> Application.delete_env(:new_relic, key)
-      {key, value} -> Application.put_env(:new_relic, key, value)
+      {key, nil} -> Application.delete_env(:new_relic_agent, key)
+      {key, value} -> Application.put_env(:new_relic_agent, key, value)
     end)
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -22,7 +22,7 @@ defmodule ConfigTest do
     System.put_env("ENV_VAR_NAME", "env-var-value")
 
     Application.put_env(
-      :new_relic,
+      :new_relic_agent,
       :automatic_attributes,
       env_var: {:system, "ENV_VAR_NAME"},
       function_call: {String, :upcase, ["fun"]},
@@ -35,7 +35,7 @@ defmodule ConfigTest do
              function_call: "FUN"
            }
 
-    Application.put_env(:new_relic, :automatic_attributes, [])
+    Application.put_env(:new_relic_agent, :automatic_attributes, [])
     System.delete_env("ENV_VAR_NAME")
   end
 end

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -64,7 +64,7 @@ defmodule CustomEventTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :custom_event_harvest_cycle, 300)
+    Application.put_env(:new_relic_agent, :custom_event_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.CustomEvent.HarvestCycle)
@@ -80,7 +80,7 @@ defmodule CustomEventTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-    Application.delete_env(:new_relic, :custom_event_harvest_cycle)
+    Application.delete_env(:new_relic_agent, :custom_event_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000
@@ -118,7 +118,7 @@ defmodule CustomEventTest do
     System.put_env("MY_SERVICE_NAME", "crazy-service")
 
     Application.put_env(
-      :new_relic,
+      :new_relic_agent,
       :automatic_attributes,
       service_name: {:system, "MY_SERVICE_NAME"}
     )
@@ -132,12 +132,12 @@ defmodule CustomEventTest do
              event[:key] == "TestEvent" && event[:service_name] == "crazy-service"
            end)
 
-    Application.put_env(:new_relic, :automatic_attributes, [])
+    Application.put_env(:new_relic_agent, :automatic_attributes, [])
     System.delete_env("MY_SERVICE_NAME")
   end
 
   test "Respect the reservoir_size" do
-    Application.put_env(:new_relic, :custom_event_reservoir_size, 3)
+    Application.put_env(:new_relic_agent, :custom_event_reservoir_size, 3)
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
 
     NewRelic.report_custom_event(:Event, %{key: "TestEvent1"})
@@ -149,7 +149,7 @@ defmodule CustomEventTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
     assert length(events) == 3
 
-    Application.delete_env(:new_relic, :custom_event_reservoir_size)
+    Application.delete_env(:new_relic_agent, :custom_event_reservoir_size)
     TestHelper.pause_harvest_cycle(Collector.CustomEvent.HarvestCycle)
   end
 end

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -47,7 +47,7 @@ defmodule ErrorTraceTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :data_report_period, 300)
+    Application.put_env(:new_relic_agent, :data_report_period, 300)
     TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.ErrorTrace.HarvestCycle)
@@ -63,7 +63,7 @@ defmodule ErrorTraceTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
-    Application.delete_env(:new_relic, :data_report_period)
+    Application.delete_env(:new_relic_agent, :data_report_period)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/integration/agent_run_test.exs
+++ b/test/integration/agent_run_test.exs
@@ -38,8 +38,8 @@ defmodule AgentRunIntegrationTest do
   test "Agent restart ability" do
     original_agent_run_id = Collector.AgentRun.agent_run_id()
 
-    Application.stop(:new_relic)
-    Application.start(:new_relic)
+    Application.stop(:new_relic_agent)
+    Application.start(:new_relic_agent)
 
     GenServer.call(Collector.AgentRun, :connected)
     new_agent_run_id = Collector.AgentRun.agent_run_id()

--- a/test/integration/collector_test.exs
+++ b/test/integration/collector_test.exs
@@ -34,13 +34,13 @@ defmodule CollectorIntegrationTest do
   end
 
   test "handles invalid license key" do
-    prev = Application.get_env(:new_relic, :harvest_enabled)
+    prev = Application.get_env(:new_relic_agent, :harvest_enabled)
     System.put_env("NEW_RELIC_LICENSE_KEY", "invalid_key")
 
     assert {:error, :license_exception} = Collector.Protocol.preconnect()
 
     System.delete_env("NEW_RELIC_LICENSE_KEY")
-    Application.put_env(:new_relic, :harvest_enabled, prev)
+    Application.put_env(:new_relic_agent, :harvest_enabled, prev)
   end
 
   test "Can post a metric" do

--- a/test/metric_harvester_test.exs
+++ b/test/metric_harvester_test.exs
@@ -24,7 +24,7 @@ defmodule MetricHarvesterTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :data_report_period, 300)
+    Application.put_env(:new_relic_agent, :data_report_period, 300)
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.Metric.HarvestCycle)
@@ -40,7 +40,7 @@ defmodule MetricHarvesterTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
-    Application.delete_env(:new_relic, :data_report_period)
+    Application.delete_env(:new_relic_agent, :data_report_period)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -42,7 +42,7 @@ defmodule SpanEventTest do
   end
 
   test "collect and store top priority events" do
-    Application.put_env(:new_relic, :span_event_reservoir_size, 2)
+    Application.put_env(:new_relic_agent, :span_event_reservoir_size, 2)
     {:ok, harvester} = Supervisor.start_child(Collector.SpanEvent.HarvesterSupervisor, [])
 
     s1 = %NewRelic.Span.Event{priority: 3, trace_id: "abc123"}
@@ -65,7 +65,7 @@ defmodule SpanEventTest do
     Collector.SpanEvent.Harvester.complete(harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
 
-    Application.delete_env(:new_relic, :span_event_reservoir_size)
+    Application.delete_env(:new_relic_agent, :span_event_reservoir_size)
   end
 
   test "report a span event through the harvester" do

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -193,13 +193,13 @@ defmodule TracerTest do
   end
 
   test "Don't track trace segments that are NOT part of a process in a Transaction" do
-    Application.put_env(:new_relic, :tx_attr_expire, 50)
+    Application.put_env(:new_relic_agent, :tx_attr_expire, 50)
 
     Traced.fun()
 
     attrs = NewRelic.Util.AttrStore.find_attributes(NewRelic.Transaction.Reporter, [self()])
     assert Enum.empty?(attrs)
 
-    Application.delete_env(:new_relic, :tx_attr_expire)
+    Application.delete_env(:new_relic_agent, :tx_attr_expire)
   end
 end

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -107,7 +107,7 @@ defmodule TransactionErrorEventTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :error_event_harvest_cycle, 300)
+    Application.put_env(:new_relic_agent, :error_event_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.TransactionErrorEvent.HarvestCycle)
@@ -125,7 +125,7 @@ defmodule TransactionErrorEventTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
-    Application.delete_env(:new_relic, :error_event_harvest_cycle)
+    Application.delete_env(:new_relic_agent, :error_event_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -44,7 +44,7 @@ defmodule TransactionEventTest do
   end
 
   test "collect and store top priority events" do
-    Application.put_env(:new_relic, :transaction_event_reservoir_size, 2)
+    Application.put_env(:new_relic_agent, :transaction_event_reservoir_size, 2)
     {:ok, harvester} = Supervisor.start_child(Collector.TransactionEvent.HarvesterSupervisor, [])
 
     ev1 = %Event{name: "Ev1", duration: 1, user_attributes: %{priority: 3}}
@@ -67,7 +67,7 @@ defmodule TransactionEventTest do
     Collector.TransactionEvent.Harvester.complete(harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
 
-    Application.delete_env(:new_relic, :transaction_event_reservoir_size)
+    Application.delete_env(:new_relic_agent, :transaction_event_reservoir_size)
   end
 
   test "user attributes can be truncated" do
@@ -87,7 +87,7 @@ defmodule TransactionEventTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :transaction_event_harvest_cycle, 300)
+    Application.put_env(:new_relic_agent, :transaction_event_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.TransactionEvent.HarvestCycle)
@@ -103,7 +103,7 @@ defmodule TransactionEventTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
-    Application.delete_env(:new_relic, :transaction_event_harvest_cycle)
+    Application.delete_env(:new_relic_agent, :transaction_event_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000
@@ -138,7 +138,7 @@ defmodule TransactionEventTest do
   end
 
   test "Respect the reservoir_size" do
-    Application.put_env(:new_relic, :transaction_event_reservoir_size, 3)
+    Application.put_env(:new_relic_agent, :transaction_event_reservoir_size, 3)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
     Task.async(fn ->
@@ -153,7 +153,7 @@ defmodule TransactionEventTest do
     events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
     assert length(events) == 3
 
-    Application.delete_env(:new_relic, :transaction_event_reservoir_size)
+    Application.delete_env(:new_relic_agent, :transaction_event_reservoir_size)
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 end

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -86,7 +86,7 @@ defmodule TransactionTraceTest do
   end
 
   test "harvest cycle" do
-    Application.put_env(:new_relic, :data_report_period, 300)
+    Application.put_env(:new_relic_agent, :data_report_period, 300)
     TestHelper.restart_harvest_cycle(Collector.TransactionTrace.HarvestCycle)
 
     first = Collector.HarvestCycle.current_harvester(Collector.TransactionTrace.HarvestCycle)
@@ -102,7 +102,7 @@ defmodule TransactionTraceTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.TransactionTrace.HarvestCycle)
-    Application.delete_env(:new_relic, :data_report_period)
+    Application.delete_env(:new_relic_agent, :data_report_period)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000


### PR DESCRIPTION
The name `new_relic` is already taken, so we already call the Hex package `new_relic_agent`. This PR switches the name of the application as well, so we don't get confused.