### PR TITLE
Boot blocking prevention

### DIFF
--- a/lib/new_relic/application.ex
+++ b/lib/new_relic/application.ex
@@ -11,7 +11,7 @@ defmodule NewRelic.Application do
     children = [
       worker(NewRelic.Logger, []),
       supervisor(NewRelic.AlwaysOnSupervisor, []),
-      supervisor(NewRelic.EnabledSupervisor, []),
+      worker(NewRelic.EnabledSupervisorManager, []),
       supervisor(NewRelic.TelemetrySupervisor, []),
       worker(NewRelic.GracefulShutdown, [], shutdown: 30_000)
     ]

--- a/lib/new_relic/enabled_supervisor.ex
+++ b/lib/new_relic/enabled_supervisor.ex
@@ -7,7 +7,6 @@ defmodule NewRelic.EnabledSupervisor do
   @moduledoc false
 
   def start_link() do
-    NewRelic.Harvest.Collector.AgentRun.ensure_init()
     start_link(enabled: NewRelic.Config.enabled?())
   end
 

--- a/lib/new_relic/enabled_supervisor_manager.ex
+++ b/lib/new_relic/enabled_supervisor_manager.ex
@@ -1,0 +1,24 @@
+defmodule NewRelic.EnabledSupervisorManager do
+  use GenServer
+
+  # This "Manager" makes sure that we start the EnabledSupervisor
+  # only after we have confirmed that we are connected
+
+  @moduledoc false
+
+  alias NewRelic.Harvest.Collector.AgentRun
+
+  def start_link(name \\ __MODULE__) do
+    GenServer.start_link(__MODULE__, :ok, name: name)
+  end
+
+  def init(:ok) do
+    GenServer.cast(AgentRun, {:connected?, self()})
+    {:ok, %{}}
+  end
+
+  def handle_info(:connected, state) do
+    NewRelic.EnabledSupervisor.start_link()
+    {:noreply, state}
+  end
+end

--- a/lib/new_relic/enabled_supervisor_manager.ex
+++ b/lib/new_relic/enabled_supervisor_manager.ex
@@ -13,11 +13,11 @@ defmodule NewRelic.EnabledSupervisorManager do
   end
 
   def init(:ok) do
-    GenServer.cast(AgentRun, {:connected?, self()})
+    GenServer.cast(AgentRun, {:connect_cycle_complete?, self()})
     {:ok, %{}}
   end
 
-  def handle_info(:connected, state) do
+  def handle_info(:connect_cycle_complete, state) do
     NewRelic.EnabledSupervisor.start_link()
     {:noreply, state}
   end

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -30,8 +30,6 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
 
   def reconnect, do: send(__MODULE__, :reconnect)
 
-  def ensure_init, do: GenServer.call(__MODULE__, :ping)
-
   def handle_continue(:preconnect, _state) do
     case Collector.Protocol.preconnect() do
       {:ok, %{"redirect_host" => redirect_host}} ->
@@ -53,8 +51,13 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     {:noreply, %{status: status}}
   end
 
-  def handle_call(:ping, _from, state) do
+  def handle_call(:connected?, _from, state) do
     {:reply, true, state}
+  end
+
+  def handle_cast({:connected?, from}, state) do
+    send(from, :connected)
+    {:noreply, state}
   end
 
   defp connect() do

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -51,12 +51,8 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     {:noreply, %{status: status}}
   end
 
