### PR TITLE
Sb8244 request queue

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -10,49 +10,50 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         total_time_s: total_time_s,
         queue_duration_s: queue_duration_s
       ),
-      do: [
-        %Metric{
-          name: :HttpDispatcher,
-          call_count: 1,
-          total_call_time: duration_s,
-          total_exclusive_time: duration_s,
-          min_call_time: duration_s,
-          max_call_time: duration_s
-        },
-        %Metric{
-          name: :WebTransaction,
-          call_count: 1,
-          total_call_time: duration_s,
-          total_exclusive_time: duration_s,
-          min_call_time: duration_s,
-          max_call_time: duration_s
-        },
-        %Metric{
-          name: join(["WebTransaction", name]),
-          call_count: 1,
-          total_call_time: duration_s,
-          total_exclusive_time: duration_s,
-          min_call_time: duration_s,
-          max_call_time: duration_s
-        },
-        %Metric{
-          name: :WebTransactionTotalTime,
-          call_count: 1,
-          total_call_time: total_time_s,
-          total_exclusive_time: total_time_s,
-          min_call_time: total_time_s,
-          max_call_time: total_time_s
-        },
-        %Metric{
-          name: join(["WebTransactionTotalTime", name]),
-          call_count: 1,
-          total_call_time: total_time_s,
-          total_exclusive_time: total_time_s,
-          min_call_time: total_time_s,
-          max_call_time: total_time_s
-        }
-      ]
-      |> queue_duration_metric(queue_duration_s)
+      do:
+        [
+          %Metric{
+            name: :HttpDispatcher,
+            call_count: 1,
+            total_call_time: duration_s,
+            total_exclusive_time: duration_s,
+            min_call_time: duration_s,
+            max_call_time: duration_s
+          },
+          %Metric{
+            name: :WebTransaction,
+            call_count: 1,
+            total_call_time: duration_s,
+            total_exclusive_time: duration_s,
+            min_call_time: duration_s,
+            max_call_time: duration_s
+          },
+          %Metric{
+            name: join(["WebTransaction", name]),
+            call_count: 1,
+            total_call_time: duration_s,
+            total_exclusive_time: duration_s,
+            min_call_time: duration_s,
+            max_call_time: duration_s
+          },
+          %Metric{
+            name: :WebTransactionTotalTime,
+            call_count: 1,
+            total_call_time: total_time_s,
+            total_exclusive_time: total_time_s,
+            min_call_time: total_time_s,
+            max_call_time: total_time_s
+          },
+          %Metric{
+            name: join(["WebTransactionTotalTime", name]),
+            call_count: 1,
+            total_call_time: total_time_s,
+            total_exclusive_time: total_time_s,
+            min_call_time: total_time_s,
+            max_call_time: total_time_s
+          }
+        ]
+        |> queue_duration_metric(queue_duration_s)
 
   def transform({:other_transaction, name}, duration_s: duration_s, total_time_s: total_time_s),
     do: [

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -5,55 +5,49 @@ defmodule NewRelic.Harvest.Collector.MetricData do
 
   alias NewRelic.Metric
 
-  def transform({:transaction, name},
-        duration_s: duration_s,
-        total_time_s: total_time_s,
-        queue_duration_s: queue_duration_s
-      ),
-      do:
-        [
-          %Metric{
-            name: :HttpDispatcher,
-            call_count: 1,
-            total_call_time: duration_s,
-            total_exclusive_time: duration_s,
-            min_call_time: duration_s,
-            max_call_time: duration_s
-          },
-          %Metric{
-            name: :WebTransaction,
-            call_count: 1,
-            total_call_time: duration_s,
-            total_exclusive_time: duration_s,
-            min_call_time: duration_s,
-            max_call_time: duration_s
-          },
-          %Metric{
-            name: join(["WebTransaction", name]),
-            call_count: 1,
-            total_call_time: duration_s,
-            total_exclusive_time: duration_s,
-            min_call_time: duration_s,
-            max_call_time: duration_s
-          },
-          %Metric{
-            name: :WebTransactionTotalTime,
-            call_count: 1,
-            total_call_time: total_time_s,
-            total_exclusive_time: total_time_s,
-            min_call_time: total_time_s,
-            max_call_time: total_time_s
-          },
-          %Metric{
-            name: join(["WebTransactionTotalTime", name]),
-            call_count: 1,
-            total_call_time: total_time_s,
-            total_exclusive_time: total_time_s,
-            min_call_time: total_time_s,
-            max_call_time: total_time_s
-          }
-        ]
-        |> queue_duration_metric(queue_duration_s)
+  def transform({:transaction, name}, duration_s: duration_s, total_time_s: total_time_s),
+    do: [
+      %Metric{
+        name: :HttpDispatcher,
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: :WebTransaction,
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: join(["WebTransaction", name]),
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: :WebTransactionTotalTime,
+        call_count: 1,
+        total_call_time: total_time_s,
+        total_exclusive_time: total_time_s,
+        min_call_time: total_time_s,
+        max_call_time: total_time_s
+      },
+      %Metric{
+        name: join(["WebTransactionTotalTime", name]),
+        call_count: 1,
+        total_call_time: total_time_s,
+        total_exclusive_time: total_time_s,
+        min_call_time: total_time_s,
+        max_call_time: total_time_s
+      }
+    ]
 
   def transform({:other_transaction, name}, duration_s: duration_s, total_time_s: total_time_s),
     do: [
@@ -259,12 +253,10 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
-  defp join(segments), do: NewRelic.Util.metric_join(segments)
+  def transform(:queue_time, duration_s: nil), do: []
 
-  defp queue_duration_metric(metrics, nil), do: metrics
-
-  defp queue_duration_metric(metrics, duration_s),
-    do: [
+  def transform(:queue_time, duration_s: duration_s) do
+    [
       %Metric{
         name: "WebFrontend/QueueTime",
         call_count: 1,
@@ -273,6 +265,8 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         min_call_time: duration_s,
         max_call_time: duration_s
       }
-      | metrics
     ]
+  end
+
+  defp join(segments), do: NewRelic.Util.metric_join(segments)
 end

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -5,49 +5,54 @@ defmodule NewRelic.Harvest.Collector.MetricData do
 
   alias NewRelic.Metric
 
-  def transform({:transaction, name}, duration_s: duration_s, total_time_s: total_time_s),
-    do: [
-      %Metric{
-        name: :HttpDispatcher,
-        call_count: 1,
-        total_call_time: duration_s,
-        total_exclusive_time: duration_s,
-        min_call_time: duration_s,
-        max_call_time: duration_s
-      },
-      %Metric{
-        name: :WebTransaction,
-        call_count: 1,
-        total_call_time: duration_s,
-        total_exclusive_time: duration_s,
-        min_call_time: duration_s,
-        max_call_time: duration_s
-      },
-      %Metric{
-        name: join(["WebTransaction", name]),
-        call_count: 1,
-        total_call_time: duration_s,
-        total_exclusive_time: duration_s,
-        min_call_time: duration_s,
-        max_call_time: duration_s
-      },
-      %Metric{
-        name: :WebTransactionTotalTime,
-        call_count: 1,
-        total_call_time: total_time_s,
-        total_exclusive_time: total_time_s,
-        min_call_time: total_time_s,
-        max_call_time: total_time_s
-      },
-      %Metric{
-        name: join(["WebTransactionTotalTime", name]),
-        call_count: 1,
-        total_call_time: total_time_s,
-        total_exclusive_time: total_time_s,
-        min_call_time: total_time_s,
-        max_call_time: total_time_s
-      }
-    ]
+  def transform({:transaction, name},
+        duration_s: duration_s,
+        total_time_s: total_time_s,
+        queue_duration_s: queue_duration_s
+      ),
+      do: [
+        %Metric{
+          name: :HttpDispatcher,
+          call_count: 1,
+          total_call_time: duration_s,
+          total_exclusive_time: duration_s,
+          min_call_time: duration_s,
+          max_call_time: duration_s
+        },
+        %Metric{
+          name: :WebTransaction,
+          call_count: 1,
+          total_call_time: duration_s,
+          total_exclusive_time: duration_s,
+          min_call_time: duration_s,
+          max_call_time: duration_s
+        },
+        %Metric{
+          name: join(["WebTransaction", name]),
+          call_count: 1,
+          total_call_time: duration_s,
+          total_exclusive_time: duration_s,
+          min_call_time: duration_s,
+          max_call_time: duration_s
+        },
+        %Metric{
+          name: :WebTransactionTotalTime,
+          call_count: 1,
+          total_call_time: total_time_s,
+          total_exclusive_time: total_time_s,
+          min_call_time: total_time_s,
+          max_call_time: total_time_s
+        },
+        %Metric{
+          name: join(["WebTransactionTotalTime", name]),
+          call_count: 1,
+          total_call_time: total_time_s,
+          total_exclusive_time: total_time_s,
+          min_call_time: total_time_s,
+          max_call_time: total_time_s
+        }
+      ]
+      |> queue_duration_metric(queue_duration_s)
 
   def transform({:other_transaction, name}, duration_s: duration_s, total_time_s: total_time_s),
     do: [
@@ -254,4 +259,19 @@ defmodule NewRelic.Harvest.Collector.MetricData do
     ]
 
   defp join(segments), do: NewRelic.Util.metric_join(segments)
+
+  defp queue_duration_metric(metrics, nil), do: metrics
+
+  defp queue_duration_metric(metrics, duration_s),
+    do: [
+      %Metric{
+        name: "WebFrontend/QueueTime",
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      }
+      | metrics
+    ]
 end

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -62,7 +62,11 @@ defmodule NewRelic.Transaction.Complete do
     start_time_us = System.convert_time_unit(start_time, :native, :microsecond)
     queue_duration_us = max(0, start_time_us - queue_start_us)
 
-    Map.put(tx, :queue_duration_us, queue_duration_us)
+    tx
+    |> Map.merge(%{
+      queue_duration_us: queue_duration_us,
+      queue_duration_s: queue_duration_us / 1_000_000
+    })
   end
 
   defp derive_queue_duration(tx), do: tx

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -323,7 +323,7 @@ defmodule NewRelic.Transaction.Complete do
       duration: tx_attrs.duration_s,
       total_time: tx_attrs.total_time_s,
       name: Util.metric_join(["WebTransaction", tx_attrs.name]),
-      queue_duration: Map.get(tx_attrs, :queue_duration_us, nil),
+      queue_duration: Map.get(tx_attrs, :queue_duration_s, nil),
       user_attributes:
         Map.merge(tx_attrs, %{
           request_url: "#{tx_attrs.host}#{tx_attrs.path}"

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -509,7 +509,8 @@ defmodule NewRelic.Transaction.Complete do
   def report_transaction_metric(tx) do
     NewRelic.report_metric({:transaction, tx.name},
       duration_s: tx.duration_s,
-      total_time_s: tx.total_time_s
+      total_time_s: tx.total_time_s,
+      queue_duration_s: Map.get(tx, :queue_duration_s, nil)
     )
   end
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -58,7 +58,8 @@ defmodule NewRelic.Transaction.Complete do
     })
   end
 
-  defp derive_queue_duration(%{start_time: start_time, queue_start_us: queue_start_us} = tx) when not is_nil(queue_start_us) do
+  defp derive_queue_duration(%{start_time: start_time, queue_start_us: queue_start_us} = tx)
+       when not is_nil(queue_start_us) do
     start_time_us = System.convert_time_unit(start_time, :native, :microsecond)
     queue_duration_us = max(0, start_time_us - queue_start_us)
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -58,7 +58,7 @@ defmodule NewRelic.Transaction.Complete do
     })
   end
 
-  defp derive_queue_duration(%{start_time: start_time, queue_start_us: queue_start_us} = tx) do
+  defp derive_queue_duration(%{start_time: start_time, queue_start_us: queue_start_us} = tx) when not is_nil(queue_start_us) do
     start_time_us = System.convert_time_unit(start_time, :native, :microsecond)
     queue_duration_us = max(0, start_time_us - queue_start_us)
 
@@ -319,6 +319,7 @@ defmodule NewRelic.Transaction.Complete do
       duration: tx_attrs.duration_s,
       total_time: tx_attrs.total_time_s,
       name: Util.metric_join(["WebTransaction", tx_attrs.name]),
+      queue_duration: Map.get(tx_attrs, :queue_duration_us, nil),
       user_attributes:
         Map.merge(tx_attrs, %{
           request_url: "#{tx_attrs.host}#{tx_attrs.path}"

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -512,7 +512,7 @@ defmodule NewRelic.Transaction.Complete do
     )
   end
 
-  def report_queue_time_metric(%{queue_duration_s: duration_s}) when not is_nil(duration_s) do
+  def report_queue_time_metric(%{queueDuration: duration_s}) when not is_nil(duration_s) do
     NewRelic.report_metric(:queue_time,
       duration_s: duration_s
     )

--- a/lib/new_relic/transaction/event.ex
+++ b/lib/new_relic/transaction/event.ex
@@ -6,8 +6,7 @@ defmodule NewRelic.Transaction.Event do
             name: nil,
             duration: nil,
             total_time: nil,
-            user_attributes: %{},
-            queue_duration: nil
+            user_attributes: %{}
 
   @moduledoc false
 
@@ -24,8 +23,7 @@ defmodule NewRelic.Transaction.Event do
         timestamp: transaction.timestamp,
         name: transaction.name,
         duration: transaction.duration,
-        type: transaction.type,
-        queueDuration: transaction.queue_duration
+        type: transaction.type
       },
       NewRelic.Util.Event.process_event(transaction.user_attributes)
     ]

