### PR TITLE
Detect and sample the top processes

### DIFF
--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -16,7 +16,10 @@ defmodule NewRelic.Sampler.Beam do
     :cpu_sup.util()
 
     NewRelic.sample_process()
-    if NewRelic.Config.enabled?(), do: send(self(), :report)
+
+    if NewRelic.Config.enabled?(),
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+
     {:ok, %{previous: take_sample()}}
   end
 

--- a/lib/new_relic/sampler/ets.ex
+++ b/lib/new_relic/sampler/ets.ex
@@ -13,7 +13,10 @@ defmodule NewRelic.Sampler.Ets do
 
   def init(:ok) do
     NewRelic.sample_process()
-    if NewRelic.Config.enabled?(), do: send(self(), :report)
+
+    if NewRelic.Config.enabled?(),
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+
     {:ok, %{}}
   end
 

--- a/lib/new_relic/sampler/reporter.ex
+++ b/lib/new_relic/sampler/reporter.ex
@@ -8,4 +8,6 @@ defmodule NewRelic.Sampler.Reporter do
     do: Application.get_env(:new_relic_agent, :sample_event_type, "ElixirSample")
 
   def sample_cycle, do: Application.get_env(:new_relic_agent, :sample_cycle, 15_000)
+
+  def random_offset, do: :rand.uniform(5 * 1000)
 end

--- a/lib/new_relic/sampler/supervisor.ex
+++ b/lib/new_relic/sampler/supervisor.ex
@@ -11,6 +11,7 @@ defmodule NewRelic.Sampler.Supervisor do
     children = [
       worker(NewRelic.Sampler.Beam, []),
       worker(NewRelic.Sampler.Process, []),
+      worker(NewRelic.Sampler.TopProcess, []),
       worker(NewRelic.Sampler.Ets, [])
     ]
 

--- a/lib/new_relic/sampler/top_process.ex
+++ b/lib/new_relic/sampler/top_process.ex
@@ -1,0 +1,86 @@
+defmodule NewRelic.Sampler.TopProcess do
+  use GenServer
+
+  # Track and sample the top processes by:
+  # * memory usage
+  # * message queue length
+
+  @moduledoc false
+
+  alias NewRelic.Util.PriorityQueue, as: PQ
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    NewRelic.sample_process()
+
+    if NewRelic.Config.enabled?(),
+      do: Process.send_after(self(), :sample, NewRelic.Sampler.Reporter.random_offset())
+
+    {:ok, :reset}
+  end
+
+  def handle_info(:sample, :reset) do
+    top_procs = detect_top_processes()
+    Process.send_after(self(), :report, NewRelic.Sampler.Reporter.sample_cycle())
+    {:noreply, top_procs}
+  end
+
+  @kb 1024
+  def handle_info(:report, top_procs) do
+    Enum.each(top_procs, &report_sample/1)
+    send(self(), :sample)
+    {:noreply, :reset}
+  end
+
+  def detect_top_processes() do
+    {mem_pq, msg_pq} =
+      Process.list()
+      |> Enum.reduce({PQ.new(), PQ.new()}, &measure_and_insert/2)
+
+    (PQ.values(mem_pq) ++ PQ.values(msg_pq))
+    |> Enum.uniq_by(&elem(&1, 0))
+  end
+
+  @size 5
+  def measure_and_insert(pid, {mem_pq, msg_pq}) do
+    case Process.info(pid, [:memory, :message_queue_len, :registered_name, :reductions]) do
+      [memory: mem, message_queue_len: msg, registered_name: _, reductions: _] = info ->
+        mem_pq = PQ.insert(mem_pq, @size, mem, {pid, info})
+        msg_pq = if msg > 0, do: PQ.insert(msg_pq, @size, msg, {pid, info}), else: msg_pq
+        {mem_pq, msg_pq}
+
+      nil ->
+        {mem_pq, msg_pq}
+    end
+  end
+
+  def report_sample({pid, info}) do
+    case Process.info(pid, :reductions) do
+      {:reductions, current_reductions} ->
+        NewRelic.report_sample(:ProcessSample, %{
+          pid: inspect(pid),
+          memory_kb: info[:memory] / @kb,
+          message_queue_length: info[:message_queue_len],
+          name: parse(:name, pid, info[:registered_name]),
+          reductions: current_reductions - info[:reductions]
+        })
+
+      nil ->
+        :ignore
+    end
+  end
+
+  defp parse(:name, pid, []) do
+    with {:dictionary, dictionary} <- Process.info(pid, :dictionary),
+         {m, f, a} <- Keyword.get(dictionary, :"$initial_call") do
+      "#{m}.#{f}/#{a}"
+    else
+      _ -> inspect(pid)
+    end
+  end
+
+  defp parse(:name, _pid, name), do: inspect(name)
+end

--- a/lib/new_relic/util/priority_queue.ex
+++ b/lib/new_relic/util/priority_queue.ex
@@ -25,4 +25,8 @@ defmodule NewRelic.Util.PriorityQueue do
   def values(tree) do
     :gb_trees.values(tree)
   end
+
+  def list(tree) do
+    :gb_trees.to_list(tree)
+  end
 end

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -129,4 +129,11 @@ defmodule SamplerTest do
       assert NewRelic.Sampler.Ets.record_sample(:nope_not_here) == :ignore
     end
   end
+
+  test "detect the processes which are top consumers" do
+    top_procs = NewRelic.Sampler.TopProcess.detect_top_processes()
+
+    assert length(top_procs) >= 5
+    assert length(top_procs) <= 10
+  end
 end


### PR DESCRIPTION
This PR adds a new sampler that will detect the top processes (according to memory & message queue length) and report on them

Also
* A few tweaks to the other process sampler to make it safer
* Randomize the start of each of the samplers so they all don't run at once