### PR TITLE
Add more flexibility for Transaction naming

### DIFF
--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -56,13 +56,13 @@ defmodule NewRelic.Transaction.Plug do
 
   def add_stop_attrs(conn) do
     [
-      default_name: default_name(conn),
+      plug_name: plug_name(conn),
       status: conn.status
     ]
     |> NewRelic.add_attributes()
   end
 
-  def default_name(conn),
+  def plug_name(conn),
     do:
       "/Plug/#{conn.method}/#{match_path(conn)}"
       |> String.replace("/*glob", "")

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -203,10 +203,9 @@ defmodule NewRelic.Transaction.Reporter do
              System.convert_time_unit(end_time_mono - start_time_mono, :native, :milliseconds)
          })
 
-  defp transform_name_attrs(%{custom_name: custom_name} = tx), do: Map.put(tx, :name, custom_name)
-
-  defp transform_name_attrs(%{default_name: default_name} = tx),
-    do: Map.put(tx, :name, default_name)
+  defp transform_name_attrs(%{custom_name: name} = tx), do: Map.put(tx, :name, name)
+  defp transform_name_attrs(%{framework_name: name} = tx), do: Map.put(tx, :name, name)
+  defp transform_name_attrs(%{plug_name: name} = tx), do: Map.put(tx, :name, name)
 
   defp extract_transaction_info(tx_attrs, pid) do
     {function_segments, tx_attrs} = Map.pop(tx_attrs, :trace_function_segments, [])


### PR DESCRIPTION
This PR extends Transaction naming storage so that we can have more flexibility.

1) Custom name if set
2) Framework name if set (for phoenix, etc)
3) Fallback to plug name