### PR TITLE
Optionally disable error reporting

### DIFF
--- a/lib/new_relic/application.ex
+++ b/lib/new_relic/application.ex
@@ -12,11 +12,17 @@ defmodule NewRelic.Application do
       worker(NewRelic.Logger, []),
       supervisor(NewRelic.Harvest.Supervisor, []),
       supervisor(NewRelic.Sampler.Supervisor, []),
-      supervisor(NewRelic.Error.Supervisor, []),
       supervisor(NewRelic.Transaction.Supervisor, []),
       supervisor(NewRelic.DistributedTrace.Supervisor, []),
       supervisor(NewRelic.Aggregate.Supervisor, [])
     ]
+
+    children =
+      if NewRelic.Config.error_reporting_enabled?() do
+        children ++ [supervisor(NewRelic.Error.Supervisor, [])]
+      else
+        children
+      end
 
     opts = [strategy: :one_for_one, name: NewRelic.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -59,6 +59,11 @@ defmodule NewRelic.Config do
     end)
   end
 
+  @doc "Whether error reporting is enabled. Default is true (error reporting on)."
+  def error_reporting_enabled? do
+    Application.get_env(:new_relic_agent, :error_reporting_enabled, true)
+  end
+
   @doc false
   def enabled?, do: (harvest_enabled?() && app_name() && license_key() && true) || false
 

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -1,6 +1,7 @@
 defmodule NewRelic.Transaction.Reporter do
   use GenServer
 
+  alias NewRelic.Config
   alias NewRelic.Util
   alias NewRelic.Util.AttrStore
   alias NewRelic.Transaction
@@ -60,12 +61,17 @@ defmodule NewRelic.Transaction.Reporter do
   def stop(%{kind: _kind} = error) do
     add_attributes(
       end_time_mono: System.monotonic_time(),
-      error: true,
-      transaction_error: error,
-      error_kind: error.kind,
-      error_reason: inspect(error.reason),
-      error_stack: inspect(error.stack)
+      error: true
     )
+
+    if Config.error_reporting_enabled?() do
+      add_attributes(
+        transaction_error: error,
+        error_kind: error.kind,
+        error_reason: inspect(error.reason),
+        error_stack: inspect(error.stack)
+      )
+    end
 
     complete()
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,6 +34,12 @@ defmodule TestHelper do
       _ -> false
     end)
   end
+
+  def with_error_reporting_disabled(func) do
+    Application.put_env(:new_relic_agent, :error_reporting_enabled, false)
+    func.()
+    Application.put_env(:new_relic_agent, :error_reporting_enabled, true)
+  end
 end
 
 ExUnit.start()

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -219,6 +219,38 @@ defmodule TransactionErrorEventTest do
     TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
   end
 
+  test "Any errors are not reported if error reporting is disabled" do
+    TestHelper.with_error_reporting_disabled(fn ->
+      Application.stop(:new_relic_agent)
+      :error_logger.delete_report_handler(NewRelic.Error.ErrorHandler)
+      Application.start(:new_relic_agent)
+
+      Logger.remove_backend(:console)
+      TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
+      TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
+      TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
+      {:ok, _sup} = Task.Supervisor.start_link(name: TestSup)
+
+      TestHelper.request(TestPlugApp, conn(:get, "/error"))
+      TestHelper.request(TestPlugApp, conn(:get, "/caught/error"))
+
+      traces = TestHelper.gather_harvest(Collector.ErrorTrace.Harvester)
+      assert length(traces) == 0
+
+      traces = TestHelper.gather_harvest(Collector.TransactionErrorEvent.Harvester)
+      assert length(traces) == 0
+
+      Process.sleep(50)
+      Logger.add_backend(:console)
+      TestHelper.pause_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
+      TestHelper.pause_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
+      TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
+    end)
+
+    Application.stop(:new_relic_agent)
+    Application.start(:new_relic_agent)
+  end
+
   defmodule CustomError do
     defexception [:message, :expected]
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -129,8 +129,26 @@ defmodule TransactionTest do
 
     assert Enum.find(events, fn [_, event] ->
              event[:status] == 500 && event[:query] =~ "query{}" &&
-               event[:error_reason] =~ "TransactionError"
+               event[:error_reason] =~ "TransactionError" && event[:error_kind] == :error &&
+               event[:error_stack] =~ "test/transaction_test.exs"
            end)
+  end
+
+  test "Error in Transaction when error_reporting_enabled = false" do
+    TestHelper.with_error_reporting_disabled(fn ->
+      TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+
+      assert_raise RuntimeError, fn ->
+        TestPlugApp.call(conn(:get, "/error"), [])
+      end
+
+      events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+
+      assert Enum.find(events, fn [_, event] ->
+               event[:status] == 500 && event[:error] == true && event[:error_reason] == nil &&
+                 event[:error_kind] == nil && event[:error_stack] == nil
+             end)
+    end)
   end
 
   test "Transaction with traced external service call" do


### PR DESCRIPTION
For environments where error reporting is not desired, the `error_reporting_enabled` config can be
set to false.

@binaryseed do you have any suggestions on the best way to test the dynamic application.ex setup? I was thinking of an integration style test in transaction_error_event_test.exs, but it would involve tearing down the entire application supervisor and restarting it. That could be done with `async: false` and would be safe. edit: Turns out that async: false is the default, so it's simply a matter of wanting to go that route.