### PR TITLE
Handle bug with bad NR DT payload

### DIFF
--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -14,15 +14,19 @@ defmodule NewRelic.DistributedTrace do
   end
 
   defp w3c_headers(conn) do
-    case Plug.Conn.get_req_header(conn, @w3c_traceparent) do
-      [_traceparent | _] -> NewRelic.DistributedTrace.W3CTraceContext.extract(conn)
+    with [_traceparent | _] <- Plug.Conn.get_req_header(conn, @w3c_traceparent),
+         %Context{} = context <- __MODULE__.W3CTraceContext.extract(conn) do
+      context
+    else
       _ -> false
     end
   end
 
   defp newrelic_header(conn) do
-    case Plug.Conn.get_req_header(conn, @nr_header) do
-      [trace_payload | _] -> NewRelic.DistributedTrace.NewRelicContext.extract(trace_payload)
+    with [trace_payload | _] <- Plug.Conn.get_req_header(conn, @nr_header),
+         %Context{} = context <- __MODULE__.NewRelicContext.extract(trace_payload) do
+      context
+    else
       _ -> false
     end
   end

--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -23,9 +23,11 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
       error ->
         NewRelic.report_metric(:supportability, [:dt, :accept, :parse_error])
         NewRelic.log(:debug, "Bad DT Payload: #{inspect(error)} #{inspect(raw_payload)}")
-        nil
+        :bad_dt_payload
     end
   end
+
+  def restrict_access(:bad_dt_payload), do: :bad_dt_payload
 
   def restrict_access(context) do
     if (context.trust_key || context.account_id) == AgentRun.trusted_account_key() do

--- a/lib/new_relic/distributed_trace/w3c_trace_context.ex
+++ b/lib/new_relic/distributed_trace/w3c_trace_context.ex
@@ -61,7 +61,7 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext do
     else
       _ ->
         NewRelic.report_metric(:supportability, [:trace_context, :accept, :exception])
-        false
+        :bad_trace_context
     end
   end
 

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -153,7 +153,7 @@ defmodule DistributedTraceTest do
     end
 
     test "ignore bad base64" do
-      refute DistributedTrace.NewRelicContext.decode("foobar")
+      assert DistributedTrace.NewRelicContext.decode("foobar") == :bad_dt_payload
     end
   end
 
@@ -224,6 +224,10 @@ defmodule DistributedTraceTest do
 
       assert :restricted == DistributedTrace.NewRelicContext.restrict_access(context)
     end
+  end
+
+  test "correctly handle a bad NR payload" do
+    TestPlugApp.call(put_req_header(conn(:get, "/"), @dt_header, "asdf"), [])
   end
 
   test "Always handle payload w/o sampling decision" do


### PR DESCRIPTION
Fix a bug if we get a bad payload value for the NR distributed trace header