### PR TITLE
Handle Ecto stream telemetry events

### DIFF
--- a/examples/apps/ecto_example/lib/ecto_example/count.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/count.ex
@@ -1,6 +1,11 @@
 defmodule EctoExample.Count do
   use Ecto.Schema
 
+  def all do
+    import Ecto.Query
+    from(c in EctoExample.Count, select: c)
+  end
+
   schema "counts" do
     timestamps()
   end

--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -50,6 +50,10 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
     {"MySQL", table, operation}
   end
 
+  def parse(%{result: {:ok, %{__struct__: Postgrex.Cursor}}}), do: :ignore
+  def parse(%{result: {:ok, %{__struct__: MyXQL.Cursor}}}), do: :ignore
+  def parse(%{result: {:ok, nil}}), do: :ignore
+
   def parse(%{result: {:error, _}}), do: :ignore
 
   def capture(regex, query, match) do


### PR DESCRIPTION
When using `Ecto.stream`, we get telemetry events with cursor results that we need to handle