### PR TITLE
Split ets tables for tracking and collecting

### DIFF
--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -343,6 +343,15 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
+  def transform({:supportability, :agent, name}, value: value),
+    do: %Metric{
+      name: join(["Supportability/ElixirAgent", name]),
+      call_count: 1,
+      total_call_time: value,
+      min_call_time: value,
+      max_call_time: value
+    }
+
   def transform({:supportability, :collector}, status: status),
     do: %Metric{
       name: join(["Supportability/Agent/Collector/HTTPError", status]),

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -343,9 +343,9 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
-  def transform({:supportability, :agent, name}, value: value),
+  def transform({:supportability, :agent, metric}, value: value),
     do: %Metric{
-      name: join(["Supportability/ElixirAgent", name]),
+      name: join(["Supportability/ElixirAgent", metric]),
       call_count: 1,
       total_call_time: value,
       min_call_time: value,

--- a/lib/new_relic/sampler/agent.ex
+++ b/lib/new_relic/sampler/agent.ex
@@ -1,0 +1,38 @@
+defmodule NewRelic.Sampler.Agent do
+  use GenServer
+
+  alias NewRelic.Transaction
+
+  # Takes samples of the state of the Agent
+
+  @moduledoc false
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    if NewRelic.Config.enabled?(),
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+
+    {:ok, %{}}
+  end
+
+  def handle_info(:report, state) do
+    record_sample()
+    Process.send_after(self(), :report, NewRelic.Sampler.Reporter.sample_cycle())
+    {:noreply, state}
+  end
+
+  def handle_call(:report, _from, state) do
+    record_sample()
+    {:reply, :ok, state}
+  end
+
+  def record_sample do
+    NewRelic.report_metric(
+      {:supportability, :agent, "ReporterCompleteActive"},
+      value: length(Task.Supervisor.children(Transaction.TaskSupervisor))
+    )
+  end
+end

--- a/lib/new_relic/sampler/agent.ex
+++ b/lib/new_relic/sampler/agent.ex
@@ -31,8 +31,24 @@ defmodule NewRelic.Sampler.Agent do
 
   def record_sample do
     NewRelic.report_metric(
-      {:supportability, :agent, "ReporterCompleteActive"},
+      {:supportability, :agent, "ReporterCollectingSize"},
+      value: ets_size(NewRelic.Transaction.Reporter.Collecting)
+    )
+
+    NewRelic.report_metric(
+      {:supportability, :agent, "ReporterTrackingSize"},
+      value: ets_size(NewRelic.Transaction.Reporter.Tracking)
+    )
+
+    NewRelic.report_metric(
+      {:supportability, :agent, "ReporterCompleteTasksActive"},
       value: length(Task.Supervisor.children(Transaction.TaskSupervisor))
     )
+  end
+
+  def ets_size(table) do
+    :ets.info(table, :size)
+  rescue
+    ArgumentError -> nil
   end
 end

--- a/lib/new_relic/sampler/supervisor.ex
+++ b/lib/new_relic/sampler/supervisor.ex
@@ -9,6 +9,7 @@ defmodule NewRelic.Sampler.Supervisor do
 
   def init(_) do
     children = [
+      worker(NewRelic.Sampler.Agent, []),
       worker(NewRelic.Sampler.Beam, []),
       worker(NewRelic.Sampler.Process, []),
       worker(NewRelic.Sampler.TopProcess, []),

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -140,6 +140,7 @@ defmodule NewRelic.Transaction.Complete do
       |> Map.merge(NewRelic.Config.automatic_attributes())
       |> Map.put(:"nr.apdexPerfZone", Util.Apdex.label(apdex))
       |> Map.put(:total_time_s, tx_attrs.duration_s + concurrent_process_time_ms / 1000)
+      |> Map.put(:process_spawns, length(process_spawns))
 
     {[segment_tree], tx_attrs, tx_error, span_events, apdex, tx_metrics}
   end

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -62,9 +62,9 @@ defmodule NewRelic.Transaction.Reporter do
 
   def ignore_transaction() do
     if tracking?(self()) do
+      ensure_purge(self())
       AttrStore.untrack(__MODULE__, self())
       AttrStore.purge(__MODULE__, self())
-      ensure_purge(self())
     end
   end
 
@@ -124,15 +124,12 @@ defmodule NewRelic.Transaction.Reporter do
 
   def track_spawn(original, pid, timestamp) do
     if tracking?(original) do
-      AttrStore.link(
-        __MODULE__,
-        original,
-        pid,
+      AttrStore.link(__MODULE__, original, pid)
+
+      AttrStore.add(__MODULE__, pid,
         trace_process_spawns: {:list, {pid, timestamp, original}},
         trace_process_names: {:list, {pid, NewRelic.Util.process_name(pid)}}
       )
-
-      AttrStore.incr(__MODULE__, original, process_spawns: 1)
     end
   end
 

--- a/lib/new_relic/util/attr_store.ex
+++ b/lib/new_relic/util/attr_store.ex
@@ -8,17 +8,10 @@ defmodule NewRelic.Util.AttrStore do
 
   @moduledoc false
 
-  @ets_options [
-    :named_table,
-    :duplicate_bag,
-    :public,
-    read_concurrency: true,
-    write_concurrency: true
-  ]
-
+  @ets_options [:named_table, :duplicate_bag, :public]
   def new(table) do
-    :ets.new(collecting(table), @ets_options)
-    :ets.new(tracking(table), @ets_options)
+    :ets.new(collecting(table), @ets_options ++ [write_concurrency: true])
+    :ets.new(tracking(table), @ets_options ++ [read_concurrency: true, write_concurrency: true])
   end
 
   def track(table, pid) do
@@ -131,7 +124,7 @@ defmodule NewRelic.Util.AttrStore do
   defp collect_attr({_pid, {k, {:counter, n}}}, acc), do: Map.update(acc, k, n, &(&1 + n))
   defp collect_attr({_pid, {k, v}}, acc), do: Map.put(acc, k, v)
 
-  defp collecting(table), do: table
+  defp collecting(table), do: Module.concat(table, Collecting)
   defp tracking(table), do: Module.concat(table, Tracking)
 
   defp lookup(table, term) do

--- a/lib/new_relic/util/attr_store.ex
+++ b/lib/new_relic/util/attr_store.ex
@@ -1,52 +1,69 @@
 defmodule NewRelic.Util.AttrStore do
-  # This is an abstraction around an ETS table that lets us store efficently
+  # This is an abstraction around ETS that lets us store efficently
   # store and access arbitrary key->value pairs for all Transactions we are tracking
+  #
+  # It is backed by two ETS tables:
+  # 1) tracking all processes involved in a Transaction
+  # 2) collecting attributes stored on a Transaction
 
   @moduledoc false
 
+  @ets_options [
+    :named_table,
+    :duplicate_bag,
+    :public,
+    read_concurrency: true,
+    write_concurrency: true
+  ]
+
   def new(table) do
-    :ets.new(table, [
-      :named_table,
-      :duplicate_bag,
-      :public,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
+    :ets.new(collecting(table), @ets_options)
+    :ets.new(tracking(table), @ets_options)
   end
 
   def track(table, pid) do
-    insert(table, {{pid, :tracking}, true})
+    insert(
+      tracking(table),
+      {{pid, :tracking}, true}
+    )
   end
 
-  def link(table, parent, child, attrs \\ []) do
+  def link(table, parent, child) do
     root = find_root(table, parent)
-    extras = Enum.map(attrs, fn {key, value} -> {child, {key, value}} end)
 
-    insert(table, [
-      {{child, :tracking}, true},
-      {{child, :child_of}, root},
-      {{root, :root_of}, child} | extras
-    ])
+    insert(
+      tracking(table),
+      [
+        {{child, :tracking}, true},
+        {{child, :child_of}, root},
+        {{root, :root_of}, child}
+      ]
+    )
   end
 
-  def add(table, pid, attrs)
-      when is_list(attrs) do
-    items = Enum.map(attrs, fn {key, value} -> {pid, {key, value}} end)
-    insert(table, items)
+  def add(table, pid, attrs) when is_list(attrs) do
+    insert(
+      collecting(table),
+      Enum.map(attrs, fn {key, value} -> {pid, {key, value}} end)
+    )
   end
 
-  def incr(table, pid, attrs)
-      when is_list(attrs) do
-    items = Enum.map(attrs, fn {key, value} -> {pid, {key, {:counter, value}}} end)
-    insert(table, items)
+  def incr(table, pid, attrs) when is_list(attrs) do
+    insert(
+      collecting(table),
+      Enum.map(attrs, fn {key, value} -> {pid, {key, {:counter, value}}} end)
+    )
   end
 
   def tracking?(table, pid) do
-    member?(table, {pid, :tracking})
+    member?(
+      tracking(table),
+      {pid, :tracking}
+    )
   end
 
   def collect(table, pid) do
-    pids = [pid | find_children(table, pid)]
+    pids = with_children(pid, table)
 
     table
     |> find_attributes(pids)
@@ -54,41 +71,66 @@ defmodule NewRelic.Util.AttrStore do
   end
 
   def untrack(table, pid) do
-    delete(table, {pid, :tracking})
+    pid
+    |> with_children(table)
+    |> Enum.each(fn pid ->
+      delete(
+        tracking(table),
+        {pid, :tracking}
+      )
+    end)
   end
 
   def purge(table, pid) do
-    [pid | find_children(table, pid)]
+    pid
+    |> with_children(table)
     |> Enum.each(fn pid ->
-      delete(table, pid)
-      delete(table, {pid, :tracking})
-      delete(table, {pid, :child_of})
-      delete(table, {pid, :root_of})
+      delete(collecting(table), pid)
+
+      delete(tracking(table), {pid, :tracking})
+      delete(tracking(table), {pid, :child_of})
+      delete(tracking(table), {pid, :root_of})
     end)
   end
 
   def find_root(table, pid) do
-    lookup(table, {pid, :child_of})
+    lookup(
+      tracking(table),
+      {pid, :child_of}
+    )
     |> case do
       [{_, root} | _] -> root
       [] -> pid
     end
   end
 
+  def with_children(pid, table) do
+    [pid | find_children(table, pid)]
+  end
+
   def find_children(table, root_pid) do
-    lookup(table, {root_pid, :root_of})
+    lookup(
+      tracking(table),
+      {root_pid, :root_of}
+    )
     |> Enum.map(fn {_, child} -> child end)
   end
 
   def find_attributes(table, pids) do
     Enum.flat_map(pids, fn pid ->
-      lookup(table, pid)
+      lookup(
+        collecting(table),
+        pid
+      )
     end)
   end
 
   defp collect_attr({_pid, {k, {:list, item}}}, acc), do: Map.update(acc, k, [item], &[item | &1])
   defp collect_attr({_pid, {k, {:counter, n}}}, acc), do: Map.update(acc, k, n, &(&1 + n))
   defp collect_attr({_pid, {k, v}}, acc), do: Map.put(acc, k, v)
+
+  defp collecting(table), do: table
+  defp tracking(table), do: Module.concat(table, Tracking)
 
   defp lookup(table, term) do
     :ets.lookup(table, term)

--- a/lib/new_relic/util/attr_store.ex
+++ b/lib/new_relic/util/attr_store.ex
@@ -74,10 +74,7 @@ defmodule NewRelic.Util.AttrStore do
     pid
     |> with_children(table)
     |> Enum.each(fn pid ->
-      delete(
-        tracking(table),
-        {pid, :tracking}
-      )
+      delete(tracking(table), {pid, :tracking})
     end)
   end
 
@@ -118,7 +115,7 @@ defmodule NewRelic.Util.AttrStore do
 
   def find_attributes(table, pids) do
     Enum.flat_map(pids, fn pid ->
-      lookup(
+      take(
         collecting(table),
         pid
       )
@@ -134,6 +131,12 @@ defmodule NewRelic.Util.AttrStore do
 
   defp lookup(table, term) do
     :ets.lookup(table, term)
+  rescue
+    ArgumentError -> []
+  end
+
+  defp take(table, term) do
+    :ets.take(table, term)
   rescue
     ArgumentError -> []
   end

--- a/test/attr_store_test.exs
+++ b/test/attr_store_test.exs
@@ -31,13 +31,6 @@ defmodule AttrStoreTest do
     assert Enum.member?(attrs, {:two, 2})
     assert Enum.member?(attrs, {:count_tag, 2})
 
-    AttrStore.purge(table, :pid)
-    assert %{} == AttrStore.collect(table, :pid)
-
-    AttrStore.add(table, :pid, extra: "attr")
-    AttrStore.add(table, :pid, junk: "stuff")
-
-    AttrStore.purge(table, :pid)
     assert %{} == AttrStore.collect(table, :pid)
   end
 
@@ -56,14 +49,12 @@ defmodule AttrStoreTest do
     AttrStore.add(table, :pid, foo: "BAR")
     AttrStore.add(table, :task, baz: "QUX")
 
+    AttrStore.untrack(table, :pid)
     attrs = AttrStore.collect(table, :pid)
     assert attrs == %{foo: "BAR", baz: "QUX"}
 
-    AttrStore.purge(table, :task)
-    assert %{} == AttrStore.collect(table, :task)
-
-    AttrStore.purge(table, :pid)
     refute AttrStore.tracking?(table, :pid)
+    assert %{} == AttrStore.collect(table, :task)
     assert %{} == AttrStore.collect(table, :pid)
   end
 

--- a/test/attr_store_test.exs
+++ b/test/attr_store_test.exs
@@ -41,10 +41,9 @@ defmodule AttrStoreTest do
     AttrStore.track(table, :pid)
     AttrStore.link(table, :pid, :task)
 
-    links = AttrStore.find_children(table, :pid)
-    assert links == [:task]
+    assert AttrStore.root(table, :task) == :pid
 
-    assert [] == AttrStore.find_children(table, :not_there)
+    assert AttrStore.root(table, :no_links) == :no_links
 
     AttrStore.add(table, :pid, foo: "BAR")
     AttrStore.add(table, :task, baz: "QUX")
@@ -82,14 +81,11 @@ defmodule AttrStoreTest do
     AttrStore.link(table, :task, :sibling_task)
     AttrStore.link(table, :another_task, :super_nested)
 
-    links = AttrStore.find_children(table, :pid)
-    assert [] = links -- [:task, :another_task, :super_nested, :sibling_task]
-
-    assert AttrStore.find_root(table, :pid) == :pid
-    assert AttrStore.find_root(table, :task) == :pid
-    assert AttrStore.find_root(table, :another_task) == :pid
-    assert AttrStore.find_root(table, :sibling_task) == :pid
-    assert AttrStore.find_root(table, :super_nested) == :pid
+    assert AttrStore.root(table, :pid) == :pid
+    assert AttrStore.root(table, :task) == :pid
+    assert AttrStore.root(table, :another_task) == :pid
+    assert AttrStore.root(table, :sibling_task) == :pid
+    assert AttrStore.root(table, :super_nested) == :pid
 
     AttrStore.add(table, :pid, grand: "PARENT")
     AttrStore.add(table, :task, foo: "BAR")
@@ -133,11 +129,29 @@ defmodule AttrStoreTest do
     refute AttrStore.tracking?(table, :task3)
   end
 
+  test "untrack doesn't break links" do
+    table = AttrStore.Test
+    AttrStore.new(table)
+
+    AttrStore.track(table, :pid)
+    AttrStore.link(table, :pid, :task1)
+
+    assert AttrStore.tracking?(table, :pid)
+    assert AttrStore.tracking?(table, :task1)
+
+    AttrStore.untrack(table, :task1)
+
+    refute AttrStore.tracking?(table, :pid)
+    refute AttrStore.tracking?(table, :task1)
+
+    assert AttrStore.root(table, :task1) == :pid
+  end
+
   test "If the table doesn't exist, don't blow up" do
     AttrStore.track(NoTable, :pid)
     AttrStore.add(NoTable, :pid, some: "VALUE")
     AttrStore.tracking?(NoTable, self())
-    AttrStore.find_root(NoTable, self())
+    AttrStore.root(NoTable, self())
     AttrStore.purge(NoTable, self())
   end
 end

--- a/test/attr_store_test.exs
+++ b/test/attr_store_test.exs
@@ -137,6 +137,9 @@ defmodule AttrStoreTest do
     assert AttrStore.tracking?(table, :pid)
     AttrStore.untrack(table, :pid)
     refute AttrStore.tracking?(table, :pid)
+    refute AttrStore.tracking?(table, :task1)
+    refute AttrStore.tracking?(table, :task2)
+    refute AttrStore.tracking?(table, :task3)
   end
 
   test "If the table doesn't exist, don't blow up" do

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -227,7 +227,10 @@ defmodule DistributedTraceTest do
   end
 
   test "correctly handle a bad NR payload" do
-    TestPlugApp.call(put_req_header(conn(:get, "/"), @dt_header, "asdf"), [])
+    TestHelper.request(
+      TestPlugApp,
+      put_req_header(conn(:get, "/"), @dt_header, "asdf")
+    )
   end
 
   test "Always handle payload w/o sampling decision" do

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -96,7 +96,7 @@ defmodule MetricTransactionTest do
   end
 
   test "Basic web transaction" do
-    TestPlugApp.call(conn(:get, "/foo/1"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/foo/1"))
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
@@ -107,7 +107,7 @@ defmodule MetricTransactionTest do
   end
 
   test "External metrics" do
-    TestPlugApp.call(conn(:get, "/foo/1"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/foo/1"))
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
@@ -159,7 +159,7 @@ defmodule MetricTransactionTest do
       conn(:get, "/foo/1")
       |> put_req_header("x-request-start", request_start)
 
-    TestPlugApp.call(conn, [])
+    TestHelper.request(TestPlugApp, conn)
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
@@ -181,7 +181,7 @@ defmodule MetricTransactionTest do
   end
 
   test "Custom transaction names" do
-    TestPlugApp.call(conn(:get, "/custom_name"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/custom_name"))
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
@@ -189,7 +189,7 @@ defmodule MetricTransactionTest do
   end
 
   test "fancy transaction names" do
-    TestPlugApp.call(conn(:get, "/fancy/transaction/names/supported/here!"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/fancy/transaction/names/supported/here!"))
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -127,7 +127,7 @@ defmodule SamplerTest do
     assert [_, [_, 2, _, _, _, _]] =
              TestHelper.find_metric(
                metrics,
-               "Supportability/ElixirAgent/ReporterCompleteActive"
+               "Supportability/ElixirAgent/ReporterCompleteTasksActive"
              )
   end
 

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -211,13 +211,9 @@ defmodule TracerTest do
   end
 
   test "Don't track trace segments that are NOT part of a process in a Transaction" do
-    Application.put_env(:new_relic_agent, :tx_attr_expire, 50)
-
     Traced.funny()
 
-    attrs = NewRelic.Util.AttrStore.find_attributes(NewRelic.Transaction.Reporter, [self()])
-    assert Enum.empty?(attrs)
-
-    Application.delete_env(:new_relic_agent, :tx_attr_expire)
+    assert %{} == NewRelic.Util.AttrStore.collect(NewRelic.Transaction.Reporter, self())
+    assert %{} == NewRelic.Util.AttrStore.collect(NewRelic.Transaction.Reporter.Tracking, self())
   end
 end

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -117,8 +117,8 @@ defmodule TransactionEventTest do
   test "instrument & harvest" do
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
-    TestPlugApp.call(conn(:get, "/"), [])
-    TestPlugApp.call(conn(:get, "/"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
 
     [event | _] = events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
 
@@ -148,14 +148,11 @@ defmodule TransactionEventTest do
     Application.put_env(:new_relic_agent, :transaction_event_reservoir_size, 3)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
-    Task.async(fn ->
-      TestPlugApp.call(conn(:get, "/"), [])
-      TestPlugApp.call(conn(:get, "/"), [])
-      TestPlugApp.call(conn(:get, "/"), [])
-      TestPlugApp.call(conn(:get, "/"), [])
-      TestPlugApp.call(conn(:get, "/"), [])
-    end)
-    |> Task.await()
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
+    TestHelper.request(TestPlugApp, conn(:get, "/"))
 
     events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
     assert length(events) == 3

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -154,7 +154,7 @@ defmodule TransactionTraceTest do
   end
 
   test "Prepare a payload" do
-    TestPlugApp.call(conn(:get, "/supremely_custom_name"), [])
+    TestHelper.request(TestPlugApp, conn(:get, "/supremely_custom_name"))
 
     start_time = 1_440_435_088
     metric_name = "WebTransaction/supremely/unique/name"


### PR DESCRIPTION
This PR splits the Transaction backing store into 2 ETS tables, one for tracking processes that are part of a Transaction, and one for collecting the attributes for Transactions.

The goal of this is to reduce contention in cases of the app being overloaded.