### PR TITLE
Add runtime_tools to extra_applications

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,6 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - elixir: '1.11'
+            otp: '23'
+          - elixir: '1.11'
+            otp: '22'
           - elixir: '1.10'
             otp: '23'
           - elixir: '1.10'

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule NewRelic.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger, :inets, :ssl, :os_mon],
+      extra_applications: [:logger, :inets, :ssl, :os_mon, :runtime_tools],
       mod: {NewRelic.Application, []}
     ]
   end


### PR DESCRIPTION
This prevents a compilation warning on Elixir 1.11 about using a dependency that hasn't been defined.