### PR TITLE
Clear warning with left side pattern match

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -193,7 +193,7 @@ defmodule NewRelic.Tracer.Macro do
   # Search for variables on the left side of a pattern match
   # and prefix them with an underscore so they don't end up as
   # unused variables
-  def rewrite_call_term({:=, metadata, [pattern, {name, _, context} = value]})
+  def rewrite_call_term({:=, metadata, [{name, _, context} = pattern, value]})
       when is_variable(name, context) do
     ignored_pattern = Macro.postwalk(pattern, &rewrite_match_pattern/1)
     {:=, metadata, [ignored_pattern, value]}

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -193,8 +193,7 @@ defmodule NewRelic.Tracer.Macro do
   # Search for variables on the left side of a pattern match
   # and prefix them with an underscore so they don't end up as
   # unused variables
-  def rewrite_call_term({:=, metadata, [{name, _, context} = pattern, value]})
-      when is_variable(name, context) do
+  def rewrite_call_term({:=, metadata, [pattern, value]}) do
     ignored_pattern = Macro.postwalk(pattern, &rewrite_match_pattern/1)
     {:=, metadata, [ignored_pattern, value]}
   end

--- a/test/tracer_macro_test.exs
+++ b/test/tracer_macro_test.exs
@@ -1,6 +1,11 @@
 defmodule NewRelic.Tracer.MacroTest do
   use ExUnit.Case
 
+  @doc """
+  We re-inject the function args into the call to the Tracer reporter
+  To do this w/o generating a bunch of warnings, we need to mark various
+  pattern matching captures as ignored.
+  """
   describe "build_call_args/1" do
     test "do nothing to simple argument lists" do
       ast =
@@ -64,12 +69,12 @@ defmodule NewRelic.Tracer.MacroTest do
     test "ignore variables on the left side of a pattern match" do
       ast =
         quote do
-          [data = %{foo: :bar}]
+          [data = %{foo: %{baz: "qux"} = map}]
         end
 
       expected =
         quote do
-          [_data = %{foo: :bar}]
+          [_data = %{foo: %{baz: "qux"} = map}]
         end
 
       assert expected == NewRelic.Tracer.Macro.build_call_args(ast)

--- a/test/tracer_macro_test.exs
+++ b/test/tracer_macro_test.exs
@@ -60,5 +60,19 @@ defmodule NewRelic.Tracer.MacroTest do
 
       assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
     end
+
+    test "ignore variables on the left side of a pattern match" do
+      ast =
+        quote do
+          [data = %{foo: :bar}]
+        end
+
+      expected =
+        quote do
+          [_data = %{foo: :bar}]
+        end
+
+      assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
+    end
   end
 end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -50,6 +50,9 @@ defmodule TracerTest do
     def default_multiclause(:case_1), do: :case_1_return
     def default_multiclause(value), do: value
 
+    @trace :left_side
+    def left_side(map = %{}), do: map
+
     @trace :rescuer
     def rescuer() do
       :do_something
@@ -205,5 +208,9 @@ defmodule TracerTest do
     assert Enum.empty?(attrs)
 
     Application.delete_env(:new_relic_agent, :tx_attr_expire)
+  end
+
+  test "Don't warn when dealing with variables on the left side of a pattern" do
+    assert %{foo: :bar} == Traced.left_side(%{foo: :bar})
   end
 end


### PR DESCRIPTION
Fixes #90 , clearing up a warning when `@trace`-ing functions that have left-side pattern matches. We unquote the args to a function to send to the reporter, and so we need to clean up pattern matching as we are outside the actual function head.

There was logic for this but it wasn't catching the condition properly

sidekick/ @mattbaker 