### PR TITLE
Safely access optional ecto config

### DIFF
--- a/lib/new_relic/telemetry/ecto/handler.ex
+++ b/lib/new_relic/telemetry/ecto/handler.ex
@@ -15,7 +15,9 @@ defmodule NewRelic.Telemetry.Ecto.Handler do
     queue_time_ms = measurements[:queue_time] |> to_ms
     decode_time_ms = measurements[:decode_time] |> to_ms
 
-    %{hostname: hostname, port: port, database: database} = config.repo_configs[repo]
+    database = config.repo_configs[repo][:database] || "unknown"
+    hostname = config.repo_configs[repo][:hostname] || "unknown"
+    port = config.repo_configs[repo][:port] || "unknown"
 
     query = (config.collect_sql? && metadata.query) || ""
 


### PR DESCRIPTION
Some config options are optional, so defaulting according to new relic metric naming conventions

closes #171 