### PR TITLE
Handle multiple app names properly

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -5,9 +5,11 @@ defmodule NewRelic.Config do
   All configuration items can be set via ENV variable _or_ via Application config
   """
 
-  @doc "Configure your application name. **Required**"
-  def app_name,
-    do: System.get_env("NEW_RELIC_APP_NAME") || Application.get_env(:new_relic_agent, :app_name)
+  @doc "Configure your application name. May contain up to 3 names seperated by `;`. **Required**"
+  def app_name do
+    (System.get_env("NEW_RELIC_APP_NAME") || Application.get_env(:new_relic_agent, :app_name))
+    |> parse_app_names
+  end
 
   @doc "Configure your New Relic License Key. **Required**"
   def license_key,
@@ -79,6 +81,12 @@ defmodule NewRelic.Config do
     do:
       System.get_env("NEW_RELIC_HARVEST_ENABLED") ||
         Application.get_env(:new_relic_agent, :harvest_enabled, true)
+
+  defp parse_app_names(name_string) do
+    name_string
+    |> String.split(";")
+    |> Enum.map(&String.trim/1)
+  end
 
   @external_resource "VERSION"
   @agent_version "VERSION" |> File.read!() |> String.trim()

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -58,7 +58,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
         language: "elixir",
         pid: NewRelic.Util.pid(),
         host: NewRelic.Util.hostname(),
-        app_name: [NewRelic.Config.app_name()],
+        app_name: NewRelic.Config.app_name(),
         utilization: NewRelic.Util.utilization(),
         environment: NewRelic.Util.elixir_environment(),
         agent_version: NewRelic.Config.agent_version()

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -53,4 +53,13 @@ defmodule ConfigTest do
 
     assert NewRelic.Config.feature?(:error_collector)
   end
+
+  test "Parse multiple app names" do
+    System.put_env("NEW_RELIC_APP_NAME", "One Name; Two Names ")
+    assert "Two Names" in NewRelic.Config.app_name()
+    assert length(NewRelic.Config.app_name()) == 2
+
+    System.put_env("NEW_RELIC_APP_NAME", "One Name")
+    assert length(NewRelic.Config.app_name()) == 1
+  end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -52,6 +52,8 @@ defmodule ConfigTest do
     Application.get_env(:new_relic_agent, :error_collector_enabled, false)
 
     assert NewRelic.Config.feature?(:error_collector)
+
+    System.delete_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED")
   end
 
   test "Parse multiple app names" do
@@ -61,5 +63,7 @@ defmodule ConfigTest do
 
     System.put_env("NEW_RELIC_APP_NAME", "One Name")
     assert length(NewRelic.Config.app_name()) == 1
+
+    System.delete_env("NEW_RELIC_APP_NAME")
   end
 end


### PR DESCRIPTION
An agent is able to report to as many as 3 different applications. This PR enables that behavior. App names are split by the `;` char.