### PR TITLE
Set cowboy dependency to be test only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule NewRelic.Mixfile do
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:jason, "~> 1.0"},
       {:plug, "~> 1.6"},
-      {:cowboy, "~> 2.0"},
+      {:cowboy, "~> 2.0", only: :test},
       {:httpoison, "~> 1.0"}
     ]
   end


### PR DESCRIPTION
This dependency blocks usage for phoenix apps on 1.3 since they have a
requirement for cowboy 1.x.  This shouldn't be necessary since cowboy is
only used in tests.