### PR TITLE
Enable communication through a proxy

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -34,6 +34,12 @@ defmodule NewRelic.Config do
     do: System.get_env("NEW_RELIC_LOG") || Application.get_env(:new_relic_agent, :log)
 
   @doc """
+  Configure the Agent to communicate through a proxy. The value should be the URL of your proxy.
+  """
+  def proxy,
+    do: System.get_env("NEW_RELIC_PROXY_URL") || Application.get_env(:new_relic_agent, :proxy_url)
+
+  @doc """
   An optional list of key/value pairs that will be automatic custom attributes
   on all event types reported (Transactions, etc)
 

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -45,7 +45,7 @@ defmodule NewRelic.Harvest.Collector.Protocol do
     do:
       params
       |> collector_method_url
-      |> NewRelic.Util.post(payload, collector_headers())
+      |> NewRelic.Util.Http.post(payload, collector_headers())
       |> parse_http_response(params)
 
   defp retry_call({:ok, response}, _params, _payload), do: {:ok, response}

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -7,12 +7,6 @@ defmodule NewRelic.Util do
 
   def pid, do: System.get_pid() |> String.to_integer()
 
-  def post(url, body, headers) when is_binary(body),
-    do: HTTPoison.post(url, body, headers)
-
-  def post(url, body, headers),
-    do: post(url, Jason.encode!(body), headers)
-
   def time_to_ms({megasec, sec, microsec}),
     do: (megasec * 1_000_000 + sec) * 1_000 + round(microsec / 1_000)
 

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -1,0 +1,17 @@
+defmodule NewRelic.Util.Http do
+  @moduledoc false
+
+  def post(url, body, headers) when is_binary(body) do
+    HTTPoison.post(url, body, headers, options())
+  end
+
+  def post(url, body, headers),
+    do: post(url, Jason.encode!(body), headers)
+
+  defp options() do
+    case NewRelic.Config.proxy() do
+      nil -> []
+      proxy -> [proxy: proxy]
+    end
+  end
+end

--- a/test/integration/collector_test.exs
+++ b/test/integration/collector_test.exs
@@ -6,17 +6,6 @@ defmodule CollectorIntegrationTest do
 
   # mix test test/integration --include skip
 
-  defmodule EvilCollectorPlug do
-    import Plug.Conn
-
-    def init(options), do: options
-
-    def call(conn, test_pid: test_pid) do
-      send(test_pid, :attempt)
-      send_resp(conn, 503, ':(')
-    end
-  end
-
   setup do
     GenServer.call(Collector.AgentRun, :connected)
     System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")

--- a/test/integration/proxy_test.exs
+++ b/test/integration/proxy_test.exs
@@ -1,0 +1,29 @@
+defmodule ProxyIntegrationTest do
+  use ExUnit.Case
+
+  @moduletag skip: "Tests require a running proxy on port 9000"
+
+  # Eaily run a proxy:
+  # docker run --rm -it -p 9000:9000 mitmproxy/mitmproxy mitmproxy -p 9000
+
+  # mix test test/integration --include skip
+
+  defmodule PlainServerPlug do
+    import Plug.Conn
+    def init(options), do: options
+    def call(conn, _), do: send_resp(conn, 200, "hi, there")
+  end
+
+  test "Make HTTP request through proxy" do
+    {:ok, _} = Plug.Adapters.Cowboy2.http(PlainServerPlug, [], port: 8886)
+
+    System.put_env("NEW_RELIC_PROXY_URL", "http://localhost:9000")
+
+    try do
+      {:ok, %{body: body}} = NewRelic.Util.Http.post("http://localhost:8886", "", [])
+      assert body == "hi, there"
+    after
+      System.delete_env("NEW_RELIC_PROXY_URL")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for communicating through a proxy. 

Opt-in via config:
```elixir
config :new_relic_agent, proxy_url: "http://my.proxy:8080"
```

closes #60