### PR TITLE
Detect heroku hostnames

### DIFF
--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -2,7 +2,7 @@ defmodule NewRelic.Util do
   @moduledoc false
 
   def hostname do
-    with {:ok, name} <- :inet.gethostname(), do: to_string(name)
+    maybe_heroku_dyno_hostname() || get_hostname()
   end
 
   def pid, do: System.get_pid() |> String.to_integer()
@@ -94,6 +94,20 @@ defmodule NewRelic.Util do
 
       _error ->
         nil
+    end
+  end
+
+  defp get_hostname do
+    with {:ok, name} <- :inet.gethostname(), do: to_string(name)
+  end
+
+  defp maybe_heroku_dyno_hostname do
+    System.get_env("DYNO")
+    |> case do
+      nil -> nil
+      "scheduler." <> _ -> "scheduler.*"
+      "run." <> _ -> "run.*"
+      name -> name
     end
   end
 end

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -65,4 +65,16 @@ defmodule UtilTest do
     util = NewRelic.Util.maybe_add_vendors(%{}, aws_url: "http://localhost:8883")
     assert get_in(util, [:vendors, :aws, "instanceId"]) == "test.id"
   end
+
+  test "hostname detection" do
+    System.put_env("DYNO", "foobar")
+    assert NewRelic.Util.hostname() == "foobar"
+
+    System.put_env("DYNO", "run.100")
+    assert NewRelic.Util.hostname() == "run.*"
+
+    System.delete_env("DYNO")
+    hostname = NewRelic.Util.hostname()
+    assert is_binary(hostname)
+  end
 end


### PR DESCRIPTION
This PR adds a special condition that reports the `DYNO` env var in Heroku as the `hostname`.

closes #77 