### PR TITLE
Ignore extraneous Plug errors

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -2,7 +2,7 @@ defmodule NewRelic.Config do
   @moduledoc """
   New Relic Agent Configuration
 
-  All configuration items can be set via ENV variable _or_ via Application config
+  All configuration items can be set via `ENV` variable _or_ via `Application` config
   """
 
   @doc """

--- a/lib/new_relic/error/error_logger_handler.ex
+++ b/lib/new_relic/error/error_logger_handler.ex
@@ -31,10 +31,10 @@ defmodule NewRelic.Error.ErrorLoggerHandler do
   def handle_event({:error_report, _gl, {pid, :crash_report, [report | _]}}, state)
       when is_list(report) do
     if NewRelic.Transaction.Reporter.tracking?(pid) do
-      NewRelic.Error.Reporter.report_transaction_error(report)
+      NewRelic.Error.Reporter.report_error(:transaction, report)
     else
       Task.Supervisor.start_child(NewRelic.Error.TaskSupervisor, fn ->
-        NewRelic.Error.Reporter.report_process_error(report)
+        NewRelic.Error.Reporter.report_error(:process, report)
       end)
     end
 

--- a/lib/new_relic/error/logger_handler.ex
+++ b/lib/new_relic/error/logger_handler.ex
@@ -20,9 +20,9 @@ defmodule NewRelic.Error.LoggerHandler do
         _config
       ) do
     if NewRelic.Transaction.Reporter.tracking?(self()) do
-      NewRelic.Error.Reporter.report_transaction_error(report)
+      NewRelic.Error.Reporter.report_error(:transaction, report)
     else
-      NewRelic.Error.Reporter.report_process_error(report)
+      NewRelic.Error.Reporter.report_error(:process, report)
     end
   end
 

--- a/lib/new_relic/graceful_shutdown.ex
+++ b/lib/new_relic/graceful_shutdown.ex
@@ -1,4 +1,5 @@
 defmodule NewRelic.GracefulShutdown do
+  @moduledoc false
   use GenServer
 
   def start_link() do

--- a/lib/new_relic/harvest/collector/connect.ex
+++ b/lib/new_relic/harvest/collector/connect.ex
@@ -1,4 +1,6 @@
 defmodule NewRelic.Harvest.Collector.Connect do
+  @moduledoc false
+
   def payload do
     [
       %{

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -1,4 +1,6 @@
 defmodule NewRelic.Util.Vendor do
+  @moduledoc false
+
   def maybe_add_linux_boot_id(util) do
     case File.read("/proc/sys/kernel/random/boot_id") do
       {:ok, boot_id} -> Map.put(util, "boot_id", boot_id)


### PR DESCRIPTION
This PR ignores a category of error report that is generated by Plug + Cowboy for 400 level exceptions which crash the Cowboy process yet are caught by Plug.

Also fixes a few modules to be excluded from docs