### PR TITLE
Enable ignoring a transaction

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -58,6 +58,11 @@ defmodule NewRelic do
   defdelegate start_transaction(category, name), to: NewRelic.Transaction
 
   @doc """
+  Call within a transaction to prevent it from reporting.
+  """
+  defdelegate ignore_transaction(), to: NewRelic.Transaction
+
+  @doc """
   Store information about the type of work the current span is doing.
 
   Options:

--- a/lib/new_relic/transaction.ex
+++ b/lib/new_relic/transaction.ex
@@ -55,4 +55,10 @@ defmodule NewRelic.Transaction do
     NewRelic.DistributedTrace.generate_new_context()
     |> NewRelic.DistributedTrace.track_transaction(transport_type: "Other")
   end
+
+  @doc false
+  def ignore_transaction() do
+    NewRelic.Transaction.Reporter.ignore_transaction()
+    NewRelic.DistributedTrace.Tracker.cleanup(self())
+  end
 end

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -55,6 +55,14 @@ defmodule NewRelic.Transaction.Reporter do
     end
   end
 
+  def ignore_transaction() do
+    if tracking?(self()) do
+      AttrStore.untrack(__MODULE__, self())
+      AttrStore.purge(__MODULE__, self())
+      ensure_purge(self())
+    end
+  end
+
   def fail(%{kind: kind, reason: reason, stack: stack} = error) do
     if tracking?(self()) do
       if NewRelic.Config.feature?(:error_collector) do


### PR DESCRIPTION
Add a function that enables the user to mark the current transaction to be ignored. The agent will stop tracking information about it and won't report any information about it.

```elixir
NewRelic.ignore_transaction()
```

closes #52 