### PR TITLE
Add docker id to the utilization vendors

### DIFF
--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -1,13 +1,81 @@
 defmodule NewRelic.Util.Vendor do
   @moduledoc false
 
+  @cgroup_file "/proc/self/cgroup"
+
   def maybe_add_vendors(util, options \\ []) do
     %{}
     |> maybe_add_aws(options)
     |> maybe_add_kubernetes()
+    |> maybe_add_docker_container_id(@cgroup_file)
     |> case do
       vendors when map_size(vendors) == 0 -> util
       vendors -> Map.put(util, :vendors, vendors)
+    end
+  end
+
+  @doc """
+  Adds the docker container ID to the given vendors map. The container ID
+  is retrieved from the given cgroup file, It's taken from the first cgroup
+  in the file that meets the following requirements:
+
+  - The definition must contain 3 parts separated by a colon.
+  - It must specify the cpu subsystem.
+  - The contianer ID is the last item in the cgroup path and it should
+    be a 64-digit hex string.
+  """
+  def maybe_add_docker_container_id(vendors, cgroup_file) do
+    case File.read(cgroup_file) do
+      {:ok, content} ->
+        cid = container_id_from_cgroup_file_content(content)
+
+        if cid != nil do
+          Map.put(vendors, :docker, %{id: cid})
+        else
+          vendors
+        end
+
+      _ ->
+        vendors
+    end
+  end
+
+  defp container_id_from_cgroup_file_content(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.find_value(&container_id_from_cgroup_definition/1)
+  end
+
+  defp container_id_from_cgroup_definition(cgroup) do
+    with {:ok, cgroup_parts} <- validate_cgroup(cgroup),
+         true <- is_cgroup_for_cpu_subsystem?(Enum.at(cgroup_parts, 1)),
+         container_id <- container_id_from_cgroup_path(Enum.at(cgroup_parts, 2)),
+         true <- Regex.match?(~r/[0-9a-f]{64,}/, container_id) do
+      container_id
+    else
+      _ -> false
+    end
+  end
+
+  defp container_id_from_cgroup_path(cgroup_path) do
+    cgroup_path
+    |> String.split("/")
+    |> List.last()
+  end
+
+  defp is_cgroup_for_cpu_subsystem?(subsystems) do
+    subsystems
+    |> String.split(",")
+    |> Enum.any?(fn x -> x == "cpu" end)
+  end
+
+  defp validate_cgroup(cgroup) do
+    cgroup_parts = String.split(cgroup, ":")
+
+    if length(cgroup_parts) == 3 do
+      {:ok, cgroup_parts}
+    else
+      :error
     end
   end
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

If the agent detects that the app is running inside a container the container ID is added to the utilization map as:

%{docker: %{id: "<CONTAINER_ID>"}}

The conatainer ID is taken from the file "/proc/self/cgroup". It's taken from the first cgroup in the file that meets the following requirements: 

- The definition must contain 3 parts separated by a colon.
- It must specify the cpu subsystem.
- The contianer ID is the last item in the cgroup path and it should be a 64-digit hex string. 

Fixes https://github.com/newrelic/elixir_agent/issues/204 