### PR TITLE
headers needs to be reassigned to include the NewRelic.distributed_trace_headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ defmodule MyExternalService do
   @trace {:request, category: :external}
   def request(method, url, headers) do
     NewRelic.set_span(:http, url: url, method: method, component: "HttpClient")
-    headers ++ NewRelic.distributed_trace_headers(:http)
+    headers = headers ++ NewRelic.distributed_trace_headers(:http)
     HttpClient.request(method, url, headers)
   end
 end


### PR DESCRIPTION
Just a small documentation update for clarity. As written the NewRelic headers are not passed to the `HttpClient`.