### PR TITLE
Clear deprecation warnings in 1.8.0

### DIFF
--- a/lib/new_relic/distributed_trace/context.ex
+++ b/lib/new_relic/distributed_trace/context.ex
@@ -70,7 +70,7 @@ defmodule NewRelic.DistributedTrace.Context do
           "tr" => context.trace_id,
           "pr" => context.priority,
           "sa" => context.sampled,
-          "ti" => System.system_time(:milliseconds)
+          "ti" => System.system_time(:millisecond)
         }
         |> maybe_put(:span_guid, "id", context.sampled, current_span_guid)
         |> maybe_put(:trust_key, "tk", context.account_id, context.trust_key)

--- a/lib/new_relic/distributed_trace/plug.ex
+++ b/lib/new_relic/distributed_trace/plug.ex
@@ -149,6 +149,6 @@ defmodule NewRelic.DistributedTrace.Plug do
   defp generate_priority, do: :rand.uniform() |> Float.round(6)
 
   defp transport_duration(context_start_time) do
-    (System.system_time(:milliseconds) - context_start_time) / 1_000
+    (System.system_time(:millisecond) - context_start_time) / 1_000
   end
 end

--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -25,7 +25,7 @@ defmodule NewRelic.Error.Reporter do
     automatic_attributes = NewRelic.Config.automatic_attributes()
 
     Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       error_type: inspect(exception_type),
       message: exception_reason,
       expected: expected,
@@ -38,7 +38,7 @@ defmodule NewRelic.Error.Reporter do
     })
 
     Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       error_class: inspect(exception_type),
       error_message: exception_reason,
       expected: expected,

