### PR TITLE
Fix memory bloat in process dictionary

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -202,6 +202,7 @@ defmodule NewRelic.Tracer.Macro do
         Process.put({:nr_duration_acc, parent_ref}, duration_acc + duration_ms)
 
         child_duration_ms = Process.delete({:nr_duration_acc, current_ref}) || 0
+        if parent_ref == :root, do: Process.delete({:nr_duration_acc, parent_ref})
 
         Tracer.Report.call(
           {unquote(module), unquote(function), unquote(build_call_args(args))},

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -201,7 +201,7 @@ defmodule NewRelic.Tracer.Macro do
         duration_acc = Process.get({:nr_duration_acc, parent_ref}, 0)
         Process.put({:nr_duration_acc, parent_ref}, duration_acc + duration_ms)
 
-        child_duration_ms = Process.get({:nr_duration_acc, current_ref}, 0)
+        child_duration_ms = Process.delete({:nr_duration_acc, current_ref}) || 0
 
         Tracer.Report.call(
           {unquote(module), unquote(function), unquote(build_call_args(args))},


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

## What I did
I think New Relic agent keeps unnecessary data in the process dictionary.
It causes memory bloat on the process that lives for a long time.

This PR changed to remove the data after submitting tracing information.

## Background
I have developed an Elixir application with [Broadway](https://github.com/dashbitco/broadway).
The application pulls data from a message bus and processes them.

I noticed the Erlang VM memory usage had been increasing over a few days.
Then, I attached the application and investigated the memory usage of the processes.

This snippets shows the TOP 64 processes sort by memory usage.
```elixir
mems =
  for pid <- :erlang.processes() do
    {:erlang.process_info(pid, :memory), pid}
  end
tops = mems |> Enum.sort() |> Enum.reverse() |> Enum.take(64)
res = tops |> Enum.map(fn {_, pid} ->
  {_, name} = Process.info(pid, :registered_name)
  {_, mem} = Process.info(pid, :memory)
  {name, mem / 1024 / 1024}
end)
```
Most of them are Broadway worker processes that live for a long time.
Theses stores `{{:nr_duration_acc, ref}, duration}` in its process dictionary.

```
[
    registered_name: Consumer.Broadway.Processor_default_59,
    current_function: {:gen_server, :loop, 7},
    initial_call: {:proc_lib, :init_p, 5},
    status: :waiting,
    message_queue_len: 0,
    links: [#PID<0.4418.0>],
    dictionary: [
      {{:nr_duration_acc, #Reference<0.2303704252.2010906626.48229>}, 13},
      {{:nr_duration_acc, #Reference<0.2303704252.2022965251.27882>}, 8},
      {{:nr_duration_acc, #Reference<0.2303704252.2063859716.187956>}, 15},
      {{:nr_duration_acc, #Reference<0.2303704252.2019557379.182415>}, 13},
      {{:nr_duration_acc, #Reference<0.2303704252.2028994563.114452>}, 16},
      {{:nr_duration_acc, #Reference<0.2303704252.2051801091.261355>}, 14},
      {{:nr_duration_acc, #Reference<0.2303704252.2009071619.118686>}, 17},
      {{:nr_duration_acc, #Reference<0.2303704252.2016411653.29201>}, 18},
      {{:nr_duration_acc, #Reference<0.2303704252.2022965253.63354>}, 6},
      {{:nr_duration_acc, #Reference<0.2303704252.2001993730.239993>}, 18},
      {{:nr_duration_acc, #Reference<0.2303704252.2009071623.117337>}, 9},
      {{:nr_duration_acc, #Reference<0.2303704252.2026635269.108922>}, 13},
      {{:nr_duration_acc, #Reference<0.2303704252.2004090886.99409>}, 15},
      {{:nr_duration_acc, #Reference<0.2303704252.2028470276.102421>}, 7},
      {{:nr_duration_acc, #Reference<0.2303704252.2060189698.251572>}, 7},
      {{:nr_duration_acc, #Reference<0.2303704252.2039480322.113386>}, 15},
      {{:nr_duration_acc, #Reference<0.2303704252.2014314502.102966>}, 9},
      {{:nr_duration_acc, #Reference<0.2303704252.2049966085.26415>}, 7},
      {{:nr_duration_acc, #Reference<0.2303704252.2006712328.29925>}, 17},
      {{:nr_duration_acc, #Reference<0.2303704252.2048393219.157950>}, 13},
      {{:nr_duration_acc, #Reference<0.2303704252.2039742468.137920>}, 18},
      {{:nr_duration_acc, #Reference<0.2303704252.2026373124.247095>}, 16},
      {{:nr_duration_acc, #Reference<0.2303704252.2008023043.45867>}, 7},
      {{:nr_duration_acc, #Reference<0.2303704252.2045509637.12882>}, 34},
      {{:nr_duration_acc, #Reference<0.2303704252.2008285191.127338>}, 18},
      {{:nr_duration_acc, #Reference<0.2303704252.2039480322.109467>}, 24},
      {{:nr_duration_acc, #Reference<0.2303704252.2087976961.205064>}, 7},
      {{:nr_duration_acc, #Reference<0.2303704252.1998323715.211331>}, 28},
      {{:nr_duration_acc, #Reference<0.2303704252.2005139463.194920>}, 13},
      {{:nr_duration_acc, #Reference<0.2303704252.2022178821.85200>}, 28},
      {{:nr_duration_acc, #Reference<0.2303704252.2059403268.221082>}, 19},
      {{:nr_duration_acc, ...}, 21},
      {{...}, ...},
      {...},
      ...
    ],
  ],
```

I'm not sure about Broadway internal implementation but I guess it works forever unless something crashes.
Then, I decided to modify New Relic implementation.

## Testing
I tested this change in our application.
I confirmed that it sends metrics to New Relic.