### PR TITLE
Fix bug when tracing special form argument

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -245,7 +245,8 @@ defmodule NewRelic.Tracer.Macro do
   # Replace ignored variables with an atom
   def rewrite_call_term({name, _, context} = term) when is_variable(name, context) do
     case Atom.to_string(name) do
-      "_" <> _rest -> :__ignored__
+      "__" <> _special_form -> term
+      "_" <> _ignored_var -> :__ignored__
       _ -> term
     end
   end


### PR DESCRIPTION
When rewriting traced functions, we need to differentiate between special forms (`__MODULE__`) and ignored variables (`_ignored`)

Fixes #234 