### PR TITLE
Improve startup failure handling

### DIFF
--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -17,17 +17,10 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     :ets.new(__MODULE__, [:named_table, :public, :set])
 
     if NewRelic.Config.enabled?() do
-      case Collector.Protocol.preconnect() do
-        {:error, _reason} ->
-          :ignore
-
-        %{"redirect_host" => redirect_host} ->
-          Application.put_env(:new_relic_agent, :collector_instance_host, redirect_host)
-          send(self(), :connect)
-      end
+      {:ok, %{status: :not_connected}, {:continue, :preconnect}}
+    else
+      {:ok, %{status: :not_connected}}
     end
-
-    {:ok, :unknown}
   end
 
   def agent_run_id, do: lookup(:agent_run_id)
@@ -35,21 +28,39 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
   def account_id, do: lookup(:account_id)
   def primary_application_id, do: lookup(:primary_application_id)
 
-  def reconnect, do: send(__MODULE__, :connect)
+  def reconnect, do: send(__MODULE__, :reconnect)
 
-  def handle_info(:connect, _state) do
-    state =
-      Collector.Connect.payload()
-      |> Collector.Protocol.connect()
-      |> parse_connect
+  def handle_continue(:preconnect, _state) do
+    case Collector.Protocol.preconnect() do
+      %{"redirect_host" => redirect_host} ->
+        Application.put_env(:new_relic_agent, :collector_instance_host, redirect_host)
+        {:noreply, %{status: :preconnected}, {:continue, :connect}}
 
-    store_agent_run(state)
+      {:error, _reason} ->
+        {:noreply, %{status: :error_during_preconnect}}
 
-    {:noreply, state}
+      {:failed_connect, _reason} ->
+        {:noreply, %{status: :failed_to_preconnect}}
+    end
+  end
+
+  def handle_continue(:connect, _state) do
+    {:noreply, connect()}
+  end
+
+  def handle_info(:reconnect, _state) do
+    {:noreply, connect()}
   end
 
   def handle_call(:connected, _from, state) do
     {:reply, true, state}
+  end
+
+  defp connect() do
+    Collector.Connect.payload()
+    |> Collector.Protocol.connect()
+    |> Collector.Connect.parse_connect()
+    |> store_agent_run
   end
 
   defp store_agent_run(%{"agent_run_id" => _} = state) do
@@ -80,30 +91,12 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     store(:data_report_period, state["data_report_period"] * 1000)
 
     store(:apdex_t, state["apdex_t"])
+
+    state
   end
 
-  defp store_agent_run(_error), do: :ignore
-
-  defp parse_connect(
-         %{"agent_run_id" => _, "messages" => [%{"message" => message}]} = connect_response
-       ) do
-    NewRelic.log(:info, message)
-    connect_response
-  end
-
-  defp parse_connect(%{"error_type" => _, "message" => message}) do
-    NewRelic.log(:error, message)
-    :error
-  end
-
-  defp parse_connect({:error, reason}) do
-    NewRelic.log(:error, "Failed connect #{inspect(reason)}")
-    :error
-  end
-
-  defp parse_connect(503) do
-    NewRelic.log(:error, "Collector unavailable")
-    :error
+  defp store_agent_run(state) do
+    state
   end
 
   def store(key, value) do

--- a/lib/new_relic/harvest/collector/connect.ex
+++ b/lib/new_relic/harvest/collector/connect.ex
@@ -19,4 +19,26 @@ defmodule NewRelic.Harvest.Collector.Connect do
       }
     ]
   end
+
+  def parse_connect(
+        %{"agent_run_id" => _, "messages" => [%{"message" => message}]} = connect_response
+      ) do
+    NewRelic.log(:info, message)
+    connect_response
+  end
+
+  def parse_connect(%{"error_type" => _, "message" => message}) do
+    NewRelic.log(:error, message)
+    :error
+  end
+
+  def parse_connect({:error, reason}) do
+    NewRelic.log(:error, "Failed connect #{inspect(reason)}")
+    :error
+  end
+
+  def parse_connect(503) do
+    NewRelic.log(:error, "Collector unavailable")
+    :error
+  end
 end


### PR DESCRIPTION
This PR refactors the `AgentRun` startup to initialize the connection to New Relic using `continue` signals, as well has handling cases where the agent can't reach New Relic due to connectivity issues.