### PR TITLE
Fix `Erlang error: {:key_exists, ...}`

### DIFF
--- a/lib/new_relic/util/priority_queue.ex
+++ b/lib/new_relic/util/priority_queue.ex
@@ -10,7 +10,7 @@ defmodule NewRelic.Util.PriorityQueue do
 
   def insert({size, _} = tree, max_size, key, value) when size >= max_size do
     {_k, _v, tree} =
-      {key, System.system_time()}
+      {key, differentiator()}
       |> :gb_trees.insert(value, tree)
       |> :gb_trees.take_smallest()
 
@@ -18,7 +18,7 @@ defmodule NewRelic.Util.PriorityQueue do
   end
 
   def insert(tree, _max_size, key, value) do
-    {key, System.system_time()}
+    {key, differentiator()}
     |> :gb_trees.insert(value, tree)
   end
 
@@ -28,5 +28,9 @@ defmodule NewRelic.Util.PriorityQueue do
 
   def list(tree) do
     :gb_trees.to_list(tree)
+  end
+
+  defp differentiator() do
+    :erlang.unique_integer()
   end
 end

--- a/test/priority_queue_test.exs
+++ b/test/priority_queue_test.exs
@@ -9,11 +9,14 @@ defmodule PriorityQueueTest do
     pq =
       PriorityQueue.new()
       |> PriorityQueue.insert(max, 2, :bar)
+      |> PriorityQueue.insert(max, 2, :bar)
+      |> PriorityQueue.insert(max, 2, :bar)
+      |> PriorityQueue.insert(max, 2, :bar)
       |> PriorityQueue.insert(max, 3, :baz)
       |> PriorityQueue.insert(max, 4, :first)
       |> PriorityQueue.insert(max, 5, :second)
-      |> PriorityQueue.insert(max, 1, :foo)
       |> PriorityQueue.insert(max, 5, :third)
+      |> PriorityQueue.insert(max, 1, :foo)
 
     assert [:first, :second, :third] == PriorityQueue.values(pq)
   end


### PR DESCRIPTION
Fixes #108 by using [`:erlang.unique_integer/0`](http://erlang.org/doc/man/erlang.html#unique_integer-0`) to ensure that we're generating a unique key for the `gb_tree`.