### PR TITLE
Fix regression with Transaction error attribute

### DIFF
--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -21,7 +21,7 @@ defmodule NewRelic.Error.Reporter do
 
     NewRelic.add_attributes(process: process_name)
 
-    NewRelic.Transaction.Reporter.fail(%{
+    NewRelic.Transaction.Reporter.error(report[:pid], %{
       kind: kind,
       reason: exception,
       stack: stacktrace

--- a/lib/new_relic/transaction.ex
+++ b/lib/new_relic/transaction.ex
@@ -62,7 +62,8 @@ defmodule NewRelic.Transaction do
   def handle_errors(conn, error) do
     NewRelic.DistributedTrace.Tracker.cleanup(self())
     NewRelic.Transaction.Plug.add_stop_attrs(conn)
-    NewRelic.Transaction.Reporter.fail(error)
+    NewRelic.Transaction.Reporter.error(self(), error)
+    NewRelic.Transaction.Reporter.fail(self(), error)
     NewRelic.Transaction.Reporter.complete(self(), :async)
   end
 

--- a/lib/new_relic/transaction/monitor.ex
+++ b/lib/new_relic/transaction/monitor.ex
@@ -90,7 +90,11 @@ defmodule NewRelic.Transaction.Monitor do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+  def handle_info({:DOWN, _ref, :process, pid, down_reason}, state) do
+    with {reason, stack} when reason != :shutdown <- down_reason do
+      Transaction.Reporter.fail(pid, %{kind: :exit, reason: reason, stack: stack})
+    end
+
     Transaction.Reporter.ensure_purge(pid)
     Transaction.Reporter.complete(pid, :async)
     DistributedTrace.Tracker.cleanup(pid)

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -68,18 +68,23 @@ defmodule NewRelic.Transaction.Reporter do
     end
   end
 
-  def fail(%{kind: kind, reason: reason, stack: stack} = error) do
-    if tracking?(self()) do
+  def error(pid, error) do
+    if tracking?(pid) do
+      AttrStore.add(__MODULE__, pid, transaction_error: {:error, error})
+    end
+  end
+
+  def fail(pid, %{kind: kind, reason: reason, stack: stack} = error) do
+    if tracking?(pid) do
       if NewRelic.Config.feature?(:error_collector) do
-        AttrStore.add(__MODULE__, self(),
+        AttrStore.add(__MODULE__, pid,
           error: true,
-          transaction_error: {:error, error},
           error_kind: kind,
           error_reason: inspect(reason),
           error_stack: inspect(stack)
         )
       else
-        AttrStore.add(__MODULE__, self(), error: true)
+        AttrStore.add(__MODULE__, pid, error: true)
       end
     end
   end

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -192,6 +192,7 @@ defmodule TransactionErrorEventTest do
     TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
+    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
     {:ok, _sup} = Task.Supervisor.start_link(name: TestSup)
 
     response = TestHelper.request(TestPlugApp, conn(:get, "/caught/error"))
@@ -216,11 +217,15 @@ defmodule TransactionErrorEventTest do
     traces = TestHelper.gather_harvest(Collector.TransactionErrorEvent.Harvester)
     assert length(traces) == 1
 
+    [[_, event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+    refute event[:error]
+
     Process.sleep(50)
     Logger.add_backend(:console)
     TestHelper.pause_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
     TestHelper.pause_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
     TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
+    TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 
   defmodule CustomError do


### PR DESCRIPTION
In the 1.18 release (https://github.com/newrelic/elixir_agent/pull/220) there was a regression in the Transaction `error` attribute handling which started putting the attribute on Transactions in cases that previously didn't have the attribute.

This PR fixes that by splitting the handling of an "error" happening and the whole Transaction experiencing "failure". Only in the "failure" state should the Transaction get the `error = true` attribute