### PR TITLE
Disallow altering framework_name attribute

### DIFF
--- a/lib/new_relic/util/attr_store.ex
+++ b/lib/new_relic/util/attr_store.ex
@@ -86,8 +86,10 @@ defmodule NewRelic.Util.AttrStore do
     end)
   end
 
+  @immutable_keys [:framework_name]
   defp collect_attr({_pid, {k, {:list, item}}}, acc), do: Map.update(acc, k, [item], &[item | &1])
   defp collect_attr({_pid, {k, {:counter, n}}}, acc), do: Map.update(acc, k, n, &(&1 + n))
+  defp collect_attr({_pid, {k, v}}, acc) when k in @immutable_keys, do: Map.put_new(acc, k, v)
   defp collect_attr({_pid, {k, v}}, acc), do: Map.put(acc, k, v)
 
   defp lookup(table, term) do

--- a/test/attr_store_test.exs
+++ b/test/attr_store_test.exs
@@ -8,9 +8,11 @@ defmodule AttrStoreTest do
 
     AttrStore.track(table, :pid)
     AttrStore.add(table, :pid, name: "FOO")
+    AttrStore.add(table, :pid, framework_name: "First Framework")
+    AttrStore.add(table, :pid, framework_name: "Second Framework")
     AttrStore.add(table, :pid, route: "/foo")
-    AttrStore.add(table, :pid, bar: "baz")
-    AttrStore.add(table, :pid, bar: "baz")
+    AttrStore.add(table, :pid, bar: "baz1")
+    AttrStore.add(table, :pid, bar: "baz2")
     AttrStore.add(table, :pid, this: "this", that: "that")
 
     AttrStore.add(table, :pid, count_tag: {:counter, 1})
@@ -23,7 +25,8 @@ defmodule AttrStoreTest do
 
     attrs = AttrStore.collect(table, :pid)
 
-    assert Enum.member?(attrs, {:bar, "baz"})
+    assert Enum.member?(attrs, {:framework_name, "First Framework"})
+    assert Enum.member?(attrs, {:bar, "baz2"})
     assert Enum.member?(attrs, {:this, "this"})
     assert Enum.member?(attrs, {:that, "that"})
     assert Enum.member?(attrs, {:seven, 7.0})


### PR DESCRIPTION
Add "immutable attributes" list, which defines transaction attributes that can be set only once and cannot be overwritten.

The `framework_name` attribute is an example, as the first framework (deepest in the callstack) sets the transaction name, it should also sign off the transaction.

Closes https://github.com/binaryseed/new_relic_absinthe/issues/4
