### PR TITLE
Safely get cpu util

### DIFF
--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -77,7 +77,7 @@ defmodule NewRelic.Sampler.Beam do
       schedulers: :erlang.system_info(:schedulers),
       scheduler_utilization: safe_check(:scheduler, :sample, []),
       cpu_count: :erlang.system_info(:logical_processors),
-      cpu_utilization: :cpu_sup.util()
+      cpu_utilization: safe_check(:cpu_sup, :util, [])
     }
   end
 


### PR DESCRIPTION
There seems to be some kind of bug / race when shutting down & checking `:cpu_sup.util`, so this PR makes that check safe.

Fixes #286 