### PR TITLE
Report external metrics based on transaction type

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -145,9 +145,25 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         total_exclusive_time: duration_s,
         min_call_time: duration_s,
         max_call_time: duration_s
-      },
+      }
+    ]
+
+  def transform(:external_web, duration_s: duration_s),
+    do: [
       %Metric{
         name: :"External/allWeb",
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      }
+    ]
+
+  def transform(:external_other, duration_s: duration_s),
+    do: [
+      %Metric{
+        name: :"External/allOther",
         call_count: 1,
         total_call_time: duration_s,
         total_exclusive_time: duration_s,

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -116,8 +116,10 @@ defmodule NewRelic.Tracer.Report do
       %{duration_ms: duration_ms, call_count: 1}
     )
 
+    Transaction.Reporter.track_metric({:external, duration_s})
+
     NewRelic.report_metric(
-      {:external, "/#{function_name({module, function}, name)}"},
+      {:external, function_name({module, function}, name)},
       duration_s: duration_s
     )
   end

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -85,6 +85,12 @@ defmodule NewRelic.Transaction.Reporter do
     end
   end
 
+  def track_metric(metric) do
+    if tracking?(self()) do
+      AttrStore.add(__MODULE__, self(), transaction_metrics: {:list, metric})
+    end
+  end
+
   def set_transaction_error(pid, error) do
     if tracking?(pid) do
       AttrStore.add(__MODULE__, pid, transaction_error: {:error, error})

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -171,6 +171,7 @@ defmodule TransactionTest do
   end
 
   test "Transaction with traced external service call" do
+    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
 


### PR DESCRIPTION
We want to track some metrics for reporting later, since they depend on information from the transaction they occur in.