### PR TITLE
Use built-in SSL hostname check

### DIFF
--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -27,7 +27,9 @@ defmodule NewRelic.Util.HTTP do
       ssl: [
         verify: :verify_peer,
         cacertfile: Application.app_dir(:new_relic_agent, "priv/cacert.pem"),
-        verify_fun: {&:ssl_verify_hostname.verify_fun/3, [{:check_hostname, '#{host}'}]}
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
       ]
     ]
   end

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -6,10 +6,9 @@ defmodule NewRelic.Util.HTTP do
   def post(url, body, headers) when is_binary(body) do
     headers = [@gzip | Enum.map(headers, fn {k, v} -> {'#{k}', '#{v}'} end)]
     request = {'#{url}', headers, 'application/json', :zlib.gzip(body)}
-    %{host: host} = URI.parse(url)
 
     with {:ok, {{_, status_code, _}, _headers, body}} <-
-           :httpc.request(:post, request, http_options(host), []) do
+           :httpc.request(:post, request, http_options(), []) do
       {:ok, %{status_code: status_code, body: to_string(body)}}
     end
   end
@@ -20,8 +19,11 @@ defmodule NewRelic.Util.HTTP do
   @doc """
   Certs are pulled from Mozilla exactly as Hex does:
   https://github.com/hexpm/hex/blob/master/README.md#bundled-ca-certs
+
+  SSL configured according to EEF Security guide:
+  https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
   """
-  def http_options(host) do
+  def http_options() do
     [
       connect_timeout: 1000,
       ssl: [

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,6 @@ defmodule NewRelic.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:jason, "~> 1.0"},
-      {:ssl_verify_fun, "~> 1.1"},
       {:telemetry, "~> 0.4"},
       # Built-in Instrumentation:
       {:plug, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,5 @@
   "plug_cowboy": {:hex, :plug_cowboy, "2.1.2", "8b0addb5908c5238fac38e442e81b6fcd32788eaa03246b4d55d147c47c5805e", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "7d722581ce865a237e14da6d946f92704101740a256bd13ec91e63c0b122fc70"},
   "plug_crypto": {:hex, :plug_crypto, "1.1.2", "bdd187572cc26dbd95b87136290425f2b580a116d3fb1f564216918c9730d227", [:mix], [], "hexpm", "6b8b608f895b6ffcfad49c37c7883e8df98ae19c6a28113b02aa1e9c5b22d6b5"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
 }

--- a/test/ssl_test.exs
+++ b/test/ssl_test.exs
@@ -1,0 +1,46 @@
+defmodule SSLTest do
+  use ExUnit.Case
+
+  describe "Verify SSL setup" do
+    test "reject bad domains" do
+      assert {:error,
+              {:failed_connect,
+               [
+                 {:to_address, {'wrong.host.badssl.com', 443}},
+                 {:inet, [:inet], {:tls_alert, _}}
+               ]}} = NewRelic.Util.HTTP.post("https://wrong.host.badssl.com/", "", [])
+
+      assert {:error,
+              {:failed_connect,
+               [
+                 {:to_address, {'expired.badssl.com', 443}},
+                 {:inet, [:inet], {:tls_alert, _}}
+               ]}} = NewRelic.Util.HTTP.post("https://expired.badssl.com/", "", [])
+
+      assert {:error,
+              {:failed_connect,
+               [
+                 {:to_address, {'self-signed.badssl.com', 443}},
+                 {:inet, [:inet], {:tls_alert, _}}
+               ]}} = NewRelic.Util.HTTP.post("https://self-signed.badssl.com/", "", [])
+
+      assert {:error,
+              {:failed_connect,
+               [
+                 {:to_address, {'untrusted-root.badssl.com', 443}},
+                 {:inet, [:inet], {:tls_alert, _}}
+               ]}} = NewRelic.Util.HTTP.post("https://untrusted-root.badssl.com/", "", [])
+
+      assert {:error,
+              {:failed_connect,
+               [
+                 {:to_address, {'incomplete-chain.badssl.com', 443}},
+                 {:inet, [:inet], {:tls_alert, _}}
+               ]}} = NewRelic.Util.HTTP.post("https://incomplete-chain.badssl.com/", "", [])
+    end
+
+    test "allows good domains" do
+      assert {:ok, _} = NewRelic.Util.HTTP.post("https://sha512.badssl.com/", "", [])
+    end
+  end
+end

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -124,49 +124,6 @@ defmodule UtilTest do
     assert is_binary(hostname)
   end
 
-  describe "Verify SSL setup" do
-    test "reject bad domains" do
-      assert {:error,
-              {:failed_connect,
-               [
-                 {:to_address, {'wrong.host.badssl.com', 443}},
-                 {:inet, [:inet], {:tls_alert, _}}
-               ]}} = NewRelic.Util.HTTP.post("https://wrong.host.badssl.com/", "", [])
-
-      assert {:error,
-              {:failed_connect,
-               [
-                 {:to_address, {'expired.badssl.com', 443}},
-                 {:inet, [:inet], {:tls_alert, _}}
-               ]}} = NewRelic.Util.HTTP.post("https://expired.badssl.com/", "", [])
-
-      assert {:error,
-              {:failed_connect,
-               [
-                 {:to_address, {'self-signed.badssl.com', 443}},
-                 {:inet, [:inet], {:tls_alert, _}}
-               ]}} = NewRelic.Util.HTTP.post("https://self-signed.badssl.com/", "", [])
-
-      assert {:error,
-              {:failed_connect,
-               [
-                 {:to_address, {'untrusted-root.badssl.com', 443}},
-                 {:inet, [:inet], {:tls_alert, _}}
-               ]}} = NewRelic.Util.HTTP.post("https://untrusted-root.badssl.com/", "", [])
-
-      assert {:error,
-              {:failed_connect,
-               [
-                 {:to_address, {'incomplete-chain.badssl.com', 443}},
-                 {:inet, [:inet], {:tls_alert, _}}
-               ]}} = NewRelic.Util.HTTP.post("https://incomplete-chain.badssl.com/", "", [])
-    end
-
-    test "allows good domains" do
-      assert {:ok, _} = NewRelic.Util.HTTP.post("https://sha512.badssl.com/", "", [])
-    end
-  end
-
   test "docker cgroup file container ID detection" do
     # docker-0.9.1
     assert_docker_container_id(


### PR DESCRIPTION
OTP 21+ (which we require) has a built-in SSL hostname verification function that we can use instead of relying on a dependency...

Described in the Erlang Elixir Foundation Security guide:
* https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl