### PR TITLE
Fix tracer compile bug with struct referenced via module

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -213,8 +213,8 @@ defmodule NewRelic.Tracer.Macro do
 
   def build_function_args(args) when is_list(args), do: Enum.map(args, &build_function_args/1)
 
+  # Don't try to re-declare the default argument
   def build_function_args({:\\, _, [arg, _default]}),
-    # Don't try to re-declare the default argument
     do: arg
 
   def build_function_args(arg), do: arg
@@ -223,9 +223,10 @@ defmodule NewRelic.Tracer.Macro do
     Macro.postwalk(args, &rewrite_call_term/1)
   end
 
-  # Unwrap Structs into Maps when reporting
-  # They can't always be re-referenced directly since they can have enforced_keys
-  def rewrite_call_term({:%, _, [{:__aliases__, _, _} = struct, {:%{}, line, members}]}) do
+  # Unwrap Struct literals into a Map, they can't be re-referenced directly due to enforced_keys
+  @struct_keys [:__aliases__, :__MODULE__]
+  def rewrite_call_term({:%, line, [{key, _, _} = struct, {:%{}, _, members}]})
+      when key in @struct_keys do
     {:%{}, line, [{:__struct__, struct}] ++ members}
   end
 

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -60,7 +60,8 @@ defmodule TracerTest do
     def default_multiclause(:case_1), do: :case_1_return
     def default_multiclause(value), do: value
 
-    defstruct [:key]
+    @enforce_keys [:key, :second_key]
+    defstruct [:key, :second_key]
 
     @trace :mod
     def mod(%__MODULE__{key: val}), do: val
@@ -199,7 +200,7 @@ defmodule TracerTest do
   test "Handle module pattern match" do
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
 
-    assert Traced.mod(%Traced{key: :val}) == :val
+    assert Traced.mod(%Traced{key: :val, second_key: :bla}) == :val
 
     TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)


### PR DESCRIPTION
The previous fix for tracers on functions with pattern matched structs needs to be extended for structs that match on `%__MODULE__{}` as the struct name vs the literal module name.

Fixes #236 