### PR TITLE
Add NewRelic.transaction macro

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -91,6 +91,22 @@ defmodule NewRelic do
   defdelegate stop_transaction(), to: NewRelic.Transaction
 
   @doc """
+  Start a new "Other" transaction and stop the transaction after execution of the given block.
+  The return value of the block is returned.
+  """
+  defmacro transaction(category, name, do: block) do
+    quote do
+      NewRelic.start_transaction(unquote(category), unquote(name))
+
+      res = unquote(block)
+
+      NewRelic.stop_transaction()
+
+      res
+    end
+  end
+
+  @doc """
   Call within a transaction to prevent it from reporting.
 
   ```elixir

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -1,5 +1,6 @@
 defmodule OtherTransactionTest do
   use ExUnit.Case
+  require NewRelic
   alias NewRelic.Harvest.Collector
 
   setup do
@@ -112,6 +113,19 @@ defmodule OtherTransactionTest do
     Task.await(task)
 
     refute NewRelic.DistributedTrace.Tracker.fetch(task.pid)
+  end
+
+  test "Returns block result" do
+    task =
+      Task.async(fn ->
+        NewRelic.transaction "TransactionCategory", "WithBlock" do
+          Process.sleep(100)
+
+          :test_value
+        end
+      end)
+
+    assert :test_value == Task.await(task)
   end
 
   @tag :capture_log


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

## What I did
I added a macro to support "Other" transaction.
I miss often calling `NewRelic.stop_transaction/0` function.
This helper macro will avoid it.