### PR TITLE
Split the functionality of stop(error)

### DIFF
--- a/lib/new_relic/transaction.ex
+++ b/lib/new_relic/transaction.ex
@@ -44,6 +44,7 @@ defmodule NewRelic.Transaction do
   def handle_errors(conn, error) do
     NewRelic.DistributedTrace.Tracker.cleanup(self())
     NewRelic.Transaction.Plug.add_stop_attrs(conn)
-    NewRelic.Transaction.Reporter.stop(error)
+    NewRelic.Transaction.Reporter.fail(error)
+    NewRelic.Transaction.Reporter.stop(conn)
   end
 end


### PR DESCRIPTION
Splitting this functionality in order to use the failure marking separate from completing the transaction.