### PR TITLE
Directly handle error reason

### DIFF
--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -38,9 +38,6 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
 
       {:error, _reason} ->
         {:noreply, %{status: :error_during_preconnect}}
-
-      {:failed_connect, _reason} ->
-        {:noreply, %{status: :failed_to_preconnect}}
     end
   end
 

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -79,7 +79,8 @@ defmodule NewRelic.Harvest.Collector.Protocol do
     {:error, reason}
   end
 
-  defp parse_collector_response({:error, code}), do: code
+  defp parse_collector_response({:error, code}) when is_integer(code), do: code
+  defp parse_collector_response({:error, reason}), do: {:error, reason}
   defp parse_collector_response({:ok, %{"return_value" => return_value}}), do: return_value
 
   defp parse_collector_response({:ok, %{"exception" => exception_value}}),

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -9,7 +9,7 @@ defmodule NewRelic.Util.HTTP do
     %{host: host} = URI.parse(url)
 
     with {:ok, {{_, status_code, _}, _headers, body}} <-
-           :httpc.request(:post, request, ssl_options(host), []) do
+           :httpc.request(:post, request, http_options(host), []) do
       {:ok, %{status_code: status_code, body: to_string(body)}}
     end
   end
@@ -21,8 +21,9 @@ defmodule NewRelic.Util.HTTP do
   Certs are pulled from Mozilla exactly as Hex does:
   https://github.com/hexpm/hex/blob/master/README.md#bundled-ca-certs
   """
-  def ssl_options(host) do
+  def http_options(host) do
     [
+      connect_timeout: 1000,
       ssl: [
         verify: :verify_peer,
         cacertfile: Application.app_dir(:new_relic_agent, "priv/cacert.pem"),

--- a/test/integration/collector_test.exs
+++ b/test/integration/collector_test.exs
@@ -22,6 +22,15 @@ defmodule CollectorIntegrationTest do
     assert redirect_host =~ "collector-"
   end
 
+  test "handles when unable to connect" do
+    Application.put_env(:new_relic_agent, :collector_instance_host, "badhost.com")
+
+    assert {:error, reason} = Collector.Protocol.preconnect()
+    assert {:failed_connect, _} = reason
+
+    Application.delete_env(:new_relic_agent, :collector_instance_host)
+  end
+
   test "handles invalid license key" do
     prev = Application.get_env(:new_relic_agent, :harvest_enabled)
     System.put_env("NEW_RELIC_LICENSE_KEY", "invalid_key")


### PR DESCRIPTION
This PR:
* Directly passes the error reason so that `AgentRun` doesn't know about the error type. This should be a no-op change
* Adds a `connect_timeout` to HTTP requests since the default is `:infinity`

sidekick/ @mattbaker 