### PR TITLE
Stop reporting aggregate for FunctionTrace

### DIFF
--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -84,15 +84,6 @@ defmodule NewRelic.Tracer.Report do
       "external.#{function_name}.duration_ms": duration_ms
     )
 
-    NewRelic.report_aggregate(
-      %{
-        name: :FunctionTrace,
-        mfa: function_arity_name,
-        metric_category: :external
-      },
-      %{duration_ms: duration_ms, call_count: 1}
-    )
-
     Transaction.Reporter.track_metric({:external, duration_s})
 
     case span_attrs do
@@ -152,11 +143,6 @@ defmodule NewRelic.Tracer.Report do
       edge: [span: id, parent: parent_id],
       category: "generic",
       attributes: Map.put(NewRelic.DistributedTrace.get_span_attrs(), :args, args)
-    )
-
-    NewRelic.report_aggregate(
-      %{name: :FunctionTrace, mfa: function_name},
-      %{duration_ms: duration_ms, call_count: 1}
     )
 
     NewRelic.report_metric(

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -83,79 +83,57 @@ defmodule TracerTest do
     end
   end
 
-  test "function that has error" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
+  setup do
+    TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
 
+    on_exit(fn ->
+      TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
+    end)
+  end
+
+  test "function that has error" do
     assert_raise(RuntimeError, fn ->
       Traced.error(RuntimeError)
     end)
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.error/1" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.error/1")
   end
 
   test "function with function head" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert :default_val == Traced.default_multiclause()
     assert :case_1_return == Traced.default_multiclause(:case_1)
     assert :regular_call == Traced.default_multiclause(:regular_call)
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" &&
-               event[:mfa] == "TracerTest.Traced.default_multiclause/1" && event[:call_count] == 3
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.default_multiclause/1", 3)
   end
 
   test "Basic traced function" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     Traced.fun()
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.fun/0" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.fun/0")
   end
 
   test "Trace function with additional name" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     Traced.foo()
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.foo:bar/0" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.foo:bar/0")
   end
 
-  test "Trace function with category" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
+  test "Trace categorized as External" do
     Traced.query()
     Traced.query()
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.query/0" &&
-               event[:metric_category] == "external" && event[:call_count] == 2
-           end)
+    assert TestHelper.find_metric(metrics, "External/TracerTest.Traced.query/all", 2)
   end
 
   test "Default arguments still work as expected" do
@@ -164,108 +142,69 @@ defmodule TracerTest do
   end
 
   test "Don't warn when tracing with an ignored arg" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.ignored(:arg) == :ignored
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.ignored/1" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.ignored/1")
   end
 
   test "Handle a struct argument with enforced_keys" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.naive(NaiveDateTime.utc_now()) == :naive
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.naive/1" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.naive/1")
   end
 
   test "Handle an assigned & ignored pattern match" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.ignored(:left) == :left
     assert Traced.ignored(:right) == :right
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.ignored/1" &&
-               event[:call_count] == 2
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.ignored/1", 2)
   end
 
   test "Handle module pattern match" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.mod(%Traced{key: :val, second_key: :bla}) == :val
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.mod/1"
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.mod/1")
   end
 
   test "Trace a function with a guard" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.guard(:foo) == :foo
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.guard/1" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.guard/1")
   end
 
   test "Trace multiple function heads" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.multi(1, 2) == {10, 2}
     assert Traced.multi(2, 2) == {20, 2}
     assert Traced.multi(4, 2) == {4, 2}
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" &&
-               event[:mfa] == "TracerTest.Traced.multi:multiple_function_heads/2" &&
-               event[:call_count] == 3
-           end)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
+
+    assert TestHelper.find_metric(
+             metrics,
+             "Function/TracerTest.Traced.multi:multiple_function_heads/2",
+             3
+           )
   end
 
   test "Trace a private function" do
-    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
-
     assert Traced.call_priv() == :priv
 
-    TestHelper.trigger_report(NewRelic.Aggregate.Reporter)
-    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:mfa] == "TracerTest.Traced.priv/0" &&
-               event[:call_count] == 1
-           end)
+    assert TestHelper.find_metric(metrics, "Function/TracerTest.Traced.priv/0")
   end
 
   test "Don't trace when trace is deprecated" do
-    TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
-
     assert Traced.db_query() == :result
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -295,11 +295,6 @@ defmodule TransactionTest do
                event[:"external.TransactionTest.ExternalService.query.call_count"] == 2 &&
                event[:status] == 200
            end)
-
-    assert Enum.find(events, fn [_, event, _] ->
-             event[:category] == "Metric" && event[:name] == "FunctionTrace" &&
-               event[:mfa] == "TransactionTest.ExternalService.query/1" && event[:call_count] == 2
-           end)
   end
 
   test "Track attrs inside proccesses spawned by the transaction" do


### PR DESCRIPTION
This PR removes the reporting of "ElixirAggregate" custom events that specifically track Function Tracers.

This behavior is a left-over from a very early version of the agent, and is redundant. The equivalent data is reported directly as Metrics, which can be queried with NRQL:

```
FROM Metric
SELECT count(newrelic.timeslice.value) 
WHERE appName = 'MyApp'
TIMESERIES FACET service SINCE 1 hour AGO 
WITH METRIC_FORMAT 'External/{service}/all'
```

```
FROM Metric
SELECT count(newrelic.timeslice.value) 
WHERE appName = 'MyApp'
TIMESERIES FACET function SINCE 1 hour AGO 
WITH METRIC_FORMAT 'Function/{function}'
```

