### PR TITLE
Enable ignoring arguments in traces

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -97,6 +97,8 @@ defmodule NewRelic.Config do
     * Controls collection of SQL query strings
   * `:ecto_instrumentation_enabled` (default `true`)
     * Controls all Ecto instrumentation
+  * `function_argument_collection_enabled` (default `true`)
+    * Controls collection of traced function arguments
   """
   def feature?(:error_collector) do
     feature_check?("NEW_RELIC_ERROR_COLLECTOR_ENABLED", :error_collector_enabled)
@@ -108,6 +110,13 @@ defmodule NewRelic.Config do
 
   def feature?(:ecto_instrumentation) do
     feature_check?("NEW_RELIC_ECTO_INSTRUMENTTION_ENABLED", :ecto_instrumentation_enabled)
+  end
+
+  def feature?(:function_argument_collection) do
+    feature_check?(
+      "NEW_RELIC_FUNCTION_ARGUMENT_COLLECTION_ENABLED",
+      :function_argument_collection_enabled
+    )
   end
 
   defp feature_check?(env, config) do

--- a/lib/new_relic/tracer.ex
+++ b/lib/new_relic/tracer.ex
@@ -62,6 +62,25 @@ defmodule NewRelic.Tracer do
     send_resp(conn, 200, "ok")
   end
   ```
+
+  #### Arguments
+
+  By default, arguments are inspected and recorded along with traces. You can opt-out of function argument tracing on individual tracers:
+
+  ```elixir
+  defmodule SecretModule do
+    use NewRelic.Tracer
+
+    @trace {:login, args: false}
+    def login(username, password) do
+      # do something secret...
+    end
+  end
+  ```
+
+  This will prevent the argument values from becoming part of Transaction Traces.
+
+  This may also be configured globally via `Application` config. See `NewRelic.Config` for details.
   """
 
   defmacro __using__(_args) do

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -129,7 +129,11 @@ defmodule NewRelic.Tracer.Report do
   end
 
   defp inspect_args(arguments) do
-    inspect(arguments, charlists: :as_lists, limit: 20, printable_limit: 100)
+    if NewRelic.Config.feature?(:function_argument_collection) do
+      inspect(arguments, charlists: :as_lists, limit: 5, printable_limit: 10)
+    else
+      "[DISABLED]"
+    end
   end
 
   defp duration_ms(start_time_mono, end_time_mono),

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -27,12 +27,21 @@ defmodule TransactionTraceTest do
       Process.sleep(200)
       args
     end
+
+    @trace {:work_hard, args: false}
+    def work_hard(args) do
+      args
+    end
   end
 
   defmodule ExternalService do
     use NewRelic.Tracer
+
     @trace {:query, category: :external}
     def query(n), do: HelperModule.function(n)
+
+    @trace {:secret_query, category: :external, args: false}
+    def secret_query(n), do: HelperModule.function(n)
   end
 
   defmodule TestPlugApp do
@@ -59,7 +68,7 @@ defmodule TransactionTraceTest do
 
       t2 =
         Task.async(fn ->
-          ExternalService.query(304)
+          ExternalService.secret_query(304)
         end)
 
       Task.await(t1)
@@ -76,6 +85,8 @@ defmodule TransactionTraceTest do
     get "/huge_args" do
       Enum.into(1..10000, %{}, &{&1, &1})
       |> HelperModule.do_work()
+
+      HelperModule.work_hard(%{on: :something})
 
       send_resp(conn, 200, "ok")
     end
@@ -331,6 +342,58 @@ defmodule TransactionTraceTest do
     assert span[:args] == "[DISABLED]"
 
     Application.delete_env(:new_relic_agent, :function_argument_collection_enabled)
+    System.delete_env("NEW_RELIC_HARVEST_ENABLED")
+    System.delete_env("NEW_RELIC_LICENSE_KEY")
+  end
+
+  test "Don't trace arguments when opted-out on individual function" do
+    System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")
+    System.put_env("NEW_RELIC_LICENSE_KEY", "foo")
+
+    TestHelper.request(TestPlugApp, conn(:get, "/huge_args"))
+
+    [span, _, _] =
+      TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
+      |> Enum.find(fn [sp, _, _] ->
+        sp.name == "TransactionTraceTest.HelperModule.work_hard/1"
+      end)
+
+    assert span[:args] == "[DISABLED]"
+
+    [span, _, _] =
+      TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
+      |> Enum.find(fn [sp, _, _] ->
+        sp.name == "TransactionTraceTest.HelperModule.do_work/1"
+      end)
+
+    refute span[:args] == "[DISABLED]"
+
+    System.delete_env("NEW_RELIC_HARVEST_ENABLED")
+    System.delete_env("NEW_RELIC_LICENSE_KEY")
+  end
+
+  test "Don't trace arguments when opted-out on individual external" do
+    System.put_env("NEW_RELIC_HARVEST_ENABLED", "true")
+    System.put_env("NEW_RELIC_LICENSE_KEY", "foo")
+
+    TestHelper.request(TestPlugApp, conn(:get, "/transaction_trace"))
+
+    [span, _, _] =
+      TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
+      |> Enum.find(fn [sp, _, _] ->
+        sp.name == "TransactionTraceTest.ExternalService.secret_query/1"
+      end)
+
+    assert span[:args] == "[DISABLED]"
+
+    [span, _, _] =
+      TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
+      |> Enum.find(fn [sp, _, _] ->
+        sp.name == "TransactionTraceTest.ExternalService.query/1"
+      end)
+
+    refute span[:args] == "[DISABLED]"
+
     System.delete_env("NEW_RELIC_HARVEST_ENABLED")
     System.delete_env("NEW_RELIC_LICENSE_KEY")
   end


### PR DESCRIPTION
This PR adds a feature toggle around function argument tracing so that it can be disabled if sensitive information is in the arguments. Also if lots of tracing is happening, this reduces memory footprint

closes #157 