### PR TITLE
Handle edge case when required attr isn't captured

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -245,5 +245,13 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
+  def transform(:supportability, [:transaction, :missing_attributes]),
+    do: [
+      %Metric{
+        name: :"Supportability/Transaction/MissingAttributes",
+        call_count: 1
+      }
+    ]
+
   defp join(segments), do: NewRelic.Util.metric_join(segments)
 end


### PR DESCRIPTION
In rare conditions a required attribute might not get captured, and this PR updates the agent to handle that case, log the error & move on..

closes #101 