### PR TITLE
Identify Phoenix transactions using the controller and action

### DIFF
--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -62,6 +62,11 @@ defmodule NewRelic.Transaction.Plug do
     |> NewRelic.add_attributes()
   end
 
+  def plug_name(%{private: %{phoenix_controller: controller, phoenix_action: action}}),
+    do:
+      "/Phoenix/#{controller}/#{action}"
+      |> String.replace("/Phoenix/Elixir.", "/Phoenix/")
+
   def plug_name(conn),
     do:
       "/Plug/#{conn.method}/#{match_path(conn)}"

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -34,4 +34,23 @@ defmodule PlugTest do
              TestHelper.request(TestPlugApp, conn(:get, "/double"))
            end) =~ "[warn]"
   end
+
+  test "plug_name is set on the transaction" do
+    conn = TestHelper.request(TestPlugApp, conn(:get, "/"))
+
+    assert NewRelic.Util.AttrStore.collect(NewRelic.Transaction.Reporter, conn.request_pid)
+           |> Map.get(:plug_name) == "/Plug/GET//"
+  end
+
+  test "Phoenix plug_name utilizes the controller and action names" do
+    request_conn =
+      conn(:get, "/")
+      |> put_private(:phoenix_action, :show)
+      |> put_private(:phoenix_controller, TestPlugApp)
+
+    conn = TestHelper.request(TestPlugApp, request_conn)
+
+    assert NewRelic.Util.AttrStore.collect(NewRelic.Transaction.Reporter, conn.request_pid)
+           |> Map.get(:plug_name) == "/Phoenix/PlugTest.TestPlugApp/show"
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,6 +3,7 @@ defmodule TestHelper do
     Task.async(fn ->
       try do
         module.call(conn, [])
+        |> Map.put(:request_pid, self())
       rescue
         error -> error
       end


### PR DESCRIPTION
This will create a transaction named like `/Phoenix/MyAppWeb.MyController/show` based on the
controller and action name.

It has been discussed putting this in a separate  package. However, I do believe it to be so common that it is best served in the base package.