### PR TITLE
Leverage OTP 21 `:logger` when we can

### DIFF
--- a/lib/new_relic/error/error_handler.ex
+++ b/lib/new_relic/error/error_handler.ex
@@ -17,10 +17,6 @@ defmodule NewRelic.Error.ErrorHandler do
   def code_change(_old_vsn, state, _extra), do: {:ok, state}
   def terminate(_reason, _state), do: :ok
 
-  alias NewRelic.Util
-  alias NewRelic.Harvest.Collector
-  alias NewRelic.Transaction
-
   def handle_event({_type, gl, _report}, state)
       when node(gl) != node() do
     {:ok, state}
@@ -28,11 +24,11 @@ defmodule NewRelic.Error.ErrorHandler do
 
   def handle_event({:error_report, _gl, {pid, :crash_report, [report | _]}}, state)
       when is_list(report) do
-    if Transaction.Reporter.tracking?(pid) do
-      report_transaction_error(report)
+    if NewRelic.Transaction.Reporter.tracking?(pid) do
+      NewRelic.Error.Reporter.report_transaction_error(report)
     else
       Task.Supervisor.start_child(NewRelic.Error.TaskSupervisor, fn ->
-        report_process_error(report)
+        NewRelic.Error.Reporter.report_process_error(report)
       end)
     end
 
@@ -40,70 +36,4 @@ defmodule NewRelic.Error.ErrorHandler do
   end
 
   def handle_event(_, state), do: {:ok, state}
-
-  def report_transaction_error(report) do
-    {kind, exception, stacktrace} = parse_error_info(report[:error_info])
-    process_name = parse_process_name(report[:registered_name], stacktrace)
-
-    Transaction.Reporter.set_transaction_error(report[:pid], %{
-      kind: kind,
-      process: process_name,
-      reason: exception,
-      stack: stacktrace
-    })
-  end
-
-  def report_process_error(report) do
-    {_kind, exception, stacktrace} = parse_error_info(report[:error_info])
-
-    {exception_type, exception_reason, exception_stacktrace} =
-      Util.Error.normalize(exception, stacktrace, report[:initial_call])
-
-    process_name = parse_process_name(report[:registered_name], stacktrace)
-    expected = parse_error_expected(exception)
-    automatic_attributes = NewRelic.Config.automatic_attributes()
-
-    Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
-      timestamp: System.system_time(:milliseconds) / 1_000,
-      error_type: inspect(exception_type),
-      message: exception_reason,
-      expected: expected,
-      stack_trace: exception_stacktrace,
-      transaction_name: "WebTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name
-        })
-    })
-
-    Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
-      timestamp: System.system_time(:milliseconds) / 1_000,
-      error_class: inspect(exception_type),
-      error_message: exception_reason,
-      expected: expected,
-      transaction_name: "WebTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name,
-          stacktrace: Enum.join(exception_stacktrace, "\n")
-        })
-    })
-
-    unless expected do
-      NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
-      NewRelic.report_metric(:error, error_count: 1)
-    end
-  end
-
-  defp parse_process_name([], [{module, _f, _a, _} | _]), do: inspect(module)
-  defp parse_process_name([], _stacktrace), do: "UnknownProcess"
-  defp parse_process_name(registered_name, _stacktrace), do: inspect(registered_name)
-
-  defp parse_error_info({kind, {exception, stacktrace}, _stack}) when is_list(stacktrace),
-    do: {kind, exception, stacktrace}
-
-  defp parse_error_info({kind, exception, stacktrace}), do: {kind, exception, stacktrace}
-
-  defp parse_error_expected(%{expected: true}), do: true
-  defp parse_error_expected(_), do: false
 end

--- a/lib/new_relic/error/error_logger_handler.ex
+++ b/lib/new_relic/error/error_logger_handler.ex
@@ -1,11 +1,17 @@
-defmodule NewRelic.Error.ErrorHandler do
+defmodule NewRelic.Error.ErrorLoggerHandler do
   @behaviour :gen_event
+  @moduledoc false
 
-  # This event handler gets installed as an Error Logger, which
-  # receives messages when error events are logged.
   # http://erlang.org/doc/man/error_logger.html
 
-  @moduledoc false
+  def add_handler() do
+    :error_logger.delete_report_handler(NewRelic.Error.ErrorLoggerHandler)
+    :error_logger.add_report_handler(NewRelic.Error.ErrorLoggerHandler)
+  end
+
+  def remove_handler() do
+    :error_logger.delete_report_handler(NewRelic.Error.ErrorLoggerHandler)
+  end
 
   def init(args) do
     NewRelic.sample_process()