--- a/lib/new_relic/transaction/event.ex
+++ b/lib/new_relic/transaction/event.ex
@@ -6,7 +6,8 @@ defmodule NewRelic.Transaction.Event do
             name: nil,
             duration: nil,
             total_time: nil,
-            user_attributes: %{}
+            user_attributes: %{},
+            queue_duration: nil
 
   @moduledoc false
 
@@ -23,7 +24,8 @@ defmodule NewRelic.Transaction.Event do
         timestamp: transaction.timestamp,
         name: transaction.name,
         duration: transaction.duration,
-        type: transaction.type
+        type: transaction.type,
+        queueDuration: transaction.queue_duration
       },
       NewRelic.Util.Event.process_event(transaction.user_attributes)
     ]

--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -90,18 +90,15 @@ defmodule NewRelic.Transaction.Plug do
     |> NewRelic.add_attributes()
   end
 
-  @queue_duration_headers ["x-request-start", "x-queue-start", "x-middleware-start"]
-
   defp extract_queue_start_us(%{req_headers: headers}),
     do:
       Enum.reduce_while(headers, nil, fn
-        {header, timestamp}, acc when header in @queue_duration_headers ->
+        {"x-request-start", timestamp}, acc ->
           case RequestQueueTime.timestamp_to_us(timestamp) do
             {:ok, us} ->
               {:halt, us}
 
-            {:error, reason} ->
-              Logger.debug(reason)
+            _ ->
               {:cont, acc}
           end
 

--- a/lib/new_relic/transaction/request_queue_time.ex
+++ b/lib/new_relic/transaction/request_queue_time.ex
@@ -1,0 +1,52 @@
+defmodule NewRelic.Transaction.RequestQueueTime do
+  @moduledoc false
+
+  # Any timestamps before this are thrown out and the parser
+  # will try again with a larger unit (2000/1/1 UTC)
+  @earliest_acceptable_time 946_684_800 * 1_000_000
+  @multipliers [1, 1_000, 1_000_000]
+
+  # Return in seconds?
+  def timestamp_to_us("t=" <> time) do
+    with {:ok, numeric} <- time_to_numeric(time),
+         {:ok, microseconds} <- time_to_microseconds(numeric) do
+      {:ok, min(microseconds, now_us())}
+    end
+  end
+
+  def timestamp_to_us(_), do:
+    {:error, "invalid request queueing format, expected `t=\d+`"}
+
+  defp time_to_microseconds(numeric),
+    do:
+      Enum.reduce_while(@multipliers, {:error, "timestamp '#{numeric}' is not valid"}, fn multiplier,
+                                                                                       acc ->
+        time = numeric * multiplier
+
+        if time > @earliest_acceptable_time do
+          {:halt, {:ok, time}}
+        else
+          {:cont, acc}
+        end
+      end)
+
+  defp time_to_numeric(time) do
+    try do
+      {:ok, String.to_integer(time)}
+    rescue
+      ArgumentError ->
+        time_to_numeric_f(time)
+    end
+  end
+
+  defp time_to_numeric_f(time) do
+    try do
+      {:ok, String.to_float(time)}
+    rescue
+      ArgumentError ->
+        {:error, @invalid_format}
+    end
+  end
+
+  defp now_us(), do: System.system_time(:microsecond)
+end

--- a/lib/new_relic/transaction/request_queue_time.ex
+++ b/lib/new_relic/transaction/request_queue_time.ex
@@ -14,21 +14,23 @@ defmodule NewRelic.Transaction.RequestQueueTime do
     end
   end
 
-  def timestamp_to_us(_), do:
-    {:error, "invalid request queueing format, expected `t=\d+`"}
+  def timestamp_to_us(_), do: {:error, "invalid request queueing format, expected `t=\d+`"}
 
   defp time_to_microseconds(numeric),
     do:
-      Enum.reduce_while(@multipliers, {:error, "timestamp '#{numeric}' is not valid"}, fn multiplier,
-                                                                                       acc ->
-        time = numeric * multiplier
+      Enum.reduce_while(
+        @multipliers,
+        {:error, "timestamp '#{numeric}' is not valid"},
+        fn multiplier, acc ->
+          time = numeric * multiplier
 
-        if time > @earliest_acceptable_time do
-          {:halt, {:ok, time}}
-        else
-          {:cont, acc}
+          if time > @earliest_acceptable_time do
+            {:halt, {:ok, time}}
+          else
+            {:cont, acc}
+          end
         end
-      end)
+      )
 
   defp time_to_numeric(time) do
     try do

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -97,13 +97,18 @@ defmodule MetricTransactionTest do
   test "Request queueing transaction" do
     conn =
       conn(:get, "/foo/1")
-      |> Plug.Conn.put_req_header("x-request-start", "t=#{:os.system_time(:microsecond) - 100_000}" )
+      |> Plug.Conn.put_req_header(
+        "x-request-start",
+        "t=#{:os.system_time(:microsecond) - 100_000}"
+      )
 
     TestPlugApp.call(conn, [])
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert [_, [1, time, time, time, time, 0]] = TestHelper.find_metric(metrics, "WebFrontend/QueueTime")
+    assert [_, [1, time, time, time, time, 0]] =
+             TestHelper.find_metric(metrics, "WebFrontend/QueueTime")
+
     assert_in_delta time, 0.1, 0.05
   end
 

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -84,6 +84,7 @@ defmodule MetricTransactionTest do
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
     assert TestHelper.find_metric(metrics, "WebTransaction/Plug/GET//foo/:blah")
+    refute TestHelper.find_metric(metrics, "WebFrontend/QueueTime")
 
     apdex = TestHelper.find_metric(metrics, "Apdex")
 
@@ -91,6 +92,19 @@ defmodule MetricTransactionTest do
 
     assert TestHelper.find_metric(metrics, "External/MetricTransactionTest.External.call/all")
     assert TestHelper.find_metric(metrics, "External/allWeb")
+  end
+
+  test "Request queueing transaction" do
+    conn =
+      conn(:get, "/foo/1")
+      |> Plug.Conn.put_req_header("x-request-start", "t=#{:os.system_time(:microsecond) - 100_000}" )
+
+    TestPlugApp.call(conn, [])
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    assert [_, [1, time, time, time, time, 0]] = TestHelper.find_metric(metrics, "WebFrontend/QueueTime")
+    assert_in_delta time, 0.1, 0.05
   end
 
   test "Failed transaction" do

--- a/test/new_relic/transaction/request_queue_time_test.exs
+++ b/test/new_relic/transaction/request_queue_time_test.exs
@@ -36,7 +36,8 @@ defmodule NewRelic.Transaction.RequestQueueTimeTest do
     end
 
     test "an invalid format is an error" do
-      assert RequestQueueTime.timestamp_to_us("nope") == {:error, "invalid request queueing format, expected `t=\d+`"}
+      assert RequestQueueTime.timestamp_to_us("nope") ==
+               {:error, "invalid request queueing format, expected `t=\d+`"}
     end
 
     test "an early time is an error" do

--- a/test/new_relic/transaction/request_queue_time_test.exs
+++ b/test/new_relic/transaction/request_queue_time_test.exs
@@ -1,0 +1,46 @@
+defmodule NewRelic.Transaction.RequestQueueTimeTest do
+  alias NewRelic.Transaction.RequestQueueTime
+
+  use ExUnit.Case, async: true
+
+  describe "timestamp_to_us/1" do
+    test "handles t={microseconds} formatted strings" do
+      now_us = System.system_time(:microsecond)
+      assert RequestQueueTime.timestamp_to_us("t=#{now_us}") == {:ok, now_us}
+    end
+
+    test "handles t={microseconds}.0 formatted strings" do
+      now_us = System.system_time(:microsecond)
+      assert RequestQueueTime.timestamp_to_us("t=#{now_us}.0") == {:ok, now_us}
+    end
+
+    test "handles t={milliseconds} formatted strings" do
+      now_ms = System.system_time(:millisecond)
+      assert RequestQueueTime.timestamp_to_us("t=#{now_ms}") == {:ok, now_ms * 1_000}
+    end
+
+    test "handles t={seconds} formatted strings" do
+      now_s = System.system_time(:second)
+      assert RequestQueueTime.timestamp_to_us("t=#{now_s}") == {:ok, now_s * 1_000_000}
+    end
+
+    test "handles t={fractional seconds} formatted strings" do
+      now_us = System.system_time(:microsecond)
+      assert RequestQueueTime.timestamp_to_us("t=#{now_us / 1_000_000}") == {:ok, now_us}
+    end
+
+    test "handles t={s in the future} formatted strings" do
+      now_s = System.system_time(:second)
+      assert {:ok, time} = RequestQueueTime.timestamp_to_us("t=#{now_s + 10}")
+      assert_in_delta time, now_s * 1_000_000, 1_000_000
+    end
+
+    test "an invalid format is an error" do
+      assert RequestQueueTime.timestamp_to_us("nope") == {:error, "invalid request queueing format, expected `t=\d+`"}
+    end
+
+    test "an early time is an error" do
+      assert RequestQueueTime.timestamp_to_us("t=1") == {:error, "timestamp '1' is not valid"}
+    end
+  end
+end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -314,6 +314,7 @@ defmodule TransactionTest do
 
         assert event[:queue_start_us] == qd_us
         assert event[:queue_duration_us] > 0 and event[:queue_duration_us] < 20_000
+        assert event[:queue_duration_s] > 0 and event[:queue_duration_s] < 0.02
       end)
     end
 
