### PR TITLE
Provide an API to stop an Other transaction

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -75,9 +75,20 @@ defmodule NewRelic do
   will risk a memory leak tracking attributes in the transaction!
   * You can't start a new transaction within an existing one. Any process
   spawned inside a transaction belongs to that transaction.
+  * If multiple transactions are started in the same Process, you must
+  call `NewRelic.stop_transaction()` to mark the end of the transaction.
   """
   @spec start_transaction(String.t(), String.t()) :: :ok
   defdelegate start_transaction(category, name), to: NewRelic.Transaction
+
+  @doc """
+  Stop an "Other" Transaction.
+
+  If multiple transactions are started in the same Process, you must
+  call `NewRelic.stop_transaction()` to mark the end of the transaction.
+  """
+  @spec stop_transaction() :: :ok
+  defdelegate stop_transaction(), to: NewRelic.Transaction
 
   @doc """
   Call within a transaction to prevent it from reporting.

--- a/lib/new_relic/transaction.ex
+++ b/lib/new_relic/transaction.ex
@@ -63,7 +63,7 @@ defmodule NewRelic.Transaction do
     NewRelic.DistributedTrace.Tracker.cleanup(self())
     NewRelic.Transaction.Plug.add_stop_attrs(conn)
     NewRelic.Transaction.Reporter.fail(error)
-    NewRelic.Transaction.Reporter.complete()
+    NewRelic.Transaction.Reporter.complete(self(), :async)
   end
 
   @doc false
@@ -73,6 +73,12 @@ defmodule NewRelic.Transaction do
     NewRelic.DistributedTrace.generate_new_context()
     |> NewRelic.DistributedTrace.track_transaction(transport_type: "Other")
 
+    :ok
+  end
+
+  @doc false
+  def stop_transaction() do
+    NewRelic.Transaction.Reporter.complete(self(), :sync)
     :ok
   end
 

--- a/lib/new_relic/transaction/monitor.ex
+++ b/lib/new_relic/transaction/monitor.ex
@@ -101,7 +101,7 @@ defmodule NewRelic.Transaction.Monitor do
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     Transaction.Reporter.ensure_purge(pid)
-    Transaction.Reporter.complete(pid)
+    Transaction.Reporter.complete(pid, :async)
     DistributedTrace.Tracker.cleanup(pid)
     {:noreply, %{state | pids: Map.delete(state.pids, pid)}}
   end

--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -40,7 +40,7 @@ defmodule NewRelic.Transaction.Plug do
 
   defp before_send(conn) do
     add_stop_attrs(conn)
-    Transaction.Reporter.complete()
+    Transaction.Reporter.complete(self(), :async)
     conn
   end
 


### PR DESCRIPTION
This PR provides an API to stop an Other transaction. This is needed if a single Process executes more than one transaction, which is the case for some batch processing frameworks like Broadway.

* `NewRelic.stop_transaction()` must be called when the work is complete before starting another transaction in the same Process

This must be used in conjunction with `NewRelic.start_transaction/2`. It is _not_ to be used inside "Web" transactions.

fixes #180 