### PR TITLE
Flatten attributes that are maps

### DIFF
--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -19,9 +19,9 @@ defmodule NewRelic.Transaction.Reporter do
 
   # Customer Exposed API
 
-  def add_attributes(attrs) do
+  def add_attributes(attrs) when is_list(attrs) do
     if tracking?(self()) do
-      AttrStore.add(__MODULE__, self(), attrs)
+      AttrStore.add(__MODULE__, self(), NewRelic.Util.deep_flatten(attrs))
     end
   end
 

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -62,7 +62,7 @@ defmodule NewRelic.Transaction.Reporter do
       add_attributes(
         end_time_mono: System.monotonic_time(),
         error: true,
-        transaction_error: error,
+        transaction_error: {:error, error},
         error_kind: error.kind,
         error_reason: inspect(error.reason),
         error_stack: inspect(error.stack)
@@ -85,7 +85,7 @@ defmodule NewRelic.Transaction.Reporter do
 
   def set_transaction_error(pid, error) do
     if tracking?(pid) do
-      AttrStore.add(__MODULE__, pid, transaction_error: error)
+      AttrStore.add(__MODULE__, pid, transaction_error: {:error, error})
     end
   end
 
@@ -381,7 +381,7 @@ defmodule NewRelic.Transaction.Reporter do
 
   defp report_transaction_error_event(_tx_attrs, nil), do: :ignore
 
-  defp report_transaction_error_event(tx_attrs, error) do
+  defp report_transaction_error_event(tx_attrs, {:error, error}) do
     attributes = Map.drop(tx_attrs, [:error, :error_kind, :error_reason, :error_stack])
 
     {exception_type, exception_reason, exception_stacktrace} =

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -16,6 +16,18 @@ defmodule NewRelic.Util do
   def time_to_ms({megasec, sec, microsec}),
     do: (megasec * 1_000_000 + sec) * 1_000 + round(microsec / 1_000)
 
+  def deep_flatten(attrs) when is_list(attrs) do
+    Enum.flat_map(attrs, &deep_flatten/1)
+  end
+
+  def deep_flatten({key, value}) when is_map(value) do
+    Enum.flat_map(value, fn {k, v} -> deep_flatten({"#{key}.#{k}", v}) end)
+  end
+
+  def deep_flatten({key, value}) do
+    [{key, value}]
+  end
+
   def elixir_environment() do
     build_info = System.build_info()
 

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -24,6 +24,14 @@ defmodule UtilTest do
     refute json =~ ":node"
   end
 
+  test "flatten deeply nested map attributes" do
+    flattened =
+      NewRelic.Util.deep_flatten(not_nested: "value", nested: %{foo: %{bar: %{baz: "qux"}}})
+
+    assert {"nested.foo.bar.baz", "qux"} in flattened
+    assert {:not_nested, "value"} in flattened
+  end
+
   test "Truncates unicode strings correctly" do
     %{key: truncated} =
       NewRelic.Util.Event.process_event(%{key: String.duplicate("a", 4094) <> "é"})


### PR DESCRIPTION
This PR will flatten any attribute value that is a map so that it's component parts all show up as their own attributes.

In favor of #39 