### PR TITLE
Safer AWS metadata query

### DIFF
--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -1,8 +1,10 @@
 defmodule NewRelic.Util do
   @moduledoc false
 
+  alias NewRelic.Util.Vendor
+
   def hostname do
-    maybe_heroku_dyno_hostname() || get_hostname()
+    Vendor.maybe_heroku_dyno_hostname() || get_hostname()
   end
 
   def pid, do: System.get_pid() |> String.to_integer()
@@ -63,8 +65,8 @@ defmodule NewRelic.Util do
       total_ram_mib: get_system_memory(),
       hostname: hostname()
     }
-    |> maybe_add_boot_id()
-    |> maybe_add_vendors()
+    |> Vendor.maybe_add_linux_boot_id()
+    |> Vendor.maybe_add_cloud_vendors()
   end
 
   @mb 1024 * 1024
@@ -75,50 +77,7 @@ defmodule NewRelic.Util do
     end
   end
 
-  defp maybe_add_boot_id(util) do
-    case File.read("/proc/sys/kernel/random/boot_id") do
-      {:ok, boot_id} -> Map.put(util, "boot_id", boot_id)
-      _ -> util
-    end
-  end
-
-  @aws_url "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document"
-  def maybe_add_vendors(util, options \\ []) do
-    Keyword.get(options, :aws_url, @aws_url)
-    |> aws_vendor_hash()
-    |> case do
-      nil -> util
-      aws_hash -> Map.put(util, :vendors, %{aws: aws_hash})
-    end
-  end
-
-  @aws_vendor_data ["availabilityZone", "instanceId", "instanceType"]
-  defp aws_vendor_hash(url) do
-    case HTTPoison.get(url, [], timeout: 100) do
-      {:ok, %{status_code: 200, body: body}} ->
-        case Jason.decode(body) do
-          {:ok, data} -> Map.take(data, @aws_vendor_data)
-          _ -> nil
-        end
-
-      _error ->
-        nil
-    end
-  rescue
-    _exception -> nil
-  end
-
   defp get_hostname do
     with {:ok, name} <- :inet.gethostname(), do: to_string(name)
-  end
-
-  defp maybe_heroku_dyno_hostname do
-    System.get_env("DYNO")
-    |> case do
-      nil -> nil
-      "scheduler." <> _ -> "scheduler.*"
-      "run." <> _ -> "run.*"
-      name -> name
-    end
   end
 end

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -104,6 +104,8 @@ defmodule NewRelic.Util do
       _error ->
         nil
     end
+  rescue
+    _exception -> nil
   end
 
   defp get_hostname do

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -1,0 +1,44 @@
+defmodule NewRelic.Util.Vendor do
+  def maybe_add_linux_boot_id(util) do
+    case File.read("/proc/sys/kernel/random/boot_id") do
+      {:ok, boot_id} -> Map.put(util, "boot_id", boot_id)
+      _ -> util
+    end
+  end
+
+  def maybe_heroku_dyno_hostname do
+    System.get_env("DYNO")
+    |> case do
+      nil -> nil
+      "scheduler." <> _ -> "scheduler.*"
+      "run." <> _ -> "run.*"
+      name -> name
+    end
+  end
+
+  @aws_url "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document"
+  def maybe_add_cloud_vendors(util, options \\ []) do
+    Keyword.get(options, :aws_url, @aws_url)
+    |> aws_vendor_hash()
+    |> case do
+      nil -> util
+      aws_hash -> Map.put(util, :vendors, %{aws: aws_hash})
+    end
+  end
+
+  @aws_vendor_data ["availabilityZone", "instanceId", "instanceType"]
+  def aws_vendor_hash(url) do
+    case HTTPoison.get(url, [], timeout: 100) do
+      {:ok, %{status_code: 200, body: body}} ->
+        case Jason.decode(body) do
+          {:ok, data} -> Map.take(data, @aws_vendor_data)
+          _ -> nil
+        end
+
+      _error ->
+        nil
+    end
+  rescue
+    _exception -> nil
+  end
+end

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -39,6 +39,8 @@ defmodule NewRelic.Util.Vendor do
         nil
     end
   rescue
-    _exception -> nil
+    exception ->
+      NewRelic.log(:error, "Failed to fetch AWS metadata. #{inspect(exception)}")
+      nil
   end
 end

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -55,14 +55,21 @@ defmodule UtilTest do
     end
   end
 
+  test "minimal utilization check" do
+    assert %{metadata_version: 3} = NewRelic.Util.utilization()
+  end
+
   test "AWS utilization fast timeout" do
-    assert %{} == NewRelic.Util.maybe_add_vendors(%{}, aws_url: "http://httpbin.org/delay/10")
+    assert %{} ==
+             NewRelic.Util.Vendor.maybe_add_cloud_vendors(%{},
+               aws_url: "http://httpbin.org/delay/10"
+             )
   end
 
   test "AWS utilization info" do
     {:ok, _} = Plug.Cowboy.http(FakeAwsPlug, [], port: 8883)
 
-    util = NewRelic.Util.maybe_add_vendors(%{}, aws_url: "http://localhost:8883")
+    util = NewRelic.Util.Vendor.maybe_add_cloud_vendors(%{}, aws_url: "http://localhost:8883")
     assert get_in(util, [:vendors, :aws, "instanceId"]) == "test.id"
   end
 


### PR DESCRIPTION
Closes #74 by protecting against exceptions when attempting to see if AWS metadata is accessible.

Most of this PR is a re-shuffle of the vendor specific functions