### PR TITLE
Handle traced function with ignored and assigned arg

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -229,6 +229,8 @@ defmodule NewRelic.Tracer.Macro do
   # Drop the de-structuring side of a pattern match
   def rewrite_call_term({:=, _, [left, right]}) do
     cond do
+      :__ignored__ == left -> right
+      :__ignored__ == right -> left
       is_variable?(right) -> right
       is_variable?(left) -> left
     end


### PR DESCRIPTION
Fixes a compile error when tracing a function that assigns a value to an ignored argument, like:

```elixir
def function(true = _ignored), do: true
```

fixes #227 