### PR TITLE
Protect against huge arguments blowing out memory

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -233,7 +233,7 @@ defmodule NewRelic.Transaction.Complete do
       class_name: "#{function}/#{arity}",
       method_name: nil,
       metric_name: "#{inspect(module)}.#{function}",
-      attributes: %{query: inspect(args, charlists: false)}
+      attributes: %{query: args}
     })
   end
 

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -19,6 +19,12 @@ defmodule TransactionTraceTest do
     use NewRelic.Tracer
     @trace :function
     def function(n), do: Process.sleep(n)
+
+    @trace :do_work
+    def do_work(args) do
+      args
+      Process.sleep(200)
+    end
   end
 
   defmodule ExternalService do
@@ -62,6 +68,13 @@ defmodule TransactionTraceTest do
 
     get "/supremely_custom_name" do
       NewRelic.set_transaction_name("/supremely/unique/name")
+      send_resp(conn, 200, "ok")
+    end
+
+    get "/huge_args" do
+      Enum.into(1..10000, %{}, &{&1, &1})
+      |> HelperModule.do_work()
+
       send_resp(conn, 200, "ok")
     end
   end
@@ -276,5 +289,16 @@ defmodule TransactionTraceTest do
                trace,
                max_named_traces
              )
+  end
+
+  test "Ensure that huge argument terms don't blow out memory" do
+    TestHelper.request(TestPlugApp, conn(:get, "/huge_args"))
+
+    [[span, _, _] | _] = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
+
+    span
+    |> IO.inspect()
+
+    assert String.length(span[:args]) < 500
   end
 end

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -8,10 +8,12 @@ defmodule TransactionTraceTest do
   setup do
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.TransactionTrace.HarvestCycle)
+    TestHelper.restart_harvest_cycle(Collector.SpanEvent.HarvestCycle)
 
     on_exit(fn ->
       TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
       TestHelper.pause_harvest_cycle(Collector.TransactionTrace.HarvestCycle)
+      TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
     end)
   end
 
@@ -22,8 +24,8 @@ defmodule TransactionTraceTest do
 
     @trace :do_work
     def do_work(args) do
-      args
       Process.sleep(200)
+      args
     end
   end
 
@@ -292,13 +294,16 @@ defmodule TransactionTraceTest do
   end
 
   test "Ensure that huge argument terms don't blow out memory" do
+    System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")
+    System.put_env("NEW_RELIC_LICENSE_KEY", "foo")
+
     TestHelper.request(TestPlugApp, conn(:get, "/huge_args"))
 
     [[span, _, _] | _] = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
 
-    span
-    |> IO.inspect()
-
     assert String.length(span[:args]) < 500
+
+    System.delete_env("NEW_RELIC_HARVEST_ENABLED")
+    System.delete_env("NEW_RELIC_LICENSE_KEY")
   end
 end


### PR DESCRIPTION
This PR is intended to protect against excessive memory usage in cases where a very large term is passed through a `@trace`d function.

This is done by `inspect`ing the term at the point of instrumentation before we store it inside a TransactionTrace or Span. `Inspect` has mechanisms for short-circuiting it's work, and we leverage those.

I tested this in our GraphQL service, which contains `Absinthe` structs that are known to be gigantic. The resulting data was 20x smaller, and avoided a full memory copy of the struct. Yay!