### PR TITLE
Add support for configuring labels

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -5,7 +5,11 @@ defmodule NewRelic.Config do
   All configuration items can be set via ENV variable _or_ via Application config
   """
 
-  @doc "Configure your application name. May contain up to 3 names seperated by `;`. **Required**"
+  @doc """
+  Configure your application name. **Required**
+
+  May contain up to 3 names seperated by `;`
+  """
   def app_name do
     (System.get_env("NEW_RELIC_APP_NAME") || Application.get_env(:new_relic_agent, :app_name))
     |> parse_app_names
@@ -22,7 +26,9 @@ defmodule NewRelic.Config do
     do: System.get_env("NEW_RELIC_HOST") || Application.get_env(:new_relic_agent, :host)
 
   @doc """
-  Configure the Agent logging mechanism. Defaults to `"tmp/new_relic.log"`
+  Configure the Agent logging mechanism.
+
+  Defaults to `"tmp/new_relic.log"`.
 
   Options:
   - `"stdout"`
@@ -35,7 +41,7 @@ defmodule NewRelic.Config do
 
   @doc """
   An optional list of key/value pairs that will be automatic custom attributes
-  on all event types reported (Transactions, etc)
+  on all event types reported (Transactions, etc).
 
   Options:
   - `{:system, "ENV_NAME"}` Read a System ENV variable
@@ -60,6 +66,26 @@ defmodule NewRelic.Config do
       {name, {m, f, a}} -> {name, apply(m, f, a)}
       {name, value} -> {name, value}
     end)
+  end
+
+  @doc """
+  An optional list of labels that will be applied to the application.
+
+  Configured with a single string containing a list of key-value pairs:
+
+  `key1:value1;key2:value2`
+
+  The delimiting characters `;` and `:` are not allowed in the `key` or `value`
+
+  Example:
+
+  ```
+  config :new_relic_agent, labels: "region:west;env:prod"
+  ```
+  """
+  def labels do
+    (System.get_env("NEW_RELIC_LABELS") || Application.get_env(:new_relic_agent, :labels))
+    |> parse_labels()
   end
 
   @doc """
@@ -89,6 +115,16 @@ defmodule NewRelic.Config do
     name_string
     |> String.split(";")
     |> Enum.map(&String.trim/1)
+  end
+
+  defp parse_labels(nil), do: []
+
+  @label_splitter ~r/;|:/
+  defp parse_labels(label_string) do
+    label_string
+    |> String.split(@label_splitter, trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.chunk_every(2, 2, :discard)
   end
 
   @external_resource "VERSION"

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -39,7 +39,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
 
   def handle_info(:connect, _state) do
     state =
-      connect_payload()
+      Collector.Connect.payload()
       |> Collector.Protocol.connect()
       |> parse_connect
 
@@ -50,20 +50,6 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
 
   def handle_call(:connected, _from, state) do
     {:reply, true, state}
-  end
-
-  def connect_payload do
-    [
-      %{
-        language: "elixir",
-        pid: NewRelic.Util.pid(),
-        host: NewRelic.Util.hostname(),
-        app_name: NewRelic.Config.app_name(),
-        utilization: NewRelic.Util.utilization(),
-        environment: NewRelic.Util.elixir_environment(),
-        agent_version: NewRelic.Config.agent_version()
-      }
-    ]
   end
 
   defp store_agent_run(%{"agent_run_id" => _} = state) do

--- a/lib/new_relic/harvest/collector/connect.ex
+++ b/lib/new_relic/harvest/collector/connect.ex
@@ -1,0 +1,20 @@
+defmodule NewRelic.Harvest.Collector.Connect do
+  def payload do
+    [
+      %{
+        language: "elixir",
+        pid: NewRelic.Util.pid(),
+        host: NewRelic.Util.hostname(),
+        app_name: NewRelic.Config.app_name(),
+        labels:
+          NewRelic.Config.labels()
+          |> Enum.map(fn [key, value] ->
+            %{label_type: key, label_value: value}
+          end),
+        utilization: NewRelic.Util.utilization(),
+        environment: NewRelic.Util.elixir_environment(),
+        agent_version: NewRelic.Config.agent_version()
+      }
+    ]
+  end
+end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -69,4 +69,17 @@ defmodule ConfigTest do
 
     System.delete_env("NEW_RELIC_APP_NAME")
   end
+
+  test "Parse labels" do
+    System.put_env("NEW_RELIC_LABELS", "key1:value1;key2:value2; key3 :value3;stray ")
+
+    labels = NewRelic.Config.labels()
+
+    assert ["key3", "value3"] in labels
+    assert length(labels) == 3
+
+    System.delete_env("NEW_RELIC_LABELS")
+
+    assert [] == NewRelic.Config.labels()
+  end
 end

--- a/test/integration/collector_test.exs
+++ b/test/integration/collector_test.exs
@@ -6,17 +6,6 @@ defmodule CollectorIntegrationTest do
 
   # mix test test/integration --include skip
 
-  defmodule EvilCollectorPlug do
-    import Plug.Conn
-
-    def init(options), do: options
-
-    def call(conn, test_pid: test_pid) do
-      send(test_pid, :attempt)
-      send_resp(conn, 503, ':(')
-    end
-  end
-
   setup do
     GenServer.call(Collector.AgentRun, :connected)
     System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")


### PR DESCRIPTION
This PR adds support for adding labels to an application. The syntax follows the way all other NewRelic agents configure labels, and is a simple delimited string.