### PR TITLE
Boot block prevention take 2

### DIFF
--- a/lib/new_relic/application.ex
+++ b/lib/new_relic/application.ex
@@ -11,7 +11,7 @@ defmodule NewRelic.Application do
     children = [
       worker(NewRelic.Logger, []),
       supervisor(NewRelic.AlwaysOnSupervisor, []),
-      supervisor(NewRelic.EnabledSupervisor, []),
+      supervisor(NewRelic.EnabledSupervisorManager, []),
       supervisor(NewRelic.TelemetrySupervisor, []),
       worker(NewRelic.GracefulShutdown, [], shutdown: 30_000)
     ]

--- a/lib/new_relic/enabled_supervisor.ex
+++ b/lib/new_relic/enabled_supervisor.ex
@@ -6,20 +6,11 @@ defmodule NewRelic.EnabledSupervisor do
 
   @moduledoc false
 
-  def start_link() do
-    NewRelic.Harvest.Collector.AgentRun.ensure_init()
-    start_link(enabled: NewRelic.Config.enabled?())
+  def start_link(_) do
+    Supervisor.start_link(__MODULE__, :ok)
   end
 
-  def start_link(enabled: enabled) do
-    Supervisor.start_link(__MODULE__, enabled: enabled)
-  end
-
-  def init(enabled: false) do
-    :ignore
-  end
-
-  def init(enabled: true) do
+  def init(:ok) do
     children = [
       supervisor(NewRelic.Harvest.Supervisor, []),
       supervisor(NewRelic.Sampler.Supervisor, []),

--- a/lib/new_relic/enabled_supervisor_manager.ex
+++ b/lib/new_relic/enabled_supervisor_manager.ex
@@ -1,0 +1,17 @@
+defmodule NewRelic.EnabledSupervisorManager do
+  use DynamicSupervisor
+
+  @moduledoc false
+
+  def start_link() do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_child() do
+    DynamicSupervisor.start_child(__MODULE__, NewRelic.EnabledSupervisor)
+  end
+end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -68,4 +68,9 @@ defmodule IntegrationTest do
     {:ok, :accepted} =
       Collector.Protocol.metric_data([agent_run_id, ts_start, ts_end, data_array])
   end
+
+  test "EnabledSupervisor starts" do
+    # make sure a process under EnabledSupervisor started
+    assert Process.whereis(NewRelic.Sampler.Beam)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
 unless System.get_env("NR_INT_TEST") do
-  {:ok, _} = NewRelic.EnabledSupervisor.start_link(enabled: true)
+  {:ok, _} = NewRelic.EnabledSupervisor.start_link(:ok)
 end
 
 ExUnit.start()


### PR DESCRIPTION
Alternative to #184 that uses a `DynamicSupervisor` to let us complete the boot cycle after we know we've connected inside `AgentRun`

This removes the blocking call that we previously relied on to ensure boot order.

fixes https://github.com/newrelic/elixir_agent/pull/184

@mattbaker @tpitale 