### PR TITLE
Extend the timeout on harvester send_harvest

### DIFF
--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -47,15 +47,6 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.CustomEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.CustomEvent.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -51,7 +51,7 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.CustomEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.CustomEvent.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/data_supervisor.ex
+++ b/lib/new_relic/harvest/collector/data_supervisor.ex
@@ -15,7 +15,6 @@ defmodule NewRelic.Harvest.Collector.DataSupervisor do
     harvester_cycle = Module.concat(namespace, HarvestCycle)
 
     children = [
-      supervisor(Task.Supervisor, [[name: Module.concat(namespace, TaskSupervisor)]]),
       supervisor(Collector.HarvesterSupervisor, [
         [harvester: harvester, name: harvester_supervisor]
       ]),
@@ -23,7 +22,6 @@ defmodule NewRelic.Harvest.Collector.DataSupervisor do
         [
           name: harvester_cycle,
           harvest_cycle_key: harvest_cycle_key,
-          module: harvester,
           supervisor: harvester_supervisor
         ]
       ])

--- a/lib/new_relic/harvest/collector/error_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/error_trace/harvester.ex
@@ -35,15 +35,6 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.ErrorTrace.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.ErrorTrace.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/error_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/error_trace/harvester.ex
@@ -39,7 +39,7 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.ErrorTrace.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.ErrorTrace.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -33,15 +33,6 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.Metric.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.Metric.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -37,7 +37,7 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.Metric.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.Metric.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -76,15 +76,6 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.SpanEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.SpanEvent.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -80,7 +80,7 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.SpanEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.SpanEvent.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
@@ -42,7 +42,7 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.TransactionErrorEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.TransactionErrorEvent.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
@@ -38,15 +38,6 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.TransactionErrorEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.TransactionErrorEvent.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/transaction_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_event/harvester.ex
@@ -43,7 +43,7 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.TransactionEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.TransactionEvent.HarvesterSupervisor, harvester)
     end)
   end

--- a/lib/new_relic/harvest/collector/transaction_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_event/harvester.ex
@@ -39,15 +39,6 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.TransactionEvent.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.TransactionEvent.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
@@ -40,15 +40,6 @@ defmodule NewRelic.Harvest.Collector.TransactionTrace.Harvester do
       |> Collector.HarvestCycle.current_harvester()
       |> GenServer.call(:gather_harvest)
 
-  def complete(nil), do: :ignore
-
-  def complete(harvester) do
-    Task.Supervisor.start_child(Collector.TransactionTrace.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest, 15_000)
-      Supervisor.terminate_child(Collector.TransactionTrace.HarvesterSupervisor, harvester)
-    end)
-  end
-
   # Server
 
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}

--- a/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
@@ -44,7 +44,7 @@ defmodule NewRelic.Harvest.Collector.TransactionTrace.Harvester do
 
   def complete(harvester) do
     Task.Supervisor.start_child(Collector.TransactionTrace.TaskSupervisor, fn ->
-      GenServer.call(harvester, :send_harvest)
+      GenServer.call(harvester, :send_harvest, 15_000)
       Supervisor.terminate_child(Collector.TransactionTrace.HarvesterSupervisor, harvester)
     end)
   end

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -48,7 +48,7 @@ defmodule CustomEventTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.CustomEvent.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.CustomEvent.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
   end
 

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -42,7 +42,7 @@ defmodule ErrorTraceTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.ErrorTrace.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.ErrorTrace.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
   end
 

--- a/test/metric_harvester_test.exs
+++ b/test/metric_harvester_test.exs
@@ -19,7 +19,7 @@ defmodule MetricHarvesterTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.Metric.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.Metric.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
   end
 

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -62,7 +62,7 @@ defmodule SpanEventTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.SpanEvent.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.SpanEvent.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
 
     Application.delete_env(:new_relic_agent, :span_event_reservoir_size)

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -102,7 +102,12 @@ defmodule TransactionErrorEventTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.TransactionErrorEvent.Harvester.complete(harvester)
+
+    Collector.HarvestCycle.send_harvest(
+      Collector.TransactionErrorEvent.HarvesterSupervisor,
+      harvester
+    )
+
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
   end
 

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -64,7 +64,7 @@ defmodule TransactionEventTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.TransactionEvent.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.TransactionEvent.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
 
     Application.delete_env(:new_relic_agent, :transaction_event_reservoir_size)

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -81,7 +81,7 @@ defmodule TransactionTraceTest do
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)
-    Collector.TransactionTrace.Harvester.complete(harvester)
+    Collector.HarvestCycle.send_harvest(Collector.TransactionTrace.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
   end
 


### PR DESCRIPTION
This PR extends the time that a harvester Task is willing to wait for the `send_harvest` action. The action is essentially doing an HTTPoison request, which has it's own built-in timeout values of `8000` for connecting and `5000` for receiving a response.

The Task isn't blocking anything so this won't impact anything else in the agent.