### PR TITLE
Lower log level for harvesters

### DIFF
--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -95,7 +95,7 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, CustomEvent}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Custom Event harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Custom Event harvest - size: #{harvest_size}")
   end
 
   def build_payload(state), do: Event.format_events(state.custom_events)

--- a/lib/new_relic/harvest/collector/error_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/error_trace/harvester.ex
@@ -77,7 +77,7 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, ErrorTrace}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Error Trace harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Error Trace harvest - size: #{harvest_size}")
   end
 
   def build_payload(state), do: state.error_traces |> Enum.uniq() |> Trace.format_errors()

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -75,7 +75,7 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, Metric}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Metric harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Metric harvest - size: #{harvest_size}")
   end
 
   defp build_metric_data(metrics),

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -141,7 +141,7 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, SpanEvent}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Span Event harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Span Event harvest - size: #{harvest_size}")
   end
 
   def build_payload(state) do

--- a/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
@@ -81,7 +81,7 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, TransactionErrorEvent}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Error Event harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Error Event harvest - size: #{harvest_size}")
   end
 
   def build_payload(state), do: Event.format_events(state.error_events)

--- a/lib/new_relic/harvest/collector/transaction_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_event/harvester.ex
@@ -87,7 +87,7 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, TransactionEvent}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Transaction Event harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Transaction Event harvest - size: #{harvest_size}")
   end
 
   def build_payload(state) do

--- a/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
@@ -105,7 +105,7 @@ defmodule NewRelic.Harvest.Collector.TransactionTrace.Harvester do
 
   def log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, TransactionTrace}, harvest_size: harvest_size)
-    NewRelic.log(:info, "Completed Transaction Trace harvest - size: #{harvest_size}")
+    NewRelic.log(:debug, "Completed Transaction Trace harvest - size: #{harvest_size}")
   end
 
   def build_trace_payload(state), do: state |> collect_traces |> Trace.format_traces()


### PR DESCRIPTION
Drop the log level for the output from harvesters from `info` to `debug`

closes #104 