### PR TITLE
Increase the async delay for tests

### DIFF
--- a/test/backoff_sampler_test.exs
+++ b/test/backoff_sampler_test.exs
@@ -3,6 +3,8 @@ defmodule BackoffSamplerTest do
   alias NewRelic.DistributedTrace.BackoffSampler
 
   test "Backoff behavior as best as we can" do
+    # This is testing an inherently random algorithm
+
     send(BackoffSampler, :reset)
 
     assert BackoffSampler.sample?()
@@ -30,6 +32,10 @@ defmodule BackoffSamplerTest do
     send(BackoffSampler, :cycle)
 
     decisions = [
+      BackoffSampler.sample?(),
+      BackoffSampler.sample?(),
+      BackoffSampler.sample?(),
+      BackoffSampler.sample?(),
       BackoffSampler.sample?(),
       BackoffSampler.sample?(),
       BackoffSampler.sample?(),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,12 +11,12 @@ defmodule TestHelper do
   end
 
   def trigger_report(module) do
-    Process.sleep(200)
+    Process.sleep(300)
     GenServer.call(module, :report)
   end
 
   def gather_harvest(harvester) do
-    Process.sleep(200)
+    Process.sleep(300)
     harvester.gather_harvest
   end
 


### PR DESCRIPTION
The timing is different in Travis, so this PR is increasing the async wait that we'll do to allow instrumentation events to get collected