### PR TITLE
Do not sample when newrelic is disabled

### DIFF
--- a/lib/new_relic/sampler/process.ex
+++ b/lib/new_relic/sampler/process.ex
@@ -18,7 +18,11 @@ defmodule NewRelic.Sampler.Process do
     {:ok, %{pids: %{}, previous: %{}}}
   end
 
-  def sample_process, do: GenServer.cast(__MODULE__, {:sample_process, self()})
+  def sample_process do
+    if NewRelic.Config.enabled?(),
+      do: GenServer.cast(__MODULE__, {:sample_process, self()}),
+      else: :ok
+  end
 
   def handle_cast({:sample_process, pid}, state) do
     state = store_pid(state.pids[pid], state, pid)

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -48,8 +48,9 @@ defmodule SamplerTest do
 
   test "Process Sampler" do
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-    TestProcess.start_link()
+    {:ok, process} = TestProcess.start_link()
 
+    TestHelper.dispatch_sample_process(NewRelic.Sampler.Process, process)
     TestHelper.trigger_report(NewRelic.Sampler.Process)
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
@@ -66,6 +67,7 @@ defmodule SamplerTest do
 
     spawn(fn ->
       NewRelic.sample_process()
+      TestHelper.dispatch_sample_process(NewRelic.Sampler.Process, self())
       TestHelper.trigger_report(NewRelic.Sampler.Process)
       send(parent, :continue)
     end)
@@ -81,7 +83,9 @@ defmodule SamplerTest do
   end
 
   test "Process Sampler - count work between samplings" do
-    TestProcess.start_link()
+    {:ok, process} = TestProcess.start_link()
+
+    TestHelper.dispatch_sample_process(NewRelic.Sampler.Process, process)
 
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
     TestHelper.trigger_report(NewRelic.Sampler.Process)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,6 +34,10 @@ defmodule TestHelper do
       _ -> false
     end)
   end
+
+  def dispatch_sample_process(module, pid) do
+    GenServer.cast(module, {:sample_process, pid})
+  end
 end
 
 ExUnit.start()


### PR DESCRIPTION
This PR allows sampling to be disabled when `NewRelic.Config.enabled?` returns `false`.

> Note: To ensure tests complete, a test helper has been added in the style of existing helpers.

**Alternate Solution**
The underlying issue described in #144 is an argument error when trying to calculate memory. 
Another approach considered to resolve was handling the `nil` case, however, it seemed odd that we would be sampling at all given nothing is reported.

Resolves #144 