### PR TITLE
elixir 1.10.2 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: elixir
 elixir:
   - 1.8.2
   - 1.9.4
+  - 1.10.2
 otp_release:
   - 22.2
   - 21.3

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -17,6 +17,7 @@ defmodule NewRelic.Tracer.Macro do
 
   # Take no action on the definition of a function head
   def __on_definition__(_env, _access, _name, _args, _guards, nil), do: nil
+  def __on_definition__(_env, _access, _name, _args, _guards, []), do: nil
 
   # Take no action if there is a top-level rescue clause
   def __on_definition__(env, _access, name, _args, _guards, do: _, rescue: _) do


### PR DESCRIPTION
When upgrading one of my apps to Elixir 1.10 I ran into a function clause error

```
        # 2
        :defp
    
        # 3
        :name_of_function
    
        # 4
        [{:http_result, [line: 347], nil}, {:\\, [line: 347], [{:ok_code_or_codes, [line: 347], nil}, 200]}]
    
        # 5
        []
    
        # 6
        []
    
    Attempted function clauses (showing 3 out of 3):
    
        def __on_definition__(_env, _access, _name, _args, _guards, nil)
        def __on_definition__(env, _access, name, _args, _guards, [do: _, rescue: _])
        def __on_definition__(%{module: module}, access, name, args, guards, [do: body])
```

The test suite already had a failure when running under 1.10, so I just added the missing function head. I also added the Elixir version under the travis config.

Let me know if there's anything else I should do before getting this merged. Thanks!