### PR TITLE
Allow setting the logger to use Logger

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -24,6 +24,7 @@ defmodule NewRelic.Config do
 
   Options:
   - `"stdout"`
+  - `"Logger"` Elixir's Logger
   - `"memory"` (Useful for testing)
   - `"file_name.log"`
   """

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -14,6 +14,9 @@ defmodule ConfigTest do
     System.put_env("NEW_RELIC_LOG", "some_file.log")
     assert {:file, "some_file.log"} == NewRelic.Logger.initial_logger()
 
+    System.put_env("NEW_RELIC_LOG", "Logger")
+    assert :logger == NewRelic.Logger.initial_logger()
+
     System.delete_env("NEW_RELIC_LOG")
     assert inital_logger == NewRelic.Logger.initial_logger()
   end

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -30,4 +30,12 @@ defmodule LoggerTest do
       GenServer.call(NewRelic.Logger, {:replace, previous_logger})
     end
   end
+
+  @tag :capture_log
+  test "Logger logger" do
+    previous_logger = GenServer.call(NewRelic.Logger, {:logger, :logger})
+    NewRelic.log(:info, "HELLO")
+    NewRelic.log(:error, "DANG")
+    GenServer.call(NewRelic.Logger, {:replace, previous_logger})
+  end
 end


### PR DESCRIPTION
Traditionally, New Relic agents push our log messages to a specific file, primarily for easy access to them if someone needs support. This PR adds another setting which enables them to be sent to the standard Elixir `Logger` if someone wants that.

Opt-in by:
```elixir
config :new_relic_agent, log: "Logger"
```

closes #64 