--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -31,7 +31,7 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
       %Event{
         type: type,
         attributes: annotate(attributes),
-        timestamp: System.system_time(:milliseconds) / 1_000
+        timestamp: System.system_time(:millisecond) / 1_000
       }
       |> report_custom_event
 

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -61,11 +61,11 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
 
     Collector.Protocol.metric_data([
       Collector.AgentRun.agent_run_id(),
-      System.convert_time_unit(state.start_time, :native, :seconds),
+      System.convert_time_unit(state.start_time, :native, :second),
       System.convert_time_unit(
         state.start_time + (state.end_time_mono - state.start_time_mono),
         :native,
-        :seconds
+        :second
       ),
       metric_data
     ])

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -92,7 +92,7 @@ defmodule NewRelic.Tracer.Report do
     })
 
     NewRelic.report_span(
-      timestamp_ms: System.convert_time_unit(start_time, :native, :milliseconds),
+      timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
       duration_s: duration_s,
       name: function_name({module, function, arity}, name),
       edge: [span: id, parent: parent_id],
@@ -149,7 +149,7 @@ defmodule NewRelic.Tracer.Report do
     })
 
     NewRelic.report_span(
-      timestamp_ms: System.convert_time_unit(start_time, :native, :milliseconds),
+      timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
       duration_s: duration_s,
       name: function_name({module, function, arity}, name),
       edge: [span: id, parent: parent_id],
@@ -164,7 +164,7 @@ defmodule NewRelic.Tracer.Report do
   end
 
   def duration_ms(start_time_mono, end_time_mono),
-    do: System.convert_time_unit(end_time_mono - start_time_mono, :native, :milliseconds)
+    do: System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
 
   defp function_name({m, f}, f), do: "#{inspect(m)}.#{f}"
   defp function_name({m, f}, i), do: "#{inspect(m)}.#{f}:#{i}"

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -181,17 +181,17 @@ defmodule NewRelic.Transaction.Reporter do
          tx
          |> Map.drop([:start_time_mono, :end_time_mono])
          |> Map.merge(%{
-           start_time: System.convert_time_unit(start_time, :native, :milliseconds),
+           start_time: System.convert_time_unit(start_time, :native, :millisecond),
            end_time:
              System.convert_time_unit(
                start_time + (end_time_mono - start_time_mono),
                :native,
-               :milliseconds
+               :millisecond
              ),
            duration_us:
-             System.convert_time_unit(end_time_mono - start_time_mono, :native, :microseconds),
+             System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond),
            duration_ms:
-             System.convert_time_unit(end_time_mono - start_time_mono, :native, :milliseconds)
+             System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
          })
 
   defp transform_name_attrs(%{custom_name: name} = tx), do: Map.put(tx, :name, name)

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -8,7 +8,7 @@ defmodule CustomEventTest do
     agent_run_id = Collector.AgentRun.agent_run_id()
 
     tr_1 = %Event{
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       type: "CustomEventTest",
       attributes: %{
         foo: "bar"
@@ -30,13 +30,13 @@ defmodule CustomEventTest do
 
     ev1 = %Event{
       type: "CustomEventTest",
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       attributes: %{foo: "baz"}
     }
 
     ev2 = %Event{
       type: "CustomEventTest",
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       attributes: %{foo: "bar"}
     }
 

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -241,7 +241,7 @@ defmodule DistributedTraceTest do
         "tx": "7d3efb1b173fecfa",
         "tr": "d6b4ba0c3a712ca",
         "id": "5f474d64b9cc9b2a",
-        "ti": #{System.system_time(:milliseconds) - 100},
+        "ti": #{System.system_time(:millisecond) - 100},
         "pr": 0.123456,
         "sa": true
       }

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -8,7 +8,7 @@ defmodule ErrorTraceTest do
     agent_run_id = Collector.AgentRun.agent_run_id()
 
     er_1 = %Trace{
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       transaction_name: "WebTransaction/AgentTest/Transaction/name",
       request_uri: "http://google.com",
       message: "Error: message",

--- a/test/integration/collector_test.exs
+++ b/test/integration/collector_test.exs
@@ -33,7 +33,7 @@ defmodule CollectorIntegrationTest do
   end
 
   test "Can post a metric" do
-    ts_end = System.system_time(:seconds)
+    ts_end = System.system_time(:second)
     ts_start = ts_end - 60
     agent_run_id = Collector.AgentRun.agent_run_id()
 

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -75,7 +75,7 @@ defmodule SpanEventTest do
     mfa = {:mod, :fun, 3}
 
     event = %NewRelic.Span.Event{
-      timestamp: System.system_time(:milliseconds),
+      timestamp: System.system_time(:millisecond),
       duration: 0.120,
       name: "SomeSpan",
       category: "generic",
@@ -241,7 +241,7 @@ defmodule SpanEventTest do
         "tx": "7d3efb1b173fecfa",
         "tr": "d6b4ba0c3a712ca",
         "id": "5f474d64b9cc9b2a",
-        "ti": #{System.system_time(:milliseconds) - 100},
+        "ti": #{System.system_time(:millisecond) - 100},
         "sa": true,
         "pr": 0.987654
       }

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -30,7 +30,7 @@ defmodule TransactionErrorEventTest do
   end
 
   test "post required supportability metrics" do
-    ts_end = System.system_time(:seconds)
+    ts_end = System.system_time(:second)
     ts_start = ts_end - 60
     agent_run_id = NewRelic.Harvest.Collector.AgentRun.agent_run_id()
 
@@ -49,7 +49,7 @@ defmodule TransactionErrorEventTest do
     er_1 = %Event{
       error_class: "ErrorClass",
       error_message: "Error: message",
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       transaction_name: "WebTransaction/AgentTest/Transaction/name",
       queue_duration: 0.010,
       database_duration: 0.010,

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -24,7 +24,7 @@ defmodule TransactionEventTest do
     tr_1 = %Event{
       web_duration: 0.010,
       database_duration: nil,
-      timestamp: System.system_time(:milliseconds) / 1_000,
+      timestamp: System.system_time(:millisecond) / 1_000,
       name: "WebTransaction/AgentTest/Transaction/name",
       duration: 0.010,
       type: "Transaction",


### PR DESCRIPTION
Elixir 1.8.0 soft deprecates some things, eg: `deprecated time unit`