### PR TITLE
Truncate large custom attribute counts

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -44,7 +44,7 @@ defmodule NewRelic do
   ```
 
   **Notes:**
-  * Lists and Maps are truncated at 10 items since there are a limited number
+  * Nested Lists and Maps are truncated at 10 items since there are a limited number
   of attributes that can be reported on Transaction events
   """
   defdelegate add_attributes(custom_attributes), to: NewRelic.Transaction.Reporter

--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -22,11 +22,30 @@ defmodule NewRelic do
   defdelegate set_transaction_name(name), to: NewRelic.Transaction.Reporter
 
   @doc """
-  Report a custom attribute on the current transaction
+  Report custom attributes on the current Transaction
+
+  Reporting nested data structures is supported by auto-flattening them
+  into a list of key-value pairs.
 
   ```elixir
   NewRelic.add_attributes(foo: "bar")
+    # "foo" => "bar"
+
+  NewRelic.add_attributes(map: %{foo: "bar", baz: "qux"})
+    # "map.foo" => "bar"
+    # "map.baz" => "qux"
+    # "map.size" => 2
+
+  NewRelic.add_attributes(list: ["a", "b", "c"])
+    # "list.0" => "a"
+    # "list.1" => "b"
+    # "list.2" => "c"
+    # "list.length" => 3
   ```
+
+  **Notes:**
+  * Lists and Maps are truncated at 10 items since there are a limited number
+  of attributes that can be reported on Transaction events
   """
   defdelegate add_attributes(custom_attributes), to: NewRelic.Transaction.Reporter
 

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -33,13 +33,19 @@ defmodule NewRelic.Util do
     Enum.flat_map(attrs, &deep_flatten/1)
   end
 
-  def deep_flatten({key, value}) when is_list(value) do
-    Enum.with_index(value)
+  def deep_flatten({key, list_value}) when is_list(list_value) do
+    list_value
+    |> Enum.slice(0..9)
+    |> Enum.with_index()
     |> Enum.flat_map(fn {v, index} -> deep_flatten({"#{key}.#{index}", v}) end)
+    |> Enum.concat([{"#{key}.length", length(list_value)}])
   end
 
-  def deep_flatten({key, value}) when is_map(value) do
-    Enum.flat_map(value, fn {k, v} -> deep_flatten({"#{key}.#{k}", v}) end)
+  def deep_flatten({key, map_value}) when is_map(map_value) do
+    map_value
+    |> Enum.slice(0..9)
+    |> Enum.flat_map(fn {k, v} -> deep_flatten({"#{key}.#{k}", v}) end)
+    |> Enum.concat([{"#{key}.size", map_size(map_value)}])
   end
 
   def deep_flatten({key, value}) do

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -29,7 +29,9 @@ defmodule UtilTest do
       NewRelic.Util.deep_flatten(
         not_nested: "value",
         nested: %{foo: %{bar: %{baz: "qux"}}},
-        nested_list: [%{one: %{two: "three"}}, %{four: "five"}, %{}, "string", ["nested string"]]
+        nested_list: [%{one: %{two: "three"}}, %{four: "five"}, %{}, "string", ["nested string"]],
+        super_long_list: Enum.map(0..99, & &1),
+        big_map: String.graphemes("abcdefghijklmnopqrstuvwxyz") |> Enum.into(%{}, &{&1, &1})
       )
 
     assert {"nested.foo.bar.baz", "qux"} in flattened
@@ -38,6 +40,15 @@ defmodule UtilTest do
     assert {"nested_list.1.four", "five"} in flattened
     assert {"nested_list.3", "string"} in flattened
     assert {"nested_list.4.0", "nested string"} in flattened
+    assert {"super_long_list.0", 0} in flattened
+    assert {"super_long_list.1", 1} in flattened
+    assert {"super_long_list.9", 9} in flattened
+    refute {"super_long_list.10", 10} in flattened
+    assert {"super_long_list.length", 100} in flattened
+    assert {"big_map.a", "a"} in flattened
+    assert {"big_map.j", "j"} in flattened
+    refute {"big_map.k", "k"} in flattened
+    assert {"big_map.size", 26} in flattened
   end
 
   test "Truncates unicode strings correctly" do


### PR DESCRIPTION
When adding custom attributes to an event, there are limits that get applied in the data processing pipeline.

This PR pre-emptively truncates large nested data structures so that we don't blow out the attribute count & that we can track a bit of meta-info (map size, list length).

Open to tweaking the truncation number (it's 10 now)

sidekick/ @mattbaker 