### PR TITLE
Improve formatting of ErlangError

### DIFF
--- a/lib/new_relic/util/error.ex
+++ b/lib/new_relic/util/error.ex
@@ -15,8 +15,14 @@ defmodule NewRelic.Util.Error do
     {exception_type, exception_reason, exception_stacktrace}
   end
 
+  def format_type(:error, %ErlangError{original: {_reason, {module, function, args}}}),
+    do: Exception.format_mfa(module, function, length(args))
+
   def format_type(:error, %{__struct__: struct}), do: inspect(struct)
   def format_type(:exit, _reason), do: "EXIT"
+
+  def format_reason(:error, %ErlangError{original: {reason, {module, function, args}}}),
+    do: "(" <> Exception.format_mfa(module, function, length(args)) <> ") " <> inspect(reason)
 
   def format_reason(:error, error),
     do:


### PR DESCRIPTION
This PR improves the formatting of ErlangError by unwrapping them and displaying the underlying error better