### PR TITLE
Note that original HTTPoison structs are returned

### DIFF
--- a/lib/new_relic/instrumented/httpoison.ex
+++ b/lib/new_relic/instrumented/httpoison.ex
@@ -13,6 +13,19 @@ if Code.ensure_loaded?(HTTPoison) do
     ```
 
     This module mirrors the interface of `HTTPoison`
+
+    #### Notes:
+
+    * If you need to pattern match against a result, note that the structs that come back are
+    the original `HTTPoison` structs.
+
+    ```elixir
+    # Match against the full struct name
+    {:ok, %Elixir.HTTPoison.Response{body: body}} = HTTPoison.get("http://www.example.com")
+
+    # Match against it with a raw map
+    {:ok, %{body: body}} = HTTPoison.get("http://www.example.com")
+    ```
     """
 
     defp instrument(method, url, headers) do

--- a/test/instrumented_test.exs
+++ b/test/instrumented_test.exs
@@ -6,13 +6,19 @@ defmodule InstrumentedTest do
     :ok
   end
 
+  alias NewRelic.Instrumented.HTTPoison
+
   test "HTTPoison" do
-    {:ok, response} = NewRelic.Instrumented.HTTPoison.get("http://www.google.com")
+    {:ok, response} = HTTPoison.get("http://www.google.com")
     assert response.status_code == 200
   end
 
   test "HTTPoison request" do
-    {:ok, response} = NewRelic.Instrumented.HTTPoison.request(:get, "http://www.google.com")
+    {:ok, response} = HTTPoison.request(:get, "http://www.google.com")
     assert response.status_code == 200
+  end
+
+  test "original HTTPoison.Error struct is returned" do
+    {:error, %Elixir.HTTPoison.Error{}} = HTTPoison.get("localhost:12345")
   end
 end


### PR DESCRIPTION
Adds a note about matching against the return `HTTPoison` struct

sidekick/ @mattbaker 
closes/ #26 