### PR TITLE
Fix name prefix for transaction event

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -282,7 +282,17 @@ defmodule NewRelic.Transaction.Complete do
     Enum.each(span_events, &Collector.SpanEvent.Harvester.report_span_event/1)
   end
 
-  defp report_transaction_event(%{transaction_type: :web} = tx_attrs) do
+  defp report_transaction_event(%{other_transaction_name: _} = tx_attrs) do
+    Collector.TransactionEvent.Harvester.report_event(%Transaction.Event{
+      timestamp: tx_attrs.start_time,
+      duration: tx_attrs.duration_s,
+      total_time: tx_attrs.total_time_s,
+      name: Util.metric_join(["OtherTransaction", tx_attrs.name]),
+      user_attributes: tx_attrs
+    })
+  end
+
+  defp report_transaction_event(tx_attrs) do
     Collector.TransactionEvent.Harvester.report_event(%Transaction.Event{
       timestamp: tx_attrs.start_time,
       duration: tx_attrs.duration_s,
@@ -292,16 +302,6 @@ defmodule NewRelic.Transaction.Complete do
         Map.merge(tx_attrs, %{
           request_url: "#{tx_attrs.host}#{tx_attrs.path}"
         })
-    })
-  end
-
-  defp report_transaction_event(tx_attrs) do
-    Collector.TransactionEvent.Harvester.report_event(%Transaction.Event{
-      timestamp: tx_attrs.start_time,
-      duration: tx_attrs.duration_s,
-      total_time: tx_attrs.total_time_s,
-      name: Util.metric_join(["OtherTransaction", tx_attrs.name]),
-      user_attributes: tx_attrs
     })
   end
 

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -115,8 +115,10 @@ defmodule TransactionEventTest do
     TestPlugApp.call(conn(:get, "/"), [])
     TestPlugApp.call(conn(:get, "/"), [])
 
-    events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+    [event | _] = events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+
     assert length(events) == 2
+    assert [%{name: "WebTransaction/Plug/GET"}, _] = event
 
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end


### PR DESCRIPTION
Fix a bug that put the wrong name attribute on Transaction events (web vs. other)