### PR TITLE
Handle missing tracestate sampled value

### DIFF
--- a/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
+++ b/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
@@ -131,6 +131,8 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
            priority,
            timestamp
          ] <- String.split(value, "-"),
+         {sampled, priority} <-
+           decode_sampled_priority(sampled, priority),
          [
            trusted_account_key,
            _
@@ -146,14 +148,15 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
             app_id: app_id,
             span_id: span_id,
             transaction_id: transaction_id,
-            sampled: sampled |> decode_sampled(),
-            priority: priority |> decode_priority(),
+            sampled: sampled,
+            priority: priority,
             timestamp: timestamp |> String.to_integer()
           }
         }
       ]
     else
       _ ->
+        NewRelic.report_metric(:supportability, [:trace_context, :tracestate, :invalid])
         NewRelic.log(:debug, "Bad W3C NR tracestate: `#{key}`: `#{value}`")
         []
     end
@@ -187,6 +190,14 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
   defp encode_type("App"), do: "0"
   defp encode_type("Browser"), do: "1"
   defp encode_type("Mobile"), do: "2"
+
+  defp decode_sampled_priority("", ""), do: {nil, nil}
+  defp decode_sampled_priority("", _), do: :invalid
+  defp decode_sampled_priority(_, ""), do: :invalid
+
+  defp decode_sampled_priority(sampled, priority) do
+    {decode_sampled(sampled), decode_priority(priority)}
+  end
 
   defp decode_priority(""), do: nil
   defp decode_priority(priority), do: String.to_float(priority)

--- a/lib/new_relic/metric/metric_data.ex
+++ b/lib/new_relic/metric/metric_data.ex
@@ -488,6 +488,12 @@ defmodule NewRelic.Metric.MetricData do
       call_count: 1
     }
 
+  def transform(:supportability, [:trace_context, :tracestate, :invalid]),
+    do: %Metric{
+      name: :"Supportability/TraceContext/TraceState/Parse/Exception",
+      call_count: 1
+    }
+
   def transform(:supportability, [:trace_context, :traceparent, :invalid]),
     do: %Metric{
       name: :"Supportability/TraceContext/TraceParent/Parse/Exception",

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -7,6 +7,7 @@ defmodule TransactionTraceTest do
   alias NewRelic.Transaction.Trace
 
   setup do
+    send(NewRelic.DistributedTrace.BackoffSampler, :reset)
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.TransactionTrace.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.SpanEvent.HarvestCycle)


### PR DESCRIPTION
If a `tracestate` reaches us with a missing sampled flag but it does have a priority, we need to make sure we generate a new sampling decision.