--- a/lib/new_relic/error/logger_handler.ex
+++ b/lib/new_relic/error/logger_handler.ex
@@ -1,0 +1,30 @@
+defmodule NewRelic.Error.LoggerHandler do
+  @moduledoc false
+
+  # http://erlang.org/doc/man/logger.html
+
+  def add_handler() do
+    :logger.remove_handler(:new_relic)
+    :logger.add_handler(:new_relic, NewRelic.Error.LoggerHandler, %{})
+  end
+
+  def remove_handler() do
+    :logger.remove_handler(:new_relic)
+  end
+
+  def log(
+        %{
+          meta: %{error_logger: %{tag: :error_report, type: :crash_report}},
+          msg: {:report, %{report: [report | _]}}
+        },
+        _config
+      ) do
+    if NewRelic.Transaction.Reporter.tracking?(self()) do
+      NewRelic.Error.Reporter.report_transaction_error(report)
+    else
+      NewRelic.Error.Reporter.report_process_error(report)
+    end
+  end
+
+  def log(_log, _config), do: :ignore
+end

--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -1,0 +1,70 @@
+defmodule NewRelic.Error.Reporter do
+  alias NewRelic.Util
+  alias NewRelic.Harvest.Collector
+
+  def report_transaction_error(report) do
+    {kind, exception, stacktrace} = parse_error_info(report[:error_info])
+    process_name = parse_process_name(report[:registered_name], stacktrace)
+
+    NewRelic.Transaction.Reporter.set_transaction_error(report[:pid], %{
+      kind: kind,
+      process: process_name,
+      reason: exception,
+      stack: stacktrace
+    })
+  end
+
+  def report_process_error(report) do
+    {_kind, exception, stacktrace} = parse_error_info(report[:error_info])
+
+    {exception_type, exception_reason, exception_stacktrace} =
+      Util.Error.normalize(exception, stacktrace, report[:initial_call])
+
+    process_name = parse_process_name(report[:registered_name], stacktrace)
+    expected = parse_error_expected(exception)
+    automatic_attributes = NewRelic.Config.automatic_attributes()
+
+    Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
+      timestamp: System.system_time(:milliseconds) / 1_000,
+      error_type: inspect(exception_type),
+      message: exception_reason,
+      expected: expected,
+      stack_trace: exception_stacktrace,
+      transaction_name: "WebTransaction/Elixir/ElixirProcess//#{process_name}",
+      user_attributes:
+        Map.merge(automatic_attributes, %{
+          process: process_name
+        })
+    })
+
+    Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
+      timestamp: System.system_time(:milliseconds) / 1_000,
+      error_class: inspect(exception_type),
+      error_message: exception_reason,
+      expected: expected,
+      transaction_name: "WebTransaction/Elixir/ElixirProcess//#{process_name}",
+      user_attributes:
+        Map.merge(automatic_attributes, %{
+          process: process_name,
+          stacktrace: Enum.join(exception_stacktrace, "\n")
+        })
+    })
+
+    unless expected do
+      NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
+      NewRelic.report_metric(:error, error_count: 1)
+    end
+  end
+
+  defp parse_process_name([], [{module, _f, _a, _} | _]), do: inspect(module)
+  defp parse_process_name([], _stacktrace), do: "UnknownProcess"
+  defp parse_process_name(registered_name, _stacktrace), do: inspect(registered_name)
+
+  defp parse_error_info({kind, {exception, stacktrace}, _stack}) when is_list(stacktrace),
+    do: {kind, exception, stacktrace}
+
+  defp parse_error_info({kind, exception, stacktrace}), do: {kind, exception, stacktrace}
+
+  defp parse_error_expected(%{expected: true}), do: true
+  defp parse_error_expected(_), do: false
+end

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -134,7 +134,7 @@ defmodule ErrorTraceTest do
 
   test "Doesn't report an error if the handler is not installed" do
     TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
-    :error_logger.delete_report_handler(NewRelic.Error.ErrorHandler)
+    NewRelic.Error.Supervisor.remove_handler()
 
     :proc_lib.spawn(fn ->
       raise "RAISE"
@@ -145,7 +145,7 @@ defmodule ErrorTraceTest do
     traces = TestHelper.gather_harvest(Collector.ErrorTrace.Harvester)
     assert length(traces) == 0
 
-    :error_logger.add_report_handler(NewRelic.Error.ErrorHandler)
+    NewRelic.Error.Supervisor.add_handler()
 
     :proc_lib.spawn(fn ->
       raise "RAISE"


### PR DESCRIPTION
This improves our ability to connect an Error and the Transaction it was part of since the OTP 21 `:logger` executes the callback in the originating process, instead of receiving it as an async `gen_event`!