### PR TITLE
Fix: race condition when tracing async_nolink processes

### DIFF
--- a/lib/new_relic/transaction/monitor.ex
+++ b/lib/new_relic/transaction/monitor.ex
@@ -54,16 +54,6 @@ defmodule NewRelic.Transaction.Monitor do
   end
 
   def handle_info(
-        {:trace_ts, source, :return_from, {Task.Supervisor, :async_nolink, _}, %Task{pid: pid},
-         timestamp},
-        state
-      ) do
-    enable_trace_flags(pid)
-    Transaction.Reporter.track_spawn(source, pid, NewRelic.Util.time_to_ms(timestamp))
-    {:noreply, state}
-  end
-
-  def handle_info(
         {:trace_ts, source, :return_from, {:poolboy, :checkout, _}, pid, timestamp},
         state
       ) do
@@ -110,12 +100,7 @@ defmodule NewRelic.Transaction.Monitor do
     # Use function tracers to notice when Async work has been kicked off
     #   http://erlang.org/doc/man/erlang.html#trace_3_trace_messages_return_from
     #   http://erlang.org/doc/apps/erts/match_spec.html
-    trace_task_async_nolink()
     trace_poolboy_checkout()
-  end
-
-  defp trace_task_async_nolink do
-    :erlang.trace_pattern({Task.Supervisor, :async_nolink, :_}, [{:_, [], [{:return_trace}]}], [])
   end
 
   defp trace_poolboy_checkout do

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -18,13 +18,18 @@ defmodule TransactionErrorEventTest do
     end
 
     get "/caught/error" do
-      Task.Supervisor.async_nolink(TestSup, fn ->
+      Process.flag(:trap_exit, true)
+
+      Task.async(fn ->
         Process.sleep(5)
         NewRelic.add_attributes(nested: "process")
         raise "NestedTaskError"
       end)
 
-      Process.sleep(50)
+      receive do
+        {:EXIT, _pid, {%RuntimeError{message: "NestedTaskError"}, _}} -> :ignore
+      end
+
       send_resp(conn, 200, "ok, fine")
     end
   end

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -30,6 +30,7 @@ defmodule TransactionErrorEventTest do
         {:EXIT, _pid, {%RuntimeError{message: "NestedTaskError"}, _}} -> :ignore
       end
 
+      Process.sleep(500)
       send_resp(conn, 200, "ok, fine")
     end
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -72,7 +72,7 @@ defmodule TransactionTest do
           Process.sleep(20)
           NewRelic.add_attributes(nested: "spawn")
 
-          Task.Supervisor.async_nolink(TestTaskSup, fn ->
+          Task.async(fn ->
             Process.sleep(20)
             NewRelic.add_attributes(not_linked: "still_tracked")
 
@@ -229,7 +229,6 @@ defmodule TransactionTest do
 
   test "Track attrs inside proccesses spawned by the transaction" do
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
-    Task.Supervisor.start_link(name: TestTaskSup)
 
     TestHelper.request(TestPlugApp, conn(:get, "/spawn"))
 


### PR DESCRIPTION
## Description

Discovered a race condition where, when an `async_nolink` process is started within a transaction, if it finishes after the transaction has completed, the transaction it is linked to no longer exists so the process's results will not be reported.

This PR removes the linking of an `async_nolink` process to a transaction so that it will consistently be reported to the agent. Note: when using erlang 20, the logging is async and the race condition still exists.
