### PR TITLE
Update README.md: "start new_relic application"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ defp deps do
 end
 ```
 
+Ensure new_relic is started before your application:
+
+```elixir
+def application do
+  [
+    ...,
+    applications: [
+      :new_relic_agent,
+      ...
+      :myapp,
+      ...
+   ]
+  ]
+end
+```
+
 ## Configuration
 
 You need to set a few required configuration keys so we can authenticate properly.


### PR DESCRIPTION
While installing, I didn't immediately realise it was necessary to start the new_relic application, and my instrumentation was failing.

I believe this is the right thing to do. It certainly got my installation working! If there is a different way to do it, then I suggest that should be documented instead. Thanks!

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
