### PR TITLE
Enable naming External metrics with HTTP request host

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ defmodule MyPlug do
 end
 ```
 
-#### Function Tracing
+#### Tracing
 
-* `NewRelic.Tracer` enables detailed Function Tracing. Annotate a function and it'll show up as a span in Transaction Traces / Distributed Traces, and we'll collect aggregate stats about it. Install it by adding `use NewRelic.Tracer` to any module, and annotating any function with `@trace` module attribute
+* `NewRelic.Tracer` enables detailed Function tracing. Annotate a function and it'll show up as a span in Transaction Traces / Distributed Traces, and we'll collect aggregate stats about it. Install it by adding `use NewRelic.Tracer` to any module, and annotating any function with `@trace` module attribute
+
 
 ```elixir
 defmodule MyModule do
@@ -83,6 +84,21 @@ defmodule MyModule do
   @trace :func
   def func do
     # Will report as `MyModule.func/0`
+  end
+end
+```
+
+* `NewRelic.Tracer` also enables detailed External request tracing. A little more instrumentation is required to pass the trace context forward with Distributed Tracing.
+
+```elixir
+defmodule MyExternalService do
+  use NewRelic.Tracer
+
+  @trace {:request, category: :external}
+  def request(method, url, headers) do
+    NewRelic.set_span(:http, url: url, method: method, component: "HttpClient")
+    headers ++ NewRelic.create_distributed_trace_payload(:http)
+    HttpClient.request(method, url, headers)
   end
 end
 ```

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -136,6 +136,38 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
+  def transform({:external, url, component, method}, duration_s: duration_s) do
+    host = URI.parse(url).host
+    method = method |> to_string() |> String.upcase()
+
+    [
+      %Metric{
+        name: :"External/all",
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: join(["External", host, "all"]),
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
+      %Metric{
+        name: join(["External", host, component, method]),
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      }
+    ]
+  end
+
   def transform({:external, name}, duration_s: duration_s),
     do: [
       %Metric{

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -112,13 +112,6 @@ defmodule NewRelic.Util do
     end
   end
 
-  def get_host(url) do
-    case URI.parse(url) do
-      %{host: nil} -> url
-      %{host: host} -> host
-    end
-  end
-
   @mb 1024 * 1024
   defp get_system_memory() do
     case :memsup.get_system_memory_data()[:system_total_memory] do

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -24,8 +24,8 @@ defmodule MetricTracerTest do
     end
 
     @trace {:query, category: :external}
-    def distributed_query do
-      NewRelic.set_span(:http, url: "domain.net", method: "GET", component: "MetricTraced")
+    def external_call do
+      NewRelic.set_span(:http, url: "http://domain.net", method: "GET", component: "MetricTraced")
     end
 
     @trace {:db_query, category: :datastore}
@@ -55,12 +55,14 @@ defmodule MetricTracerTest do
   end
 
   test "External metrics use span data" do
-    MetricTraced.distributed_query()
-    MetricTraced.distributed_query()
+    MetricTraced.external_call()
+    MetricTraced.external_call()
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert TestHelper.find_metric(metrics, "External/domain.net/MetricTraced/GET/all", 2)
+    assert TestHelper.find_metric(metrics, "External/all", 2)
+    assert TestHelper.find_metric(metrics, "External/domain.net/all", 2)
+    assert TestHelper.find_metric(metrics, "External/domain.net/MetricTraced/GET", 2)
   end
 
   test "Datastore metrics" do

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -25,7 +25,7 @@ defmodule MetricTracerTest do
 
     @trace {:query, category: :external}
     def external_call do
-      NewRelic.set_span(:http, url: "http://domain.net", method: "GET", component: "MetricTraced")
+      NewRelic.set_span(:http, url: "http://domain.net", method: "GET", component: "HttpClient")
     end
 
     @trace {:db_query, category: :datastore}
@@ -62,7 +62,7 @@ defmodule MetricTracerTest do
 
     assert TestHelper.find_metric(metrics, "External/all", 2)
     assert TestHelper.find_metric(metrics, "External/domain.net/all", 2)
-    assert TestHelper.find_metric(metrics, "External/domain.net/MetricTraced/GET", 2)
+    assert TestHelper.find_metric(metrics, "External/domain.net/HttpClient/GET", 2)
   end
 
   test "Datastore metrics" do


### PR DESCRIPTION
This PR enables naming External metrics after the host of the `HTTP` request being made instead of the `Module.function`.

For this to happen, you must instrument the outgoing HTTP request function with `@trace` like normal, as well as setting the needed span attributes:

```elixir
@trace {:request, category: :external}
def request(method, url, headers) do
  NewRelic.set_span(:http, url: url, method: method, component: "HttpClient")
  HttpClient.request(method, url, headers)
end
```

This PR pulls in #130 with some changes to match the set of metrics we need to report. Thanks @CaiqueMitsuoka

closes #129