### PR TITLE
Avoid @trace warning when unnecessary

### DIFF
--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -81,6 +81,12 @@ defmodule TracerTest do
     after
       :do_after
     end
+
+    def non_traced_with_rescue() do
+      :do_somthing
+    rescue
+      error -> error
+    end
   end
 
   test "function that has error" do


### PR DESCRIPTION
Don't warn about using `@trace` on function with `rescue`, `else`, etc. if there is no `@trace` attribute set.

Running `mix test` before:
![image](https://user-images.githubusercontent.com/151912/92886035-9afc3f80-f413-11ea-9808-fa147fb3543e.png)
after:
![image](https://user-images.githubusercontent.com/151912/92886087-a8192e80-f413-11ea-911b-9e2d780ee1a3.png)

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
