### PR TITLE
Handle any version of function level clauses in tracer

### DIFF
--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -72,6 +72,15 @@ defmodule TracerTest do
     rescue
       error -> error
     end
+
+    @trace :afterer
+    def afterer() do
+      :do_something
+    rescue
+      error -> error
+    after
+      :do_after
+    end
   end
 
   test "function that has error" do


### PR DESCRIPTION
There can be a number of function level clauses (`rescue`, `after`). If there are any besides just a `do`, we can't `@trace` the function. This PR updates the logic that catches & warns for that situation...

closes #254 