### PR TITLE
Add reporter fail to public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ def my_func() do
 
   rescue
     error ->
-      NewRelic.Transaction.Reporter.fail(%{
+      NewRelic.fail(%{
         kind: "#{__MODULE__}.process/1 failed",
         reason: inspect(error),
         stack: __STACKTRACE__

--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -171,6 +171,20 @@ defmodule NewRelic do
   defdelegate report_custom_event(type, attributes),
     to: NewRelic.Harvest.Collector.CustomEvent.Harvester
 
+  @doc """
+  Mark a ongoing transaction as failed and enrich with the error information
+  Expects a map with the following information %{kind: kind, reason: reason, stack: stack}
+
+  ```elixir
+  NewRelic.fail(%{
+    kind: "#{__MODULE__}.process/1 failed",
+    reason: inspect(error),
+    stack: __STACKTRACE__
+  })
+  ```
+  """
+  defdelegate fail(error), to: NewRelic.Transaction.Reporter
+
   @doc false
   defdelegate report_aggregate(meta, values), to: NewRelic.Aggregate.Reporter
 


### PR DESCRIPTION
Delegate the transaction fail on the public API and fix the reference on the doc.