### PR TITLE
Set plug_name upon stop

### DIFF
--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -56,7 +56,6 @@ defmodule NewRelic.Transaction.Plug do
 
   def add_stop_attrs(conn) do
     [
-      plug_name: plug_name(conn),
       status: conn.status
     ]
     |> NewRelic.add_attributes()

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -67,8 +67,12 @@ defmodule NewRelic.Transaction.Reporter do
     end
   end
 
-  def stop(%Plug.Conn{}) do
-    add_attributes(end_time_mono: System.monotonic_time())
+  def stop(%Plug.Conn{} = conn) do
+    add_attributes(
+      plug_name: Transaction.Plug.plug_name(conn),
+      end_time_mono: System.monotonic_time()
+    )
+
     complete()
   end
 


### PR DESCRIPTION
Always set the `plug_name` upon Transaction stop, instead of in the Plug. This will make it easier to stop the transaction in other adapters.