### PR TITLE
Fix tracer bug with struct literal and enforced_keys

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -223,6 +223,12 @@ defmodule NewRelic.Tracer.Macro do
     Macro.postwalk(args, &rewrite_call_term/1)
   end
 
+  # Unwrap Structs into Maps when reporting
+  # They can't always be re-referenced directly since they can have enforced_keys
+  def rewrite_call_term({:%, _, [{:__aliases__, _, _} = struct, {:%{}, line, members}]}) do
+    {:%{}, line, [{:__struct__, struct}] ++ members}
+  end
+
   # Strip default arguments
   def rewrite_call_term({:\\, _, [arg, _default]}), do: arg
 

--- a/test/tracer_macro_test.exs
+++ b/test/tracer_macro_test.exs
@@ -92,5 +92,19 @@ defmodule NewRelic.Tracer.MacroTest do
 
       assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
     end
+
+    test "Handle a struct with enforced_keys" do
+      ast =
+        quote do
+          [%NaiveDateTime{year: year}]
+        end
+
+      expected =
+        quote do
+          [%{__struct__: NaiveDateTime, year: year}]
+        end
+
+      assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
+    end
   end
 end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -47,6 +47,9 @@ defmodule TracerTest do
     def ignored(_ignored = :right), do: :right
     def ignored(_ignored), do: :ignored
 
+    @trace :naive
+    def naive(%NaiveDateTime{}), do: :naive
+
     @trace :error
     def error(exception) do
       raise exception
@@ -155,6 +158,20 @@ defmodule TracerTest do
 
     assert Enum.find(events, fn [_, event, _] ->
              event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.ignored/1" &&
+               event[:call_count] == 1
+           end)
+  end
+
+  test "Handle a struct argument with enforced_keys" do
+    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
+
+    assert Traced.naive(NaiveDateTime.utc_now()) == :naive
+
+    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
+    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+
+    assert Enum.find(events, fn [_, event, _] ->
+             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.naive/1" &&
                event[:call_count] == 1
            end)
   end


### PR DESCRIPTION
Fixes a tracer compilation issue when an argument is a matched struct with `enforced_keys`

fixes #229 