### PR TITLE
Coercion of custom attributes

### DIFF
--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -41,6 +41,10 @@ defmodule NewRelic.Util do
     |> Enum.concat([{"#{key}.length", length(list_value)}])
   end
 
+  def deep_flatten({key, %{__struct__: _} = value}) do
+    [{key, value}]
+  end
+
   def deep_flatten({key, map_value}) when is_map(map_value) do
     map_value
     |> Enum.slice(0..9)
@@ -50,6 +54,36 @@ defmodule NewRelic.Util do
 
   def deep_flatten({key, value}) do
     [{key, value}]
+  end
+
+  def coerce_attributes(attrs) do
+    Enum.map(attrs, fn
+      {key, value} when is_number(value) when is_boolean(value) ->
+        {key, value}
+
+      {key, value} when is_bitstring(value) ->
+        case String.valid?(value) do
+          true -> {key, value}
+          false -> bad_value(key, value)
+        end
+
+      {key, value} when is_reference(value) when is_pid(value) when is_port(value) ->
+        {key, inspect(value)}
+
+      {key, value} when is_atom(value) ->
+        {key, to_string(value)}
+
+      {key, %struct{} = value} when struct in [Date, DateTime, Time, NaiveDateTime] ->
+        {key, inspect(value)}
+
+      {key, value} ->
+        bad_value(key, value)
+    end)
+  end
+
+  defp bad_value(key, value) do
+    NewRelic.log(:debug, "Bad attribute value: #{inspect(key)} => #{inspect(value)}")
+    {key, "[BAD_VALUE]"}
   end
 
   def elixir_environment() do

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -74,7 +74,7 @@ defmodule NewRelic.Util do
         {key, to_string(value)}
 
       {key, %struct{} = value} when struct in [Date, DateTime, Time, NaiveDateTime] ->
-        {key, inspect(value)}
+        {key, struct.to_iso8601(value)}
 
       {key, value} ->
         bad_value(key, value)

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -42,7 +42,7 @@ defmodule TransactionTest do
         # allowed:
         one: 1,
         half: 0.5,
-        string: "String",
+        string: "A string",
         bool: true,
         atom: :atom,
         pid: self(),
@@ -173,7 +173,7 @@ defmodule TransactionTest do
     assert event[:one] == 1
     assert event[:half] == 0.5
     assert event[:bool] == true
-    assert event[:string] == "String"
+    assert event[:string] == "A string"
     assert event[:atom] == "atom"
 
     # Fancy values

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -180,10 +180,10 @@ defmodule TransactionTest do
     assert event[:pid] =~ "#PID"
     assert event[:ref] =~ "#Reference"
     assert event[:port] =~ "#Port"
-    assert event[:date_time] =~ "~U"
-    assert event[:naive_date_time] =~ "~N"
-    assert event[:date] =~ "~D"
-    assert event[:time] =~ "~T"
+    assert {:ok, _, _} = DateTime.from_iso8601(event[:date_time])
+    assert {:ok, _} = NaiveDateTime.from_iso8601(event[:naive_date_time])
+    assert {:ok, _} = Date.from_iso8601(event[:date])
+    assert {:ok, _} = Time.from_iso8601(event[:time])
 
     # Bad values
     assert event[:binary] == @bad


### PR DESCRIPTION
This PR handles user-supplied attributes of types that aren't normally JSON serializable.

A set of types we can easily `inspect` or `to_string` to get a meaningful value. Another set we reject since we can't serialize it to JSON in a meaningful way - like tuples / functions.