### PR TITLE
Record a few stats after each transaction

### DIFF
--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -54,9 +54,14 @@ defmodule NewRelic.Transaction.Plug do
     |> NewRelic.add_attributes()
   end
 
+  @kb 1024
   def add_stop_attrs(conn) do
+    info = Process.info(self(), [:memory, :reductions])
+
     [
-      status: conn.status
+      status: conn.status,
+      memory_kb: info[:memory] / @kb,
+      reductions: info[:reductions]
     ]
     |> NewRelic.add_attributes()
   end


### PR DESCRIPTION
This adds a few stats to each transaction for `memory_kb` and `reductions` of the main Transaction process (not including any async processes that contributed to the request)