### PR TITLE
Protect against missing http status

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -457,7 +457,7 @@ defmodule NewRelic.Transaction.Complete do
       expected: expected,
       transaction_name: Util.metric_join(["WebTransaction", tx_attrs.name]),
       agent_attributes: %{
-        http_response_code: tx_attrs.status,
+        http_response_code: tx_attrs[:status],
         request_method: tx_attrs.request_method
       },
       user_attributes:


### PR DESCRIPTION
In some race conditions, the HTTP `status` attribute might not get reported. This PR handles that case.

sidekick/ @mattbaker 