### PR TITLE
Report scoped function trace metrics

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -17,8 +17,7 @@ defmodule NewRelic.Harvest.Collector.MetricData do
 
   def transform({:transaction, name},
         type: type,
-        duration_s: duration_s,
-        total_time_s: total_time_s
+        duration_s: duration_s
       ),
       do: [
         %Metric{
@@ -45,21 +44,15 @@ defmodule NewRelic.Harvest.Collector.MetricData do
           min_call_time: duration_s,
           max_call_time: duration_s
         },
+        # UI doesn't handle Elixir's level of concurrency so great
+        # sending just call count improves things
         %Metric{
           name: "#{type}TransactionTotalTime",
-          call_count: 1,
-          total_call_time: total_time_s,
-          total_exclusive_time: total_time_s,
-          min_call_time: total_time_s,
-          max_call_time: total_time_s
+          call_count: 1
         },
         %Metric{
           name: join(["#{type}TransactionTotalTime", name]),
-          call_count: 1,
-          total_call_time: total_time_s,
-          total_exclusive_time: total_time_s,
-          min_call_time: total_time_s,
-          max_call_time: total_time_s
+          call_count: 1
         }
       ]
 

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -209,6 +209,37 @@ defmodule NewRelic.Harvest.Collector.MetricData do
     }
   end
 
+  def transform({:function, function_name},
+        duration_s: duration_s,
+        exclusive_time_s: exclusive_time_s
+      ) do
+    %Metric{
+      name: join(["Function", function_name]),
+      call_count: 1,
+      total_call_time: duration_s,
+      total_exclusive_time: exclusive_time_s,
+      min_call_time: duration_s,
+      max_call_time: duration_s
+    }
+  end
+
+  def transform({:function, function_name},
+        type: type,
+        scope: scope,
+        duration_s: duration_s,
+        exclusive_time_s: exclusive_time_s
+      ) do
+    %Metric{
+      name: join(["Function", function_name]),
+      scope: join(["#{type}Transaction", scope]),
+      call_count: 1,
+      total_call_time: duration_s,
+      total_exclusive_time: exclusive_time_s,
+      min_call_time: duration_s,
+      max_call_time: duration_s
+    }
+  end
+
   def transform(:error, error_count: error_count),
     do: %Metric{
       name: :"Errors/all",

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -226,6 +226,10 @@ defmodule NewRelic.Transaction.Complete do
         parent_id: original,
         name: name,
         start_time: start_time,
+        attributes: %{
+          exclusive_duration_millis: 0,
+          async_wait: true
+        },
         end_time: end_time
       }
     end
@@ -571,6 +575,18 @@ defmodule NewRelic.Transaction.Complete do
       type: type,
       scope: tx_name,
       duration_s: duration_s
+    )
+  end
+
+  def report_transaction_metrics(
+        %{name: tx_name, transactionType: type},
+        {{:function, function_name}, duration_s: duration_s, exclusive_time_s: exclusive_time_s}
+      ) do
+    NewRelic.report_metric({:function, function_name},
+      type: type,
+      scope: tx_name,
+      duration_s: duration_s,
+      exclusive_time_s: exclusive_time_s
     )
   end
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -115,6 +115,7 @@ defmodule NewRelic.Transaction.Complete do
       |> Enum.map(&transform_trace_time_attrs(&1, tx_attrs.start_time))
       |> Enum.map(&transform_trace_name_attrs/1)
       |> Enum.map(&struct(Transaction.Trace.Segment, &1))
+      |> Enum.reject(&(&1.relative_start_time == &1.relative_end_time))
       |> Enum.sort_by(& &1.relative_start_time)
 
     segment_tree =
@@ -529,8 +530,7 @@ defmodule NewRelic.Transaction.Complete do
   def report_transaction_metric(tx) do
     NewRelic.report_metric({:transaction, tx.name},
       type: tx.transactionType,
-      duration_s: tx.duration_s,
-      total_time_s: tx.total_time_s
+      duration_s: tx.duration_s
     )
   end
 

--- a/test/metric_tracer_test.exs
+++ b/test/metric_tracer_test.exs
@@ -31,6 +31,39 @@ defmodule MetricTracerTest do
     @trace {:special, category: :external}
     def custom_name do
     end
+
+    @trace :nested
+    def nested do
+      # duration ~ 1100
+      # exclusive ~ 0
+      nested_1()
+    end
+
+    @trace :nested_1
+    def nested_1 do
+      # duration ~ 1100
+      # exclusive ~ 100
+      Process.sleep(50)
+      nested_2()
+      Process.sleep(50)
+      nested_2()
+    end
+
+    @trace :nested_2
+    def nested_2 do
+      # duration ~ 500
+      # exclusive ~ 200
+      Process.sleep(200)
+      nested_3()
+    end
+
+    @trace :nested_3
+    def nested_3 do
+      # duration ~ 300
+      # exclusive ~ 300
+      Process.sleep(300)
+      :done
+    end
   end
 
   test "External metrics" do
@@ -59,5 +92,42 @@ defmodule MetricTracerTest do
     assert TestHelper.find_metric(metrics, "External/all", 2)
     assert TestHelper.find_metric(metrics, "External/domain.net/all", 2)
     assert TestHelper.find_metric(metrics, "External/domain.net/HttpClient/GET", 2)
+  end
+
+  @delta 0.05
+  test "Exclusive time calculations" do
+    MetricTraced.nested()
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    {total, exclusive} =
+      get_avg_times(metrics, "Function/MetricTracerTest.MetricTraced.nested/0", 1)
+
+    assert_in_delta total, 1.1, @delta
+    assert_in_delta exclusive, 0.0, @delta
+
+    {total, exclusive} =
+      get_avg_times(metrics, "Function/MetricTracerTest.MetricTraced.nested_1/0", 1)
+
+    assert_in_delta total, 1.1, @delta
+    assert_in_delta exclusive, 0.1, @delta
+
+    {total, exclusive} =
+      get_avg_times(metrics, "Function/MetricTracerTest.MetricTraced.nested_2/0", 2)
+
+    assert_in_delta total, 0.5, @delta
+    assert_in_delta exclusive, 0.2, @delta
+
+    {total, exclusive} =
+      get_avg_times(metrics, "Function/MetricTracerTest.MetricTraced.nested_3/0", 2)
+
+    assert_in_delta total, 0.3, @delta
+    assert_in_delta exclusive, 0.3, @delta
+  end
+
+  defp get_avg_times(metrics, name, count) do
+    [_, [count, total, exclusive, _min, _max, _sq]] = TestHelper.find_metric(metrics, name, count)
+
+    {total / count, exclusive / count}
   end
 end


### PR DESCRIPTION
This PR
* Reports "scoped" function trace metrics
* Calculates "exclusive time" for those function traces
* Improves the data in the Transaction Trace for viewing scoped metrics