### PR TITLE
Spread samplers across full sample cycle

### DIFF
--- a/lib/new_relic/sampler/agent.ex
+++ b/lib/new_relic/sampler/agent.ex
@@ -13,7 +13,7 @@ defmodule NewRelic.Sampler.Agent do
 
   def init(:ok) do
     if NewRelic.Config.enabled?(),
-      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_sample_offset())
 
     {:ok, %{}}
   end

--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -18,7 +18,7 @@ defmodule NewRelic.Sampler.Beam do
     NewRelic.sample_process()
 
     if NewRelic.Config.enabled?(),
-      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_sample_offset())
 
     {:ok, %{previous: take_sample()}}
   end

--- a/lib/new_relic/sampler/ets.ex
+++ b/lib/new_relic/sampler/ets.ex
@@ -15,7 +15,7 @@ defmodule NewRelic.Sampler.Ets do
     NewRelic.sample_process()
 
     if NewRelic.Config.enabled?(),
-      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_sample_offset())
 
     {:ok, %{}}
   end

--- a/lib/new_relic/sampler/process.ex
+++ b/lib/new_relic/sampler/process.ex
@@ -13,7 +13,7 @@ defmodule NewRelic.Sampler.Process do
     NewRelic.sample_process()
 
     if NewRelic.Config.enabled?(),
-      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_offset())
+      do: Process.send_after(self(), :report, NewRelic.Sampler.Reporter.random_sample_offset())
 
     {:ok, %{pids: %{}, previous: %{}}}
   end

--- a/lib/new_relic/sampler/reporter.ex
+++ b/lib/new_relic/sampler/reporter.ex
@@ -9,5 +9,5 @@ defmodule NewRelic.Sampler.Reporter do
 
   def sample_cycle, do: Application.get_env(:new_relic_agent, :sample_cycle, 15_000)
 
-  def random_offset, do: :rand.uniform(5 * 1000)
+  def random_sample_offset, do: :rand.uniform(sample_cycle())
 end

--- a/lib/new_relic/sampler/top_process.ex
+++ b/lib/new_relic/sampler/top_process.ex
@@ -17,7 +17,7 @@ defmodule NewRelic.Sampler.TopProcess do
     NewRelic.sample_process()
 
     if NewRelic.Config.enabled?(),
-      do: Process.send_after(self(), :sample, NewRelic.Sampler.Reporter.random_offset())
+      do: Process.send_after(self(), :sample, NewRelic.Sampler.Reporter.random_sample_offset())
 
     {:ok, :reset}
   end


### PR DESCRIPTION
This PR tweaks the Samplers such that they are spread out across the full sample cycle.

Before "faster event harvest", all harvesters reported on a 60 second cycle. With "faster event harvest" they report at 5 second intervals. That means that the current behavior clumps all the `Sample` events together in the same harvest and then skips 2 harvests.

This situation can be improved by spreading the samplers evenly over the `sample_cycle`.