### PR TITLE
Report custom metrics

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -169,6 +169,16 @@ defmodule NewRelic do
   defdelegate report_custom_event(type, attributes),
     to: NewRelic.Harvest.Collector.CustomEvent.Harvester
 
+  @doc """
+  Report a Custom metric.
+
+  ```elixir
+  NewRelic.report_custom_metric("My/Metric", 123)
+  ```
+  """
+  defdelegate report_custom_metric(name, value),
+    to: NewRelic.Harvest.Collector.Metric.Harvester
+
   @doc false
   defdelegate report_aggregate(meta, values), to: NewRelic.Aggregate.Reporter
 

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -23,6 +23,9 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
 
   # API
 
+  def report_custom_metric(name, value),
+    do: report_metric({:custom, name}, count: 1, value: value)
+
   def report_metric(identifier, values),
     do:
       Collector.Metric.HarvestCycle

--- a/lib/new_relic/metric/metric_data.ex
+++ b/lib/new_relic/metric/metric_data.ex
@@ -5,6 +5,15 @@ defmodule NewRelic.Metric.MetricData do
 
   alias NewRelic.Metric
 
+  def transform({:custom, name}, count: count, value: value),
+    do: %Metric{
+      name: join(["Custom", name]),
+      call_count: count,
+      total_call_time: value,
+      min_call_time: value,
+      max_call_time: value
+    }
+
   def transform(:http_dispatcher, duration_s: duration_s),
     do: %Metric{
       name: :HttpDispatcher,

--- a/test/metric_test.exs
+++ b/test/metric_test.exs
@@ -33,4 +33,21 @@ defmodule MetricTest do
     assert aggregated.total_call_time == 105
     assert aggregated.total_exclusive_time == 91
   end
+
+  test "custom metrics" do
+    TestHelper.restart_harvest_cycle(NewRelic.Harvest.Collector.Metric.HarvestCycle)
+
+    NewRelic.report_custom_metric("Foo/Bar", 100)
+    NewRelic.report_custom_metric("Foo/Bar", 50)
+
+    metrics = TestHelper.gather_harvest(NewRelic.Harvest.Collector.Metric.Harvester)
+
+    expected_count = 2
+    expected_value = 150
+
+    [_, [^expected_count, ^expected_value, _, _, _, _]] =
+      TestHelper.find_metric(metrics, "Custom/Foo/Bar", expected_count)
+
+    TestHelper.pause_harvest_cycle(NewRelic.Harvest.Collector.Metric.HarvestCycle)
+  end
 end


### PR DESCRIPTION
This PR adds an API function for reporting custom metrics to New Relic.

```elixir
NewRelic.report_custom_metric("My/Metric", 123.4)
```

Which can then be [queried in NRDB](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-apm-metric-timeslice-data-nrql):
```
FROM Metric
SELECT average(newrelic.timeslice.value)
WHERE appName = 'MyApp' AND metricTimesliceName = 'Custom/My/Metric'
TIMESERIES SINCE 1 hour ago
```