-  def handle_call(:connected?, _from, state) do
-    {:reply, true, state}
-  end
-
-  def handle_cast({:connected?, from}, state) do
-    send(from, :connected)
+  def handle_cast({:connect_cycle_complete?, from}, state) do
+    send(from, :connect_cycle_complete)
     {:noreply, state}
   end
 

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -4,6 +4,13 @@ defmodule AggregateTest do
   alias NewRelic.Aggregate
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   test "Aggregate metrics" do
     metric = %Aggregate{
       meta: %{key: "value", foo: "bar"},

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -4,6 +4,13 @@ defmodule CustomEventTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.Custom.Event
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   test "post a custom event" do
     agent_run_id = Collector.AgentRun.agent_run_id()
 

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -5,6 +5,13 @@ defmodule DistributedTraceTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.DistributedTrace
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   @dt_header "newrelic"
 
   defmodule TestPlugApp do

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -1,7 +1,15 @@
 defmodule ErrorTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
+
   alias NewRelic.Harvest.Collector
+
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
 
   defmodule ErrorDummy do
     use GenServer

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -4,6 +4,13 @@ defmodule ErrorTraceTest do
   alias NewRelic.Error.Trace
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   test "post an error trace" do
     agent_run_id = Collector.AgentRun.agent_run_id()
 

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -9,7 +9,7 @@ defmodule IntegrationTest do
   setup do
     System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")
     Collector.AgentRun.reconnect()
-    GenServer.call(Collector.AgentRun, :ping)
+    GenServer.call(Collector.AgentRun, :connected?)
 
     on_exit(fn ->
       System.delete_env("NEW_RELIC_HARVEST_ENABLED")
@@ -40,7 +40,7 @@ defmodule IntegrationTest do
     original_agent_run_id = Collector.AgentRun.agent_run_id()
 
     Collector.AgentRun.reconnect()
-    GenServer.call(Collector.AgentRun, :ping)
+    GenServer.call(Collector.AgentRun, :connected?)
 
     new_agent_run_id = Collector.AgentRun.agent_run_id()
 

--- a/test/metric_error_test.exs
+++ b/test/metric_error_test.exs
@@ -2,6 +2,13 @@ defmodule MetricErrorTest do
   use ExUnit.Case
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule CustomError do
     defexception [:message, :expected]
   end

--- a/test/metric_harvester_test.exs
+++ b/test/metric_harvester_test.exs
@@ -2,6 +2,13 @@ defmodule MetricHarvesterTest do
   use ExUnit.Case
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   test "Harvester - collect and aggregate some metrics" do
     {:ok, harvester} =
       DynamicSupervisor.start_child(

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -3,6 +3,13 @@ defmodule MetricTracerTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   setup do
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
     on_exit(fn -> TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle) end)

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -4,6 +4,13 @@ defmodule MetricTransactionTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule TestPlugAppForward do
     import Plug.Conn
 

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -2,6 +2,13 @@ defmodule OtherTransactionTest do
   use ExUnit.Case
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   setup do
     System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")
     System.put_env("NEW_RELIC_LICENSE_KEY", "foo")

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -3,6 +3,13 @@ defmodule SamplerTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule TestProcess do
     use GenServer
 

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -7,6 +7,13 @@ defmodule SpanEventTest do
 
   @dt_header "newrelic"
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   setup do
     prev_key = Collector.AgentRun.trusted_account_key()
     Collector.AgentRun.store(:trusted_account_key, "190")

--- a/test/telemetry/ecto_test.exs
+++ b/test/telemetry/ecto_test.exs
@@ -3,6 +3,13 @@ defmodule NewRelic.Telemetry.EctoTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule TestRepo do
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,3 @@
-unless System.get_env("NR_INT_TEST") do
-  {:ok, _} = NewRelic.EnabledSupervisor.start_link(enabled: true)
-end
-
 ExUnit.start()
 
 System.at_exit(fn _ ->

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -3,6 +3,13 @@ defmodule TracerTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule Traced do
     use NewRelic.Tracer
 

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -5,6 +5,13 @@ defmodule TransactionErrorEventTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.Error.Event
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule TestPlugApp do
     use Plug.Router
     use NewRelic.Transaction

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -5,6 +5,13 @@ defmodule TransactionEventTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.Transaction.Event
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule TestPlugApp do
     use Plug.Router
     use NewRelic.Transaction

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -4,6 +4,13 @@ defmodule TransactionTest do
 
   alias NewRelic.Harvest.Collector
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   defmodule HelperModule do
     use NewRelic.Tracer
     @trace :function

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -5,6 +5,13 @@ defmodule TransactionTraceTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.Transaction.Trace
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   setup do
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.TransactionTrace.HarvestCycle)

--- a/test/wc3_trace_context_test.exs
+++ b/test/wc3_trace_context_test.exs
@@ -9,6 +9,13 @@ defmodule W3CTraceContextTest do
   alias NewRelic.Harvest.Collector
   alias NewRelic.DistributedTrace
 
+  setup_all do
+    unless System.get_env("NR_INT_TEST") do
+      start_supervised({NewRelic.EnabledSupervisor, enabled: true})
+      :ok
+    end
+  end
+
   @w3c_traceparent "traceparent"
   @w3c_tracestate "tracestate"
 


### PR DESCRIPTION
This PR addresses #181 by making sure that we start the `EnabledSupervisor` only when we get confirmation that the agent is fully connected to New Relic

sidekick/ @mattbaker @tpitale 