### PR TITLE
Scoped external metrics

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -168,8 +168,33 @@ defmodule NewRelic.Harvest.Collector.MetricData do
     ]
   end
 
+  def transform({:external, url, component, method}, scope: scope, duration_s: duration_s) do
+    host = URI.parse(url).host
+    method = method |> to_string() |> String.upcase()
+
+    [
+      %Metric{
+        name: join(["External", host, component, method]),
+        scope: join(["WebTransaction", scope]),
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      }
+    ]
+  end
+
   def transform({:external, name}, duration_s: duration_s),
     do: [
+      %Metric{
+        name: :"External/all",
+        call_count: 1,
+        total_call_time: duration_s,
+        total_exclusive_time: duration_s,
+        min_call_time: duration_s,
+        max_call_time: duration_s
+      },
       %Metric{
         name: join(["External", name, "all"]),
         call_count: 1,
@@ -179,6 +204,17 @@ defmodule NewRelic.Harvest.Collector.MetricData do
         max_call_time: duration_s
       }
     ]
+
+  def transform({:external, name}, scope: scope, duration_s: duration_s),
+    do: %Metric{
+      name: join(["External", name]),
+      scope: join(["WebTransaction", scope]),
+      call_count: 1,
+      total_call_time: duration_s,
+      total_exclusive_time: duration_s,
+      min_call_time: duration_s,
+      max_call_time: duration_s
+    }
 
   def transform(:external_web, duration_s: duration_s),
     do: [

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -71,8 +71,18 @@ defmodule NewRelic.Tracer.Report do
       %{url: url, component: component, method: method} ->
         NewRelic.report_metric({:external, url, component, method}, duration_s: duration_s)
 
+        Transaction.Reporter.track_metric({
+          {:external, url, component, method},
+          duration_s: duration_s
+        })
+
       _ ->
         NewRelic.report_metric({:external, function_name}, duration_s: duration_s)
+
+        Transaction.Reporter.track_metric({
+          {:external, function_name},
+          duration_s: duration_s
+        })
     end
   end
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -546,6 +546,28 @@ defmodule NewRelic.Transaction.Complete do
     NewRelic.report_metric(:external_web, duration_s: duration_s)
   end
 
+  def report_transaction_metrics(
+        %{name: tx_name},
+        {{:external, url, component, method}, duration_s: duration_s}
+      ) do
+    NewRelic.report_metric(
+      {:external, url, component, method},
+      scope: tx_name,
+      duration_s: duration_s
+    )
+  end
+
+  def report_transaction_metrics(
+        %{name: tx_name},
+        {{:external, function_name}, duration_s: duration_s}
+      ) do
+    NewRelic.report_metric(
+      {:external, function_name},
+      scope: tx_name,
+      duration_s: duration_s
+    )
+  end
+
   def report_apdex_metric(:ignore), do: :ignore
 
   def report_apdex_metric(apdex) do

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -14,12 +14,14 @@ defmodule NewRelic.Transaction.Complete do
       tx_attrs
       |> transform_name_attrs
       |> transform_time_attrs
+      |> identify_transaction_type
       |> transform_queue_duration
       |> extract_transaction_info(pid)
 
     report_transaction_event(tx_attrs)
     report_transaction_trace(tx_attrs, tx_segments)
     report_transaction_error_event(tx_attrs, tx_error)
+    report_http_dispatcher_metric(tx_attrs)
     report_transaction_metric(tx_attrs)
     report_queue_time_metric(tx_attrs)
     report_transaction_metrics(tx_attrs, tx_metrics)
@@ -39,6 +41,12 @@ defmodule NewRelic.Transaction.Complete do
   defp transform_name_attrs(%{plug_name: name} = tx), do: Map.put(tx, :name, name)
   defp transform_name_attrs(%{other_transaction_name: name} = tx), do: Map.put(tx, :name, name)
   defp transform_name_attrs(tx), do: Map.put(tx, :name, "Unknown")
+
+  defp identify_transaction_type(%{other_transaction_name: _} = tx),
+    do: Map.put(tx, :transactionType, :Other)
+
+  defp identify_transaction_type(tx),
+    do: Map.put(tx, :transactionType, :Web)
 
   defp transform_time_attrs(
          %{start_time: start_time, end_time_mono: end_time_mono, start_time_mono: start_time_mono} =
@@ -144,7 +152,7 @@ defmodule NewRelic.Transaction.Complete do
     []
   end
 
-  defp calculate_apdex(%{other_transaction_name: _}, _error) do
+  defp calculate_apdex(%{transactionType: :Other}, _error) do
     :ignore
   end
 
@@ -323,7 +331,7 @@ defmodule NewRelic.Transaction.Complete do
     Enum.each(span_events, &Collector.SpanEvent.Harvester.report_span_event/1)
   end
 
-  defp report_transaction_event(%{other_transaction_name: _} = tx_attrs) do
+  defp report_transaction_event(%{transactionType: :Other} = tx_attrs) do
     Collector.TransactionEvent.Harvester.report_event(%Transaction.Event{
       timestamp: tx_attrs.start_time,
       duration: tx_attrs.duration_s,
@@ -346,7 +354,7 @@ defmodule NewRelic.Transaction.Complete do
     })
   end
 
-  defp report_transaction_trace(%{other_transaction_name: _} = tx_attrs, tx_segments) do
+  defp report_transaction_trace(%{transactionType: :Other} = tx_attrs, tx_segments) do
     Collector.TransactionTrace.Harvester.report_trace(%Transaction.Trace{
       start_time: tx_attrs.start_time,
       metric_name: Util.metric_join(["OtherTransaction", tx_attrs.name]),
@@ -404,7 +412,7 @@ defmodule NewRelic.Transaction.Complete do
   end
 
   defp report_error_trace(
-         %{other_transaction_name: _} = tx_attrs,
+         %{transactionType: :Other} = tx_attrs,
          exception_type,
          exception_reason,
          expected,
@@ -448,7 +456,7 @@ defmodule NewRelic.Transaction.Complete do
   end
 
   defp report_error_event(
-         %{other_transaction_name: _} = tx_attrs,
+         %{transactionType: :Other} = tx_attrs,
          exception_type,
          exception_reason,
          expected,
@@ -498,7 +506,7 @@ defmodule NewRelic.Transaction.Complete do
     })
   end
 
-  defp report_aggregate(%{other_transaction_name: _} = tx) do
+  defp report_aggregate(%{transactionType: :Other} = tx) do
     NewRelic.report_aggregate(%{type: :OtherTransaction, name: tx[:name]}, %{
       duration_us: tx.duration_us,
       duration_ms: tx.duration_ms,
@@ -514,15 +522,9 @@ defmodule NewRelic.Transaction.Complete do
     })
   end
 
-  def report_transaction_metric(%{other_transaction_name: _} = tx) do
-    NewRelic.report_metric({:other_transaction, tx.name},
-      duration_s: tx.duration_s,
-      total_time_s: tx.total_time_s
-    )
-  end
-
   def report_transaction_metric(tx) do
     NewRelic.report_metric({:transaction, tx.name},
+      type: tx.transactionType,
       duration_s: tx.duration_s,
       total_time_s: tx.total_time_s
     )
@@ -532,37 +534,41 @@ defmodule NewRelic.Transaction.Complete do
     NewRelic.report_metric(:queue_time, duration_s: duration_s)
   end
 
-  def report_queue_time_metric(_), do: nil
+  def report_queue_time_metric(_), do: :ignore
+
+  def report_http_dispatcher_metric(%{transactionType: :Web} = tx) do
+    NewRelic.report_metric(:http_dispatcher, duration_s: tx.duration_s)
+  end
+
+  def report_http_dispatcher_metric(_), do: :ignore
 
   def report_transaction_metrics(tx, tx_metrics) when is_list(tx_metrics) do
     Enum.each(tx_metrics, &report_transaction_metrics(tx, &1))
   end
 
-  def report_transaction_metrics(%{other_transaction_name: _}, {:external, duration_s}) do
-    NewRelic.report_metric(:external_other, duration_s: duration_s)
-  end
-
-  def report_transaction_metrics(_tx, {:external, duration_s}) do
-    NewRelic.report_metric(:external_web, duration_s: duration_s)
+  def report_transaction_metrics(%{transactionType: type}, {:external, duration_s}) do
+    NewRelic.report_metric(:external, type: type, duration_s: duration_s)
   end
 
   def report_transaction_metrics(
-        %{name: tx_name},
+        %{name: tx_name, transactionType: type},
         {{:external, url, component, method}, duration_s: duration_s}
       ) do
     NewRelic.report_metric(
       {:external, url, component, method},
+      type: type,
       scope: tx_name,
       duration_s: duration_s
     )
   end
 
   def report_transaction_metrics(
-        %{name: tx_name},
+        %{name: tx_name, transactionType: type},
         {{:external, function_name}, duration_s: duration_s}
       ) do
     NewRelic.report_metric(
       {:external, function_name},
+      type: type,
       scope: tx_name,
       duration_s: duration_s
     )

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -89,14 +89,15 @@ defmodule MetricTransactionTest do
     end)
   end
 
-  test "Basic transaction" do
+  test "Basic web transaction" do
     TestPlugApp.call(conn(:get, "/foo/1"), [])
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
     assert TestHelper.find_metric(metrics, "WebTransaction/Plug/GET//foo/:blah")
     refute TestHelper.find_metric(metrics, "WebFrontend/QueueTime")
-    assert TestHelper.find_metric(metrics, "Apdex", 1)
+    assert TestHelper.find_metric(metrics, "Apdex")
+    assert TestHelper.find_metric(metrics, "HttpDispatcher")
   end
 
   test "External metrics" do

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -65,6 +65,12 @@ defmodule OtherTransactionTest do
     assert TestHelper.find_metric(metrics, "External/OtherTransactionTest.External.call/all")
     assert TestHelper.find_metric(metrics, "External/allOther")
 
+    assert TestHelper.find_metric(
+             metrics,
+             {"External/OtherTransactionTest.External.call",
+              "OtherTransaction/TransactionCategory/MyTaskName"}
+           )
+
     span_events = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
     assert length(span_events) == 3
 

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -29,7 +29,16 @@ defmodule TestHelper do
     GenServer.call(harvest_cycle, :pause)
   end
 
-  def find_metric(metrics, name, call_count \\ 1) do
+  def find_metric(metrics, name, call_count \\ 1)
+
+  def find_metric(metrics, {name, scope}, call_count) do
+    Enum.find(metrics, fn
+      [%{name: ^name, scope: ^scope}, [^call_count, _, _, _, _, _]] -> true
+      _ -> false
+    end)
+  end
+
+  def find_metric(metrics, name, call_count) do
     Enum.find(metrics, fn
       [%{name: ^name}, [^call_count, _, _, _, _, _]] -> true
       _ -> false


### PR DESCRIPTION
This PR adds reporting of "scoped" external metrics. This provides external metrics broken down by transaction name.

@tpitale 