### PR TITLE
Log harvest seen

### DIFF
--- a/lib/new_relic/harvest/collector/error_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/error_trace/harvester.ex
@@ -60,24 +60,43 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
 
   # Helpers
 
-  def store_error(%{error_traces_seen: seen} = state, _trace) when seen >= 20, do: state
+  @reservoir_size 20
 
-  def store_error(state, trace),
-    do: %{
+  def store_error(%{error_traces_seen: seen} = state, _trace)
+      when seen >= @reservoir_size do
+    %{
+      state
+      | error_traces_seen: state.error_traces_seen + 1
+    }
+  end
+
+  def store_error(state, trace) do
+    %{
       state
       | error_traces_seen: state.error_traces_seen + 1,
         error_traces: [trace | state.error_traces]
     }
+  end
 
   def send_harvest(state) do
     errors = build_payload(state)
     Collector.Protocol.error([Collector.AgentRun.agent_run_id(), errors])
-    log_harvest(length(errors))
+    log_harvest(length(errors), state.error_traces_seen)
   end
 
-  def log_harvest(harvest_size) do
+  def log_harvest(harvest_size, events_seen) do
     NewRelic.report_metric({:supportability, "ErrorData"}, harvest_size: harvest_size)
-    NewRelic.log(:debug, "Completed Error Trace harvest - size: #{harvest_size}")
+
+    NewRelic.report_metric({:supportability, "ErrorData"},
+      events_seen: events_seen,
+      reservoir_size: @reservoir_size
+    )
+
+    NewRelic.log(
+      :debug,
+      "Completed Error Trace harvest - " <>
+        "size: #{harvest_size}, seen: #{events_seen}, max: #{@reservoir_size}"
+    )
   end
 
   def build_payload(state), do: state.error_traces |> Enum.uniq() |> Trace.format_errors()

--- a/lib/new_relic/harvest/collector/metric_data.ex
+++ b/lib/new_relic/harvest/collector/metric_data.ex
@@ -421,14 +421,22 @@ defmodule NewRelic.Harvest.Collector.MetricData do
       }
     ]
 
-  def transform({:supportability, harvester}, reservoir_size: reservoir_size),
-    do: [
-      %Metric{
-        name: join(["Supportability/EventHarvest", harvester, "HarvestLimit"]),
-        call_count: 1,
-        total_call_time: reservoir_size
-      }
-    ]
+  def transform({:supportability, harvester},
+        events_seen: events_seen,
+        reservoir_size: reservoir_size
+      ),
+      do: [
+        %Metric{
+          name: join(["Supportability/Elixir/Collector/HarvestSeen", harvester]),
+          call_count: 1,
+          total_call_time: events_seen
+        },
+        %Metric{
+          name: join(["Supportability/EventHarvest", harvester, "HarvestLimit"]),
+          call_count: 1,
+          total_call_time: reservoir_size
+        }
+      ]
 
   def transform({:supportability, harvester}, harvest_size: harvest_size),
     do: [

--- a/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
@@ -76,12 +76,17 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
   def send_harvest(state) do
     events = build_payload(state)
     Collector.Protocol.error_event([Collector.AgentRun.agent_run_id(), state.sampling, events])
-    log_harvest(length(events))
+    log_harvest(length(events), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size) do
+  def log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "ErrorEventData"}, harvest_size: harvest_size)
-    NewRelic.log(:debug, "Completed Error Event harvest - size: #{harvest_size}")
+
+    NewRelic.log(
+      :debug,
+      "Completed TransactionError Event harvest - " <>
+        "size: #{harvest_size}, seen: #{events_seen}, max: #{reservoir_size}"
+    )
   end
 
   def build_payload(state), do: Event.format_events(state.error_events)

--- a/lib/new_relic/harvest/collector/transaction_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_event/harvester.ex
@@ -82,13 +82,22 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
       events
     ])
 
-    log_harvest(length(events), state.sampling.reservoir_size)
+    log_harvest(length(events), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size, reservoir_size) do
+  def log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "AnalyticEventData"}, harvest_size: harvest_size)
-    NewRelic.report_metric({:supportability, "AnalyticEventData"}, reservoir_size: reservoir_size)
-    NewRelic.log(:debug, "Completed Transaction Event harvest - size: #{harvest_size}")
+
+    NewRelic.report_metric({:supportability, "AnalyticEventData"},
+      events_seen: events_seen,
+      reservoir_size: reservoir_size
+    )
+
+    NewRelic.log(
+      :debug,
+      "Completed Transaction Event harvest - " <>
+        "size: #{harvest_size}, seen: #{events_seen}, max: #{reservoir_size}"
+    )
   end
 
   def build_payload(state) do


### PR DESCRIPTION
This PR extends the logs to include how many events were "seen", not just sent. Also sends some supportability metrics with the same information.