### PR TITLE
Add Ecto TDS adapter support

### DIFF
--- a/examples/apps/ecto_example/config/config.exs
+++ b/examples/apps/ecto_example/config/config.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :ecto_example,
   http_port: 4001,
-  ecto_repos: [EctoExample.PostgresRepo, EctoExample.MySQLRepo]
+  ecto_repos: [EctoExample.PostgresRepo, EctoExample.MySQLRepo, EctoExample.MsSQLRepo]
 
 config :ecto_example, EctoExample.PostgresRepo,
   database: "example_db",
@@ -17,3 +17,10 @@ config :ecto_example, EctoExample.MySQLRepo,
   password: "password",
   hostname: "localhost",
   port: 3306
+
+config :ecto_example, EctoExample.MsSQLRepo,
+  database: "example_db",
+  username: "root",
+  password: "password",
+  hostname: "localhost",
+  port: 1433

--- a/examples/apps/ecto_example/lib/ecto_example/database.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/database.ex
@@ -8,6 +8,7 @@ defmodule EctoExample.Database do
   def init(:ok) do
     start_and_migrate(EctoExample.PostgresRepo, Ecto.Adapters.Postgres)
     start_and_migrate(EctoExample.MySQLRepo, Ecto.Adapters.MyXQL)
+    start_and_migrate(EctoExample.MsSQLRepo, Ecto.Adapters.TDS)
 
     {:ok, %{}}
   end

--- a/examples/apps/ecto_example/lib/ecto_example/mssql_repo.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/mssql_repo.ex
@@ -1,0 +1,6 @@
+defmodule EctoExample.MsSQLRepo do
+  use Ecto.Repo,
+    otp_app: :ecto_example,
+    adapter: Ecto.Adapters.Tds
+end
+

--- a/examples/apps/ecto_example/lib/ecto_example/router.ex
+++ b/examples/apps/ecto_example/lib/ecto_example/router.ex
@@ -8,15 +8,19 @@ defmodule EctoExample.Router do
   get "/hello" do
     error_query(EctoExample.PostgresRepo)
     error_query(EctoExample.MySQLRepo)
+    error_query(EctoExample.MsSQLRepo)
 
     count_query(EctoExample.PostgresRepo)
     count_query(EctoExample.MySQLRepo)
+    count_query(EctoExample.MsSQLRepo)
 
     stream_query(EctoExample.PostgresRepo)
     stream_query(EctoExample.MySQLRepo)
+    stream_query(EctoExample.MsSQLRepo)
 
     delete_query(EctoExample.PostgresRepo)
     delete_query(EctoExample.MySQLRepo)
+    delete_query(EctoExample.MsSQLRepo)
 
     send_resp(conn, 200, Jason.encode!(%{hello: "world"}))
   end

--- a/examples/apps/ecto_example/test/ecto_example_test.exs
+++ b/examples/apps/ecto_example/test/ecto_example_test.exs
@@ -27,6 +27,12 @@ defmodule EctoExampleTest do
 
     assert TestHelper.find_metric(
              metrics,
+             "Datastore/statement/MsSQL/counts/insert",
+             3
+           )
+
+    assert TestHelper.find_metric(
+             metrics,
              {"Datastore/statement/Postgres/counts/insert", "WebTransaction/Plug/GET//hello"},
              3
            )
@@ -34,6 +40,12 @@ defmodule EctoExampleTest do
     assert TestHelper.find_metric(
              metrics,
              {"Datastore/statement/MySQL/counts/insert", "WebTransaction/Plug/GET//hello"},
+             3
+           )
+
+    assert TestHelper.find_metric(
+             metrics,
+             {"Datastore/statement/MsSQL/counts/insert", "WebTransaction/Plug/GET//hello"},
              3
            )
 
@@ -51,12 +63,23 @@ defmodule EctoExampleTest do
 
     assert TestHelper.find_metric(
              metrics,
+             "Datastore/statement/MsSQL/counts/select",
+             5
+           )
+
+    assert TestHelper.find_metric(
+             metrics,
              "Datastore/statement/Postgres/counts/delete"
            )
 
     assert TestHelper.find_metric(
              metrics,
              "Datastore/statement/MySQL/counts/delete"
+           )
+
+    assert TestHelper.find_metric(
+             metrics,
+             "Datastore/statement/MsSQL/counts/delete"
            )
 
     assert TestHelper.find_metric(
@@ -68,6 +91,12 @@ defmodule EctoExampleTest do
     assert TestHelper.find_metric(
              metrics,
              "Datastore/Postgres/allWeb",
+             12
+           )
+
+    assert TestHelper.find_metric(
+             metrics,
+             "Datastore/MsSQL/allWeb",
              12
            )
 

--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -74,7 +74,7 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
         _ -> {"other", "other"}
       end
 
-    {"TDS", table, operation}
+    {"MSSQL", table, operation}
   end
 
   def parse(%{result: {:ok, %{__struct__: Postgrex.Cursor}}}), do: :ignore


### PR DESCRIPTION
Just a simple implementation copied from myxql support. I did not see how can one achieve this directly in my app. Perhaps using protocol to define behaviour based on the struct should be used here but it requires some refactoring that are much bigger than my changes.

**Tests are required!**
I did not see any tests that validated the metadata parsing.

**Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.**
Since the TDS adapter is officially documented in Ecto, I think that the New Relic agent should support it. Currently is raise an error on the handler and stop instrumenting.