### PR TITLE
Test against OTP 20 and 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: elixir
 elixir: 1.7.3
-otp_release: 21.0.7
+otp_release:
+  - 21.1
+  - 20.3
 notifications:
   email:
     - vince@newrelic.com


### PR DESCRIPTION
In https://github.com/newrelic/elixir_agent/pull/38 we used some new stats from OTP 21. But for OTP 20 compat we need to protect against those calls...

To protect against this we're now running tests in OTP 20 and 21