### PR TITLE
Mix.Task instrumentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
   - mix deps.get
   - mix format --check-formatted
   - mix test
+  - mix instrumented_task.example_task

--- a/README.md
+++ b/README.md
@@ -105,23 +105,20 @@ defmodule MyExternalService do
 end
 ```
 
-#### `Mix.Task`
+#### Pre-Instrumented Modules
 
-To enable the agent during a `Mix.Task`, you simply need to start and stop it.
+* `NewRelic.Instrumented.Mix.Task` To enable the Agent and record a Transaction during a `Mix.Task`, simply `use NewRelic.Instrumented.Mix.Task`. This will ensure the agent is properly started, record the Transaction, and shut down.
 
 ```elixir
 defmodule Mix.Tasks.Example do
   use Mix.Task
+  use NewRelic.Instrumented.Mix.Task
 
   def run(args) do
-    Application.ensure_all_started(:new_relic_agent)
     # ...
-    Application.stop(:new_relic_agent)
   end
 end
 ```
-
-#### Pre-Instrumented Modules
 
 * `NewRelic.Instrumented.HTTPoison` Automatically wraps HTTP calls in a span, and adds an outbound header to track the request as part of a Distributed Trace.
 
@@ -135,11 +132,13 @@ HTTPoison.get("http://www.example.com")
 You may start an "Other" Transaction for non-HTTP related work. This could used be while consuming messages from a broker, for example.
 
 To start an other transaction:
+
 ```elixir
 NewRelic.start_transaction(category, name)
 ```
 
 And to stop the transaction within the same process:
+
 ```elixir
 NewRelic.stop_transaction()
 ```

--- a/examples/apps/instrumented_task/.formatter.exs
+++ b/examples/apps/instrumented_task/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/apps/instrumented_task/.gitignore
+++ b/examples/apps/instrumented_task/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+instrumented_task-*.tar
+

--- a/examples/apps/instrumented_task/README.md
+++ b/examples/apps/instrumented_task/README.md
@@ -1,0 +1,3 @@
+# InstrumentedTask
+
+Example of an instrumented `Mix.Task`

--- a/examples/apps/instrumented_task/lib/example_task.ex
+++ b/examples/apps/instrumented_task/lib/example_task.ex
@@ -1,0 +1,8 @@
+defmodule Mix.Tasks.InstrumentedTask.ExampleTask do
+  use Mix.Task
+  use NewRelic.Instrumented.Mix.Task
+
+  def run(_) do
+    IO.puts("Task exectued")
+  end
+end

--- a/examples/apps/instrumented_task/mix.exs
+++ b/examples/apps/instrumented_task/mix.exs
@@ -1,0 +1,29 @@
+defmodule InstrumentedTask.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :instrumented_task,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:new_relic_agent, path: "../../../"}
+    ]
+  end
+end

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -23,6 +23,10 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     end
   end
 
+  def ensure_initialized do
+    GenServer.call(__MODULE__, :ping)
+  end
+
   def agent_run_id, do: lookup(:agent_run_id)
   def trusted_account_key, do: lookup(:trusted_account_key)
   def account_id, do: lookup(:account_id)

--- a/lib/new_relic/instrumented/mix_task.ex
+++ b/lib/new_relic/instrumented/mix_task.ex
@@ -1,0 +1,36 @@
+defmodule NewRelic.Instrumented.Mix.Task do
+  defmacro __using__(_args) do
+    quote do
+      case Module.get_attribute(__MODULE__, :behaviour) do
+        [Mix.Task] ->
+          @before_compile NewRelic.Instrumented.Mix.Task
+
+        _ ->
+          require Logger
+
+          Logger.error(
+            "[New Relic] Unable to instrument #{inspect(__MODULE__)} since it isn't a Mix.Task"
+          )
+      end
+    end
+  end
+
+  defmacro __before_compile__(%{module: module}) do
+    Module.make_overridable(module, run: 1)
+
+    quote do
+      def run(args) do
+        Application.ensure_all_started(:new_relic_agent)
+        NewRelic.Harvest.Collector.AgentRun.ensure_initialized()
+
+        "Elixir.Mix.Tasks." <> task_name = Atom.to_string(__MODULE__)
+        NewRelic.start_transaction("Mix.Task", task_name)
+
+        super(args)
+
+        NewRelic.stop_transaction()
+        Application.stop(:new_relic_agent)
+      end
+    end
+  end
+end

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -80,6 +80,24 @@ defmodule OtherTransactionTest do
     TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
   end
 
+  test "Rename an Other transaction" do
+    TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
+
+    Task.async(fn ->
+      NewRelic.start_transaction("TransactionCategory", "MyTaskName")
+
+      NewRelic.set_transaction_name("DifferentCategory/DifferentName")
+
+      Process.sleep(15)
+    end)
+    |> Task.await()
+
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+    assert TestHelper.find_metric(metrics, "OtherTransaction/DifferentCategory/DifferentName")
+
+    TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
+  end
+
   @tag :capture_log
   test "Error in Other Transaction" do
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)


### PR DESCRIPTION
This PR adds a macro for easy instrumentation of a `Mix.Task`

It will:
* Start the agent
* Ensure it's booted
* Start a Transaction
* Stop the Transaction
* Send the data and stop the agent

Also makes sure there aren't any errors when the agent shuts down w/o having connected to New Relic's servers.