### PR TITLE
Use HTTPoison for agent http requests

### DIFF
--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -66,10 +66,10 @@ defmodule NewRelic.Harvest.Collector.Protocol do
     |> URI.to_string()
   end
 
-  defp parse_http_response({:ok, {{_, 200, 'OK'}, _headers, body}}),
+  defp parse_http_response({:ok, %{status_code: 200, body: body}}),
     do: {:ok, Jason.decode!(body)}
 
-  defp parse_http_response({:ok, {{_, status, _}, _headers, body}}) do
+  defp parse_http_response({:ok, %{status_code: status, body: body}}) do
     NewRelic.log(:error, "(#{status}) #{body}")
     {:error, status}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule NewRelic.Mixfile do
       {:jason, "~> 1.0"},
       {:plug, "~> 1.6"},
       {:cowboy, "~> 2.0"},
-      {:httpoison, ">= 1.0.0", optional: true}
+      {:httpoison, "~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
This PR uses `HTTPoison` for internal agent http requests, which also means it's now a non-optional dep.

@mattbaker 