### PR TITLE
Move HarvesterStore to always on

### DIFF
--- a/lib/new_relic/always_on_supervisor.ex
+++ b/lib/new_relic/always_on_supervisor.ex
@@ -10,6 +10,7 @@ defmodule NewRelic.AlwaysOnSupervisor do
   def init(_) do
     children = [
       worker(NewRelic.Harvest.Collector.AgentRun, []),
+      worker(NewRelic.Harvest.Collector.HarvesterStore, []),
       supervisor(NewRelic.DistributedTrace.Supervisor, []),
       supervisor(NewRelic.Transaction.Supervisor, [])
     ]

--- a/lib/new_relic/harvest/supervisor.ex
+++ b/lib/new_relic/harvest/supervisor.ex
@@ -20,7 +20,6 @@ defmodule NewRelic.Harvest.Supervisor do
 
   def init(_) do
     children = [
-      worker(Collector.HarvesterStore, []),
       supervisor(Task.Supervisor, [[name: Collector.TaskSupervisor]]),
       supervisor(Collector.Supervisor, [])
     ]


### PR DESCRIPTION
Put this GenServer in the `AlwaysOn` supervision tree to ensure the ETS table is available always. This cleans up some edge cases when shutting down if the agent was never turned on (ie: tests)