### PR TITLE
Report as elixir

### DIFF
--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -55,7 +55,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
   def connect_payload do
     [
       %{
-        language: "sdk",
+        language: "elixir",
         pid: NewRelic.Util.pid(),
         host: NewRelic.Util.hostname(),
         app_name: [NewRelic.Config.app_name()],


### PR DESCRIPTION
Update the agent to report as `elixir` instead of `sdk`

**WIP**: the New Relic ingest pipeline is being updated to support this