### PR TITLE
More flexible datastore metric names

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -56,10 +56,10 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         }
       ]
 
-  def transform({:datastore, name}, duration_s: duration_s),
+  def transform({:datastore, datastore, table, operation}, duration_s: duration_s),
     do: [
       %Metric{
-        name: join(["Datastore/statement/Postgres", name]),
+        name: join(["Datastore/statement", datastore, table, operation]),
         call_count: 1,
         total_call_time: duration_s,
         total_exclusive_time: duration_s,
@@ -67,7 +67,15 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         max_call_time: duration_s
       },
       %Metric{
-        name: "Datastore/Postgres/all",
+        name: join(["Datastore/operation", datastore, operation]),
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: join(["Datastore", datastore, "all"]),
         call_count: 1,
         total_call_time: duration_s,
         total_exclusive_time: duration_s,
@@ -147,6 +155,7 @@ defmodule NewRelic.Harvest.Collector.MetricData do
   defp join(segments) when is_list(segments) do
     segments
     |> Enum.filter(& &1)
+    |> Enum.map(&to_string/1)
     |> Enum.map(&String.replace_leading(&1, "/", ""))
     |> Enum.map(&String.replace_trailing(&1, "/", ""))
     |> Enum.join("/")

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -45,7 +45,6 @@ defmodule NewRelic.Tracer.Report do
     )
 
     NewRelic.incr_attributes(
-      timestamp_ms: System.convert_time_unit(start_time, :native, :milliseconds),
       datastore_call_count: 1,
       datastore_duration_ms: duration_ms,
       "datastore.#{function_name({module, function}, name)}.call_count": 1,
@@ -62,7 +61,7 @@ defmodule NewRelic.Tracer.Report do
     )
 
     NewRelic.report_metric(
-      {:datastore, "/#{function_name({module, function}, name)}"},
+      {:datastore, "Database", inspect(module), function_name(function, name)},
       duration_s: duration_s
     )
   end
@@ -171,4 +170,6 @@ defmodule NewRelic.Tracer.Report do
   defp function_name({m, f}, i), do: "#{inspect(m)}.#{f}:#{i}"
   defp function_name({m, f, a}, f), do: "#{inspect(m)}.#{f}/#{a}"
   defp function_name({m, f, a}, i), do: "#{inspect(m)}.#{f}:#{i}/#{a}"
+  defp function_name(f, f), do: "#{f}"
+  defp function_name(_f, i), do: "#{i}"
 end

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -23,8 +23,8 @@ defmodule MetricTracerTest do
     def query do
     end
 
-    @trace {:db, category: :datastore}
-    def db do
+    @trace {:db_query, category: :datastore}
+    def db_query do
     end
 
     @trace {:special, category: :external}
@@ -50,15 +50,15 @@ defmodule MetricTracerTest do
   end
 
   test "Datastore metrics" do
-    MetricTraced.db()
+    MetricTraced.db_query()
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
     assert TestHelper.find_metric(
              metrics,
-             "Datastore/statement/Postgres/MetricTracerTest.MetricTraced.db"
+             "Datastore/statement/Database/MetricTracerTest.MetricTraced/db_query"
            )
 
-    assert TestHelper.find_metric(metrics, "Datastore/Postgres/all")
+    assert TestHelper.find_metric(metrics, "Datastore/Database/all")
   end
 end


### PR DESCRIPTION
This PR un-hard-codes the datastore adapter name in prep for `ecto` instrumentation