### PR TITLE
Stop reporting aggregate events for Transaction

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -25,7 +25,6 @@ defmodule NewRelic.Transaction.Complete do
     report_transaction_metric(tx_attrs)
     report_queue_time_metric(tx_attrs)
     report_transaction_metrics(tx_attrs, tx_metrics)
-    report_aggregate(tx_attrs)
     report_caller_metric(tx_attrs)
     report_apdex_metric(apdex)
     report_span_events(span_events)
@@ -509,22 +508,6 @@ defmodule NewRelic.Transaction.Complete do
           process: error[:process],
           stacktrace: Enum.join(exception_stacktrace, "\n")
         })
-    })
-  end
-
-  defp report_aggregate(%{transactionType: :Other} = tx) do
-    NewRelic.report_aggregate(%{type: :OtherTransaction, name: tx[:name]}, %{
-      duration_us: tx.duration_us,
-      duration_ms: tx.duration_ms,
-      call_count: 1
-    })
-  end
-
-  defp report_aggregate(tx) do
-    NewRelic.report_aggregate(%{type: :Transaction, name: tx[:name]}, %{
-      duration_us: tx.duration_us,
-      duration_ms: tx.duration_ms,
-      call_count: 1
     })
   end
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -300,11 +300,6 @@ defmodule TransactionTest do
              event[:category] == "Metric" && event[:name] == "FunctionTrace" &&
                event[:mfa] == "TransactionTest.ExternalService.query/1" && event[:call_count] == 2
            end)
-
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:type] == "Transaction" &&
-               event[:name] == "/service" && event[:call_count] == 1
-           end)
   end
 
   test "Track attrs inside proccesses spawned by the transaction" do


### PR DESCRIPTION
This PR removes the reporting of "`ElixirAggregate`" custom events that specifically track `Transactions`.

This behavior is a left-over from a very early version of the agent, and is redundant. The equivalent data is reported directly as `Transaction` events.