### PR TITLE
Attempt a graceful shutdown when the app exits

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -140,16 +140,6 @@ defmodule NewRelic do
   @doc false
   defdelegate log(level, message), to: NewRelic.Logger
 
-  @doc """
-  Will gracefully complete and shut down the agent harvest cycle.
-
-  To ensure a harvest at shutdown, you can add a hook to your application:
-
-  ```elixir
-  System.at_exit(fn(_) ->
-    NewRelic.manual_shutdown()
-  end)
-  ```
-  """
+  @doc false
   defdelegate manual_shutdown(), to: NewRelic.Harvest.Supervisor
 end

--- a/lib/new_relic/application.ex
+++ b/lib/new_relic/application.ex
@@ -15,7 +15,8 @@ defmodule NewRelic.Application do
       supervisor(NewRelic.Error.Supervisor, []),
       supervisor(NewRelic.Transaction.Supervisor, []),
       supervisor(NewRelic.DistributedTrace.Supervisor, []),
-      supervisor(NewRelic.Aggregate.Supervisor, [])
+      supervisor(NewRelic.Aggregate.Supervisor, []),
+      worker(NewRelic.GracefulShutdown, [], shutdown: 30_000)
     ]
 
     opts = [strategy: :one_for_one, name: NewRelic.Supervisor]

--- a/lib/new_relic/graceful_shutdown.ex
+++ b/lib/new_relic/graceful_shutdown.ex
@@ -1,0 +1,17 @@
+defmodule NewRelic.GracefulShutdown do
+  use GenServer
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  def init(:ok) do
+    Process.flag(:trap_exit, true)
+    {:ok, nil}
+  end
+
+  def terminate(_reason, _state) do
+    NewRelic.Error.Supervisor.remove_handler()
+    NewRelic.Harvest.Supervisor.manual_shutdown()
+  end
+end

--- a/lib/new_relic/harvest/collector/harvest_cycle.ex
+++ b/lib/new_relic/harvest/collector/harvest_cycle.ex
@@ -38,9 +38,8 @@ defmodule NewRelic.Harvest.Collector.HarvestCycle do
     GenServer.call(name, :pause)
 
     receive do
-      {:DOWN, _ref, _, ^harvester, _reason} -> :ok
-    after
-      1000 -> NewRelic.log(:error, "Failed to shut down #{name}")
+      {:DOWN, _ref, _, ^harvester, _reason} ->
+        NewRelic.log(:warn, "Completed shutdown #{inspect(name)}")
     end
   end
 

--- a/test/integration/agent_run_test.exs
+++ b/test/integration/agent_run_test.exs
@@ -35,13 +35,12 @@ defmodule AgentRunIntegrationTest do
     assert is_integer(NewRelic.Harvest.Collector.AgentRun.lookup(:span_event_harvest_cycle))
   end
 
-  test "Agent restart ability" do
+  test "Agent re-connect ability" do
     original_agent_run_id = Collector.AgentRun.agent_run_id()
 
-    Application.stop(:new_relic_agent)
-    Application.start(:new_relic_agent)
-
+    Collector.AgentRun.reconnect()
     GenServer.call(Collector.AgentRun, :connected)
+
     new_agent_run_id = Collector.AgentRun.agent_run_id()
 
     assert original_agent_run_id != new_agent_run_id


### PR DESCRIPTION
This PR will wire up the supervision tree so that we attempt to send the data in the harvesters before we fully shut down.

sidekick/ @mattbaker 