### PR TITLE
Control processes started when disabled

### DIFF
--- a/lib/new_relic/always_on_supervisor.ex
+++ b/lib/new_relic/always_on_supervisor.ex
@@ -1,0 +1,19 @@
+defmodule NewRelic.AlwaysOnSupervisor do
+  use Supervisor
+
+  @moduledoc false
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    children = [
+      worker(NewRelic.Harvest.Collector.AgentRun, []),
+      supervisor(NewRelic.DistributedTrace.Supervisor, []),
+      supervisor(NewRelic.Transaction.Supervisor, [])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/new_relic/application.ex
+++ b/lib/new_relic/application.ex
@@ -10,12 +10,8 @@ defmodule NewRelic.Application do
 
     children = [
       worker(NewRelic.Logger, []),
-      supervisor(NewRelic.Harvest.Supervisor, []),
-      supervisor(NewRelic.Sampler.Supervisor, []),
-      supervisor(NewRelic.Error.Supervisor, []),
-      supervisor(NewRelic.Transaction.Supervisor, []),
-      supervisor(NewRelic.DistributedTrace.Supervisor, []),
-      supervisor(NewRelic.Aggregate.Supervisor, []),
+      supervisor(NewRelic.AlwaysOnSupervisor, []),
+      supervisor(NewRelic.EnabledSupervisor, [[enabled: NewRelic.Config.enabled?()]]),
       worker(NewRelic.GracefulShutdown, [], shutdown: 30_000)
     ]
 

--- a/lib/new_relic/enabled_supervisor.ex
+++ b/lib/new_relic/enabled_supervisor.ex
@@ -1,0 +1,27 @@
+defmodule NewRelic.EnabledSupervisor do
+  use Supervisor
+
+  # This Supervisor starts processes that we
+  # only start if the agent is enabled
+
+  @moduledoc false
+
+  def start_link(enabled: enabled) do
+    Supervisor.start_link(__MODULE__, enabled: enabled)
+  end
+
+  def init(enabled: false) do
+    :ignore
+  end
+
+  def init(enabled: true) do
+    children = [
+      supervisor(NewRelic.Harvest.Supervisor, []),
+      supervisor(NewRelic.Sampler.Supervisor, []),
+      supervisor(NewRelic.Error.Supervisor, []),
+      supervisor(NewRelic.Aggregate.Supervisor, [])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/new_relic/harvest/collector/supervisor.ex
+++ b/lib/new_relic/harvest/collector/supervisor.ex
@@ -11,7 +11,6 @@ defmodule NewRelic.Harvest.Collector.Supervisor do
 
   def init(_) do
     children = [
-      worker(Collector.AgentRun, []),
       data_supervisor(Collector.Metric, :data_report_period),
       data_supervisor(Collector.TransactionTrace, :data_report_period),
       data_supervisor(Collector.ErrorTrace, :data_report_period),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -36,6 +36,8 @@ defmodule TestHelper do
   end
 end
 
+{:ok, _} = NewRelic.EnabledSupervisor.start_link(enabled: true)
+
 ExUnit.start()
 
 System.at_exit(fn _ ->


### PR DESCRIPTION
This PR prevents some processes from starting if the agent is not `enabled?`

closes #144