### PR TITLE
Raise if not running OTP 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: elixir
 elixir:
-  - 1.7.3
-  - 1.8.1
+  - 1.8.2
+  - 1.9.2
 otp_release:
+  - 22.1
   - 21.3
-  - 20.3
 notifications:
   email:
     - vince@newrelic.com

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the [Hex package](https://hex.pm/packages/new_relic_agent)
 
 Requirements:
 * Erlang/OTP 21
-* Elixir > 1.7
+* Elixir 1.8
 
 ```elixir
 defp deps do

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ We'd love to get your contributions to improve the elixir agent! Keep in mind wh
 
 Install the [Hex package](https://hex.pm/packages/new_relic_agent)
 
+Requirements:
+* Erlang/OTP 21
+* Elixir > 1.7
+
 ```elixir
 defp deps do
   [

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -2,7 +2,17 @@ defmodule NewRelic.Init do
   @moduledoc false
 
   def run() do
+    verify_erlang_otp_version()
     init_collector_host()
+  end
+
+  @erlang_version_requirement ">= 21.0.0"
+  def verify_erlang_otp_version() do
+    if Version.match?(System.otp_release() <> ".0.0", @erlang_version_requirement) do
+      :ok
+    else
+      raise "Erlang/OTP 21 required"
+    end
   end
 
   def init_collector_host() do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule NewRelic.Mixfile do
       app: :new_relic_agent,
       description: "New Relic's Open-Source Elixir Agent",
       version: agent_version(),
-      elixir: "~> 1.7",
+      elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       name: "New Relic Elixir Agent",


### PR DESCRIPTION
This PR will cause the agent to fail fast if the application is pre-OTP 21. We already rely on some features in OTP 21 and the agent will fail with unhelpful errors.

I considered other options like not starting the application supervision tree but that may cause it's own set of problems if there are calls to `NewRelic` functions for instrumentation, etc. Open to thoughts on this...

closes #150 
closes #138 

sidekick/ @mattbaker 