### PR TITLE
Properly format top process names

### DIFF
--- a/lib/new_relic/sampler/top_process.ex
+++ b/lib/new_relic/sampler/top_process.ex
@@ -76,7 +76,7 @@ defmodule NewRelic.Sampler.TopProcess do
   defp parse(:name, pid, []) do
     with {:dictionary, dictionary} <- Process.info(pid, :dictionary),
          {m, f, a} <- Keyword.get(dictionary, :"$initial_call") do
-      "#{m}.#{f}/#{a}"
+      "#{inspect(m)}.#{f}/#{a}"
     else
       _ -> inspect(pid)
     end


### PR DESCRIPTION
Inspecting a module gets rid of the `Elixir.` module prefix