### PR TITLE
Revert "Fix: race condition when tracing async_nolink processes"

### DIFF
--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -18,19 +18,13 @@ defmodule TransactionErrorEventTest do
     end
 
     get "/caught/error" do
-      Process.flag(:trap_exit, true)
-
-      Task.async(fn ->
+      Task.Supervisor.async_nolink(TestSup, fn ->
         Process.sleep(5)
         NewRelic.add_attributes(nested: "process")
         raise "NestedTaskError"
       end)
 
-      receive do
-        {:EXIT, _pid, {%RuntimeError{message: "NestedTaskError"}, _}} -> :ignore
-      end
-
-      Process.sleep(500)
+      Process.sleep(50)
       send_resp(conn, 200, "ok, fine")
     end
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -72,7 +72,7 @@ defmodule TransactionTest do
           Process.sleep(20)
           NewRelic.add_attributes(nested: "spawn")
 
-          Task.async(fn ->
+          Task.Supervisor.async_nolink(TestTaskSup, fn ->
             Process.sleep(20)
             NewRelic.add_attributes(not_linked: "still_tracked")
 
@@ -229,6 +229,7 @@ defmodule TransactionTest do
 
   test "Track attrs inside proccesses spawned by the transaction" do
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+    Task.Supervisor.start_link(name: TestTaskSup)
 
     TestHelper.request(TestPlugApp, conn(:get, "/spawn"))
 


### PR DESCRIPTION
Reverts newrelic/elixir_agent#118

Turns out we didn't think far enough ahead. It's a little more complex since there's multiple use cases for  actually considering the work in an `async_nolink` as part of the Transaction.

We're going to think about this and see how we can solve this problem better!
