### PR TITLE
Make plug_cowboy dep optional

### DIFF
--- a/examples/apps/ecto_example/mix.exs
+++ b/examples/apps/ecto_example/mix.exs
@@ -28,6 +28,7 @@ defmodule EctoExample.MixProject do
   defp deps do
     [
       {:new_relic_agent, path: "../../../"},
+      {:plug_cowboy, "~> 2.0"},
       {:ecto_sql, "~> 3.0"},
       {:postgrex, ">= 0.0.0"},
       {:myxql, ">= 0.0.0"}

--- a/mix.exs
+++ b/mix.exs
@@ -38,9 +38,11 @@ defmodule NewRelic.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"},
       {:ssl_verify_fun, "~> 1.1"},
       {:telemetry, "~> 0.4"},
+      # Built-in Instrumentation:
+      {:plug, "~> 1.0"},
+      {:plug_cowboy, "~> 2.0", optional: true},
       # Optional Instrumentation:
       {:ecto_sql, "~> 3.3", optional: true}
     ]


### PR DESCRIPTION
This PR simply makes the agent depend on:
* `plug` directly
* `plug_cowboy` optionally

The agent does use Plug functions for header manipulation, but doesn't directly use any cowboy functions, we simply need to enforce a requirement on Cowboy version 2 if it is there

Functionally, this shouldn't change anything since the app itself should be including `plug` / `plug_cowboy` if it uses them... 

This simply reduces the number of deps the agent will pull in on it's own