### PR TITLE
Extend Beam sampler stats

### DIFF
--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -56,7 +56,7 @@ defmodule NewRelic.Sampler.Beam do
       input_kb: bytes_in / @kb,
       output_kb: bytes_out / @kb,
       reductions: reductions,
-      run_queue: :erlang.statistics(:run_queue),
+      run_queue: :erlang.statistics(:total_run_queue_lengths),
       process_count: :erlang.system_info(:process_count),
       memory_total_mb: memory[:total] / @mb,
       memory_procs_mb: memory[:processes_used] / @mb,

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -49,17 +49,17 @@ defmodule SamplerTest do
   end
 
   test "Calculate scheduler utilization" do
-    last = :erlang.statistics(:scheduler_wall_time)
+    first = :erlang.statistics(:scheduler_wall_time)
 
     TestProcess.fib(20)
-    current = :erlang.statistics(:scheduler_wall_time)
+    second = :erlang.statistics(:scheduler_wall_time)
 
-    util_1 = NewRelic.Sampler.Beam.scheduler_utilization_delta(current, last)
+    util_1 = NewRelic.Sampler.Beam.scheduler_utilization_delta(second, first)
     assert util_1 > 0.05
 
     Process.sleep(5)
-    next = :erlang.statistics(:scheduler_wall_time)
-    util_2 = NewRelic.Sampler.Beam.scheduler_utilization_delta(next, last)
+    third = :erlang.statistics(:scheduler_wall_time)
+    util_2 = NewRelic.Sampler.Beam.scheduler_utilization_delta(third, first)
     assert util_1 > util_2
   end
 

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -26,8 +26,6 @@ defmodule SamplerTest do
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
 
-    TestProcess.fib(15)
-
     TestHelper.trigger_report(NewRelic.Sampler.Beam)
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
@@ -46,21 +44,6 @@ defmodule SamplerTest do
              TestHelper.find_metric(metrics, "CPU/User Time")
 
     assert cpu > 0
-  end
-
-  test "Calculate scheduler utilization" do
-    first = :erlang.statistics(:scheduler_wall_time)
-
-    TestProcess.fib(20)
-    second = :erlang.statistics(:scheduler_wall_time)
-
-    util_1 = NewRelic.Sampler.Beam.scheduler_utilization_delta(second, first)
-    assert util_1 > 0.05
-
-    Process.sleep(5)
-    third = :erlang.statistics(:scheduler_wall_time)
-    util_2 = NewRelic.Sampler.Beam.scheduler_utilization_delta(third, first)
-    assert util_1 > util_2
   end
 
   test "Process Sampler" do


### PR DESCRIPTION
This PR adds a few more statistics to the `Beam` sampler, including scheduler utilization

Also changed variable names since I got confused. `previous` is better than `last` since it's chronological order we are comparing.