### PR TITLE
Handle Postgrex error results

### DIFF
--- a/examples/apps/ecto_example/lib/ecto_example/migration.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/migration.ex
@@ -5,5 +5,8 @@ defmodule EctoExample.Migration do
     create table("counts") do
       timestamps()
     end
+
+    # used to trigger an Error in router
+    create(index(:counts, :inserted_at, unique: true))
   end
 end

--- a/examples/apps/ecto_example/lib/ecto_example/router.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/router.ex
@@ -7,6 +7,9 @@ defmodule EctoExample.Router do
   plug(:dispatch)
 
   get "/hello" do
+    error_query(EctoExample.PostgresRepo)
+    error_query(EctoExample.MySQLRepo)
+
     response =
       %{
         hello: "world",
@@ -14,9 +17,6 @@ defmodule EctoExample.Router do
         mysql_count: query_db(EctoExample.MySQLRepo)
       }
       |> Jason.encode!()
-
-    error_query(EctoExample.PostgresRepo)
-    error_query(EctoExample.MySQLRepo)
 
     Process.sleep(100)
     send_resp(conn, 200, response)

--- a/examples/apps/ecto_example/test/ecto_example_test.exs
+++ b/examples/apps/ecto_example/test/ecto_example_test.exs
@@ -21,15 +21,13 @@ defmodule EctoExampleTest do
 
     assert TestHelper.find_metric(
              metrics,
-             "Datastore/statement/Postgres/counts/insert",
-             1
-           )
+             "Datastore/statement/Postgres/counts/insert"
+           ) >= 1
 
     assert TestHelper.find_metric(
              metrics,
-             "Datastore/statement/MySQL/counts/insert",
-             1
-           )
+             "Datastore/statement/MySQL/counts/insert"
+           ) >= 1
   end
 
   def request() do

--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -48,6 +48,8 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
     {"MySQL", table, operation}
   end
 
+  def parse(%{result: {:error, _}}), do: :ignore
+
   def parse(_) do
     raise "Unsupported ecto adapter"
   end


### PR DESCRIPTION
When there is an error (e.g., a failed constraint) Ecto returns a result with an error tuple, instead of ok. This would raise as an unsupported Ecto adapter. Instead, we should ignore those results (at least until we can do something with them).
