### PR TITLE
Reset the span attributes after reporting them

### DIFF
--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -122,7 +122,7 @@ defmodule NewRelic.DistributedTrace do
   end
 
   def set_span(:generic, attrs) do
-    Process.put(:nr_current_span_attrs, attrs)
+    Process.put(:nr_current_span_attrs, Enum.into(attrs, %{}))
   end
 
   def set_span(:http, url: url, method: method, component: component) do
@@ -152,9 +152,10 @@ defmodule NewRelic.DistributedTrace do
 
   def set_current_span(label: label, ref: ref) do
     current = {label, ref}
-    previous = Process.get(:nr_current_span)
+    previous_span = Process.get(:nr_current_span)
+    previous_span_attrs = Process.get(:nr_current_span_attrs)
     Process.put(:nr_current_span, current)
-    {current, previous}
+    {current, previous_span, previous_span_attrs}
   end
 
   def get_current_span_guid() do
@@ -164,8 +165,9 @@ defmodule NewRelic.DistributedTrace do
     end
   end
 
-  def reset_span(previous: previous) do
-    Process.put(:nr_current_span, previous)
+  def reset_span(previous_span: previous_span, previous_span_attrs: previous_span_attrs) do
+    Process.put(:nr_current_span, previous_span)
+    Process.put(:nr_current_span_attrs, previous_span_attrs)
   end
 
   defp generate_sampling() do

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -152,7 +152,7 @@ defmodule NewRelic.Tracer.Macro do
       start_time = System.system_time()
       start_time_mono = System.monotonic_time()
 
-      {span, previous_span} =
+      {span, previous_span, previous_span_attrs} =
         NewRelic.DistributedTrace.set_current_span(
           label: {unquote(module), unquote(function), unquote(length(args))},
           ref: make_ref()
@@ -162,7 +162,6 @@ defmodule NewRelic.Tracer.Macro do
         unquote(body)
       after
         end_time_mono = System.monotonic_time()
-        NewRelic.DistributedTrace.reset_span(previous: previous_span)
 
         Tracer.Report.call(
           {unquote(module), unquote(function), unquote(build_call_args(args))},
@@ -170,6 +169,11 @@ defmodule NewRelic.Tracer.Macro do
           inspect(self()),
           {span, previous_span || :root},
           {start_time, start_time_mono, end_time_mono}
+        )
+
+        NewRelic.DistributedTrace.reset_span(
+          previous_span: previous_span,
+          previous_span_attrs: previous_span_attrs
         )
       end
     end


### PR DESCRIPTION
This prevents span attributes from leaking into other spans when there are multiple nested spans traced in a single process.

sidekick/ @mattbaker 