@@ -329,6 +330,7 @@ defmodule TransactionTest do
       [[_, event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
 
       assert event[:queue_duration_us] == 0
+      assert event[:queue_duration_s] == 0
     end
   end
 end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -304,9 +304,10 @@ defmodule TransactionTest do
         TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
         qd_us = :os.system_time(:microsecond)
+
         conn =
           conn(:get, "/total_time")
-          |> Plug.Conn.put_req_header(header, "t=#{qd_us}" )
+          |> Plug.Conn.put_req_header(header, "t=#{qd_us}")
 
         TestHelper.request(TestPlugApp, conn)
 
@@ -322,9 +323,10 @@ defmodule TransactionTest do
       TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
       qd_us = :os.system_time(:microsecond) - 1_000_000
+
       conn =
         conn(:get, "/total_time")
-        |> Plug.Conn.put_req_header("x-request-start", "t=#{qd_us}" )
+        |> Plug.Conn.put_req_header("x-request-start", "t=#{qd_us}")
 
       TestHelper.request(TestPlugApp, conn)
 
@@ -338,7 +340,10 @@ defmodule TransactionTest do
 
       conn =
         conn(:get, "/total_time")
-        |> Plug.Conn.put_req_header("x-request-start", "t=#{:os.system_time(:microsecond) + 100_000}" )
+        |> Plug.Conn.put_req_header(
+          "x-request-start",
+          "t=#{:os.system_time(:microsecond) + 100_000}"
+        )
 
       TestHelper.request(TestPlugApp, conn)
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -300,7 +300,7 @@ defmodule TransactionTest do
 
   describe "Request queueing" do
     test "start time is included in the transaction (in us)" do
-      Enum.each(["x-request-start", "x-queue-start"], fn header ->
+      Enum.each(["x-request-start", "x-queue-start", "x-middleware-start"], fn header ->
         TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
         qd_us = :os.system_time(:microsecond)


### PR DESCRIPTION
Okay, this is for #141. It's the biggest PR I've done here, so it probably has a good bit that could be changed.

Goals:

* Track `queueDuration` as seconds (fractional to the microsecond) on web transactions
* The queue start time is interpreted from one of `"x-request-start", "x-queue-start", "x-middleware-start"`, as per the Ruby implementation
* The queue start time can be microseconds, milliseconds, or seconds (fractions supported)
* Clock skew, start time in the future, is interpreted as "now"
* WebFrontend/QueueTime metric is dispatched with completed requests

The Ruby implementation served as inspiration for deriving queue start, but I didn't handle some cases like having a compound header, or multiple headers with different values.

I haven't tried it in practice, yet.