### PR TITLE
Properly process custom event attributes

### DIFF
--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -30,7 +30,7 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
     do:
       %Event{
         type: type,
-        attributes: annotate(attributes),
+        attributes: process(attributes),
         timestamp: System.system_time(:millisecond) / 1_000
       }
       |> report_custom_event
@@ -73,8 +73,10 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
 
   # Helpers
 
-  def annotate(event) do
+  def process(event) do
     event
+    |> NewRelic.Util.coerce_attributes()
+    |> Map.new()
     |> Map.merge(NewRelic.Config.automatic_attributes())
   end
 

--- a/test/aggregate_test.exs
+++ b/test/aggregate_test.exs
@@ -44,7 +44,7 @@ defmodule AggregateTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:meta] == "data" && event[:duration] == 15
+             event[:category] == "Metric" && event[:meta] == "data" && event[:duration] == 15
            end)
   end
 end

--- a/test/sampler_test.exs
+++ b/test/sampler_test.exs
@@ -31,7 +31,7 @@ defmodule SamplerTest do
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :BeamStat && event[:reductions] > 0 && event[:process_count] > 0
+             event[:category] == "BeamStat" && event[:reductions] > 0 && event[:process_count] > 0
            end)
 
     [%{name: "Memory/Physical"}, [_, mb, _, _, _, _]] =
@@ -54,7 +54,7 @@ defmodule SamplerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :ProcessSample && event[:name] == "SamplerTest.TestProcess" &&
+             event[:category] == "ProcessSample" && event[:name] == "SamplerTest.TestProcess" &&
                event[:message_queue_length] == 0
            end)
   end
@@ -75,7 +75,7 @@ defmodule SamplerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :ProcessSample && event[:name] =~ "PID" &&
+             event[:category] == "ProcessSample" && event[:name] =~ "PID" &&
                event[:message_queue_length] == 0
            end)
   end
@@ -90,7 +90,7 @@ defmodule SamplerTest do
 
     [_, %{reductions: first_reductions}, _] =
       Enum.find(events, fn [_, event, _] ->
-        event[:category] == :ProcessSample && event[:name] == "SamplerTest.TestProcess"
+        event[:category] == "ProcessSample" && event[:name] == "SamplerTest.TestProcess"
       end)
 
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
@@ -103,7 +103,7 @@ defmodule SamplerTest do
 
     [_, %{reductions: second_reductions}, _] =
       Enum.find(events, fn [_, event, _] ->
-        event[:category] == :ProcessSample && event[:name] == "SamplerTest.TestProcess"
+        event[:category] == "ProcessSample" && event[:name] == "SamplerTest.TestProcess"
       end)
 
     assert second_reductions > first_reductions
@@ -142,7 +142,7 @@ defmodule SamplerTest do
       events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
       assert Enum.find(events, fn [_, event, _] ->
-               event[:category] == :EtsStat && event[:table_name] == ":test_table" &&
+               event[:category] == "EtsStat" && event[:table_name] == ":test_table" &&
                  event[:size] == 510
              end)
     end

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -94,7 +94,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.error/1" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.error/1" &&
                event[:call_count] == 1
            end)
   end
@@ -110,7 +110,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric &&
+             event[:category] == "Metric" &&
                event[:mfa] == "TracerTest.Traced.default_multiclause/1" && event[:call_count] == 3
            end)
   end
@@ -124,7 +124,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.fun/0" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.fun/0" &&
                event[:call_count] == 1
            end)
   end
@@ -138,7 +138,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.foo:bar/0" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.foo:bar/0" &&
                event[:call_count] == 1
            end)
   end
@@ -153,8 +153,8 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.query/0" &&
-               event[:metric_category] == :external && event[:call_count] == 2
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.query/0" &&
+               event[:metric_category] == "external" && event[:call_count] == 2
            end)
   end
 
@@ -172,7 +172,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.ignored/1" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.ignored/1" &&
                event[:call_count] == 1
            end)
   end
@@ -186,7 +186,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.naive/1" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.naive/1" &&
                event[:call_count] == 1
            end)
   end
@@ -201,7 +201,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.ignored/1" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.ignored/1" &&
                event[:call_count] == 2
            end)
   end
@@ -215,7 +215,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.mod/1"
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.mod/1"
            end)
   end
 
@@ -228,7 +228,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.guard/1" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.guard/1" &&
                event[:call_count] == 1
            end)
   end
@@ -243,7 +243,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric &&
+             event[:category] == "Metric" &&
                event[:mfa] == "TracerTest.Traced.multi:multiple_function_heads/2" &&
                event[:call_count] == 3
            end)
@@ -258,7 +258,7 @@ defmodule TracerTest do
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:mfa] == "TracerTest.Traced.priv/0" &&
+             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.priv/0" &&
                event[:call_count] == 1
            end)
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -297,12 +297,12 @@ defmodule TransactionTest do
            end)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:name] == :FunctionTrace &&
+             event[:category] == "Metric" && event[:name] == "FunctionTrace" &&
                event[:mfa] == "TransactionTest.ExternalService.query/1" && event[:call_count] == 2
            end)
 
     assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == :Metric && event[:type] == :Transaction &&
+             event[:category] == "Metric" && event[:type] == "Transaction" &&
                event[:name] == "/service" && event[:call_count] == 1
            end)
   end


### PR DESCRIPTION
This PR runs Custom Events through the same attribute processing step as built-in events so that bad values don't cause errors.

Fixes #266 