### PR TITLE
Connect Browser Distributed Traces

### DIFF
--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -85,7 +85,7 @@ defmodule NewRelic.DistributedTrace do
 
   def maybe_generate_sampling(context), do: context
 
-  def maybe_generate_trace_id(%Context{parent_id: nil} = context) do
+  def maybe_generate_trace_id(%Context{trace_id: nil} = context) do
     %{context | trace_id: generate_guid(16)}
   end
 
@@ -112,7 +112,10 @@ defmodule NewRelic.DistributedTrace do
   end
 
   def report_attributes(
-        %Context{parent_id: nil} = context,
+        %Context{
+          parent_id: nil,
+          span_guid: nil
+        } = context,
         transport_type: _type
       ) do
     [
@@ -156,20 +159,6 @@ defmodule NewRelic.DistributedTrace do
 
   def report_attributes(context, :w3c) do
     context
-  end
-
-  def convert_to_outbound(%Context{parent_id: nil} = context) do
-    %Context{
-      source: context.source,
-      account_id: AgentRun.account_id(),
-      app_id: AgentRun.primary_application_id(),
-      parent_id: nil,
-      trust_key: context.trust_key,
-      guid: context.guid,
-      trace_id: context.trace_id,
-      priority: context.priority,
-      sampled: context.sampled
-    }
   end
 
   def convert_to_outbound(%Context{} = context) do

--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -77,19 +77,16 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
           "ap" => context.app_id |> to_string,
           "tx" => context.guid,
           "tr" => context.trace_id,
+          "id" => context.span_guid,
           "pr" => context.priority,
           "sa" => context.sampled,
           "ti" => context.timestamp
         }
-        |> maybe_put(:span_guid, "id", context.sampled, context.span_guid)
         |> maybe_put(:trust_key, "tk", context.account_id, context.trust_key)
     }
     |> Jason.encode!()
     |> Base.encode64()
   end
-
-  def maybe_put(data, :span_guid, key, true = _sampled, guid), do: Map.put(data, key, guid)
-  def maybe_put(data, :span_guid, _key, false = _sampled, _guid), do: data
 
   def maybe_put(data, :trust_key, _key, account_id, account_id), do: data
   def maybe_put(data, :trust_key, _key, _account_id, nil), do: data

--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -73,8 +73,8 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
       "d" =>
         %{
           "ty" => context.type,
-          "ac" => context.account_id,
-          "ap" => context.app_id,
+          "ac" => context.account_id |> to_string,
+          "ap" => context.app_id |> to_string,
           "tx" => context.guid,
           "tr" => context.trace_id,
           "pr" => context.priority,

--- a/lib/new_relic/logger.ex
+++ b/lib/new_relic/logger.ex
@@ -44,6 +44,10 @@ defmodule NewRelic.Logger do
     {:reply, StringIO.flush(io_device), state}
   end
 
+  def handle_call(:flush, _from, state) do
+    {:reply, "", state}
+  end
+
   def handle_call({:logger, logger}, _from, old_state) do
     {:ok, io_device} = device(logger)
     {:reply, old_state, %{io_device: io_device, logger: logger}}

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -57,27 +57,30 @@ defmodule NewRelic.Util do
   end
 
   def coerce_attributes(attrs) do
-    Enum.map(attrs, fn
+    Enum.flat_map(attrs, fn
+      {_key, nil} ->
+        []
+
       {key, value} when is_number(value) when is_boolean(value) ->
-        {key, value}
+        [{key, value}]
 
       {key, value} when is_bitstring(value) ->
         case String.valid?(value) do
-          true -> {key, value}
-          false -> bad_value(key, value)
+          true -> [{key, value}]
+          false -> [bad_value(key, value)]
         end
 
       {key, value} when is_reference(value) when is_pid(value) when is_port(value) ->
-        {key, inspect(value)}
+        [{key, inspect(value)}]
 
       {key, value} when is_atom(value) ->
-        {key, to_string(value)}
+        [{key, to_string(value)}]
 
       {key, %struct{} = value} when struct in [Date, DateTime, Time, NaiveDateTime] ->
-        {key, struct.to_iso8601(value)}
+        [{key, struct.to_iso8601(value)}]
 
       {key, value} ->
-        bad_value(key, value)
+        [bad_value(key, value)]
     end)
   end
 

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -220,13 +220,13 @@ defmodule DistributedTraceTest do
       assert context =~ ~s("id":"spguid")
     end
 
-    test "exclude id when not sampled" do
+    test "include id when not sampled" do
       context =
         %DistributedTrace.Context{sampled: false, span_guid: "spguid"}
         |> DistributedTrace.NewRelicContext.encode()
         |> Base.decode64!()
 
-      refute context =~ ~s("id")
+      assert context =~ ~s("id":"spguid")
     end
   end
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -44,6 +44,7 @@ defmodule TransactionTest do
         half: 0.5,
         string: "A string",
         bool: true,
+        nilValue: nil,
         atom: :atom,
         pid: self(),
         ref: make_ref(),
@@ -199,6 +200,9 @@ defmodule TransactionTest do
     assert event[:tuple] == @bad
     assert event[:function] == @bad
     assert event[:struct] == @bad
+
+    # Don't report nil values
+    refute Map.has_key?(event, :nilValue)
 
     # Make sure it can serialize to JSON
     Jason.encode!(events)


### PR DESCRIPTION
The New Relic Browser agent now supports DT, and there are some incorrect assumptions in the agent about which attributes will be present in the payload.

This PR fixes those assumptions to match what actually happens - there's no "transaction" (`tx`) attribute.

A few more fixes are included:
* Properly encode two DT payload values as strings
* Match the latest expected DT behavior & always send the Span ID
* Match expected nil attribute value behavior - don't coerce nil values, instead exclude them