### PR TITLE
Transaction error reporting fix

### DIFF
--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -19,9 +19,10 @@ defmodule NewRelic.Error.Reporter do
     {kind, exception, stacktrace} = parse_error_info(report[:error_info])
     process_name = parse_process_name(report[:registered_name], stacktrace)
 
-    NewRelic.Transaction.Reporter.set_transaction_error(report[:pid], %{
+    NewRelic.add_attributes(process: process_name)
+
+    NewRelic.Transaction.Reporter.fail(%{
       kind: kind,
-      process: process_name,
       reason: exception,
       stack: stacktrace
     })

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -96,12 +96,6 @@ defmodule NewRelic.Transaction.Reporter do
     end
   end
 
-  def set_transaction_error(pid, error) do
-    if tracking?(pid) do
-      AttrStore.add(__MODULE__, pid, transaction_error: {:error, error})
-    end
-  end
-
   def complete(pid, mode) do
     if tracking?(pid) do
       AttrStore.add(__MODULE__, pid, end_time_mono: System.monotonic_time())

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -82,6 +82,7 @@ defmodule OtherTransactionTest do
 
   @tag :capture_log
   test "Error in Other Transaction" do
+    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
     start_supervised({Task.Supervisor, name: TestSupervisor})
 
@@ -106,6 +107,11 @@ defmodule OtherTransactionTest do
 
     assert name =~ "OtherTransaction"
 
+    [[_, event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+
+    assert event[:error]
+
     TestHelper.pause_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
+    TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 end


### PR DESCRIPTION
This fix ensures that "Other" transactions properly account for an error by using the main error reporting function. Web transactions via Plug already did this.