### PR TITLE
Configure request queuing metric collection

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -117,6 +117,9 @@ defmodule NewRelic.Config do
     * Controls all Ecto instrumentation
   * `:redix_instrumentation_enabled` (default `true`)
     * Controls all Redix instrumentation
+  * `:request_queuing_metrics_enabled`
+    * Controls collection of request queuing metrics
+
 
   ### Configuration
 
@@ -124,28 +127,30 @@ defmodule NewRelic.Config do
   * Environment variables: `NEW_RELIC_ERROR_COLLECTOR_ENABLED=false`
   * Application config: `config :new_relic_agent, error_collector_enabled: false`
   """
+  def feature?(toggleable_agent_feature)
+
   def feature?(:error_collector) do
-    feature_check?("NEW_RELIC_ERROR_COLLECTOR_ENABLED", :error_collector_enabled)
+    get(:features, :error_collector)
   end
 
   def feature?(:db_query_collection) do
-    feature_check?("NEW_RELIC_SQL_COLLECTION_ENABLED", :sql_collection_enabled, false) ||
-      feature_check?("NEW_RELIC_DB_QUERY_COLLECTION_ENABLED", :db_query_collection_enabled)
+    get(:features, :db_query_collection)
   end
 
   def feature?(:ecto_instrumentation) do
-    feature_check?("NEW_RELIC_ECTO_INSTRUMENTATION_ENABLED", :ecto_instrumentation_enabled)
+    get(:features, :ecto_instrumentation)
   end
 
   def feature?(:redix_instrumentation) do
-    feature_check?("NEW_RELIC_REDIX_INSTRUMENTATION_ENABLED", :redix_instrumentation_enabled)
+    get(:features, :redix_instrumentation)
   end
 
   def feature?(:function_argument_collection) do
-    feature_check?(
-      "NEW_RELIC_FUNCTION_ARGUMENT_COLLECTION_ENABLED",
-      :function_argument_collection_enabled
-    )
+    get(:features, :function_argument_collection)
+  end
+
+  def feature?(:request_queuing_metrics) do
+    get(:features, :request_queuing_metrics)
   end
 
   @doc """
@@ -164,20 +169,14 @@ defmodule NewRelic.Config do
   * Environment variable `NEW_RELIC_LOGS_IN_CONTEXT=forwarder`
   * Application config `config :new_relic_agent, logs_in_context: :forwarder`
   """
+  def feature(configurable_agent_feature)
+
   def feature(:logs_in_context) do
     case System.get_env("NEW_RELIC_LOGS_IN_CONTEXT") do
       nil -> Application.get_env(:new_relic_agent, :logs_in_context, :disabled)
       "forwarder" -> :forwarder
       "direct" -> :direct
       other -> other
-    end
-  end
-
-  defp feature_check?(env, config, default \\ true) do
-    case System.get_env(env) do
-      "true" -> true
-      "false" -> false
-      _ -> Application.get_env(:new_relic_agent, config, default)
     end
   end
 
@@ -204,11 +203,15 @@ defmodule NewRelic.Config do
 
   defp harvest_enabled?, do: get(:harvest_enabled)
 
-  def get(key),
-    do: :persistent_term.get(:nr_config)[key]
+  @doc false
+  def get(key), do: :persistent_term.get(:nr_config)[key]
+  @doc false
+  def get(:features, key), do: :persistent_term.get(:nr_features)[key]
 
-  def put(items),
-    do: :persistent_term.put(:nr_config, items)
+  @doc false
+  def put(items), do: :persistent_term.put(:nr_config, items)
+  @doc false
+  def put(:features, items), do: :persistent_term.put(:nr_features, items)
 
   @external_resource "VERSION"
   @agent_version "VERSION" |> File.read!() |> String.trim()

--- a/lib/new_relic/transaction/plug.ex
+++ b/lib/new_relic/transaction/plug.ex
@@ -34,7 +34,7 @@ defmodule NewRelic.Transaction.Plug do
   defp on_call(conn) do
     Transaction.Reporter.start()
     add_start_attrs(conn)
-    maybe_report_queueing(conn)
+    maybe_report_queuing(conn)
     conn
   end
 
@@ -84,8 +84,9 @@ defmodule NewRelic.Transaction.Plug do
   end
 
   @request_start_header "x-request-start"
-  def maybe_report_queueing(conn) do
-    with [request_start | _] <- get_req_header(conn, @request_start_header),
+  def maybe_report_queuing(conn) do
+    with true <- NewRelic.Config.feature?(:request_queuing_metrics),
+         [request_start | _] <- get_req_header(conn, @request_start_header),
          {:ok, request_start_s} <- Util.RequestStart.parse(request_start) do
       NewRelic.add_attributes(request_start_s: request_start_s)
     else

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -43,20 +43,28 @@ defmodule ConfigTest do
   end
 
   test "Can configure error collecting via ENV and Application" do
+    # Via ENV
     System.put_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED", "false")
-
+    NewRelic.Init.init_features()
     refute NewRelic.Config.feature?(:error_collector)
 
+    # Via Application
     System.delete_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED")
-
+    Application.put_env(:new_relic_agent, :error_collector_enabled, true)
+    NewRelic.Init.init_features()
     assert NewRelic.Config.feature?(:error_collector)
 
+    # ENV over Application
     System.put_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED", "true")
-    Application.get_env(:new_relic_agent, :error_collector_enabled, false)
-
+    Application.put_env(:new_relic_agent, :error_collector_enabled, false)
+    NewRelic.Init.init_features()
     assert NewRelic.Config.feature?(:error_collector)
 
+    # Default
     System.delete_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED")
+    Application.delete_env(:new_relic_agent, :error_collector_enabled)
+    NewRelic.Init.init_features()
+    assert NewRelic.Config.feature?(:error_collector)
   end
 
   test "Parse multiple app names" do

--- a/test/metric_transaction_test.exs
+++ b/test/metric_transaction_test.exs
@@ -152,7 +152,7 @@ defmodule MetricTransactionTest do
            )
   end
 
-  test "Request queueing transaction" do
+  test "Request queuing transaction" do
     request_start = "t=#{System.system_time(:millisecond) - 100}"
 
     conn =

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -260,7 +260,7 @@ defmodule TransactionTest do
   end
 
   test "Allow disabling error detail collection" do
-    Application.put_env(:new_relic_agent, :error_collector_enabled, false)
+    reset_features = TestHelper.update(:nr_features, error_collector: false)
 
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
@@ -273,7 +273,7 @@ defmodule TransactionTest do
                event[:error_kind] == nil && event[:error_stack] == nil
            end)
 
-    Application.delete_env(:new_relic_agent, :error_collector_enabled)
+    reset_features.()
   end
 
   test "Transaction with traced external service call" do
@@ -355,7 +355,7 @@ defmodule TransactionTest do
     assert event[:total_time_s] > event[:duration_s]
   end
 
-  describe "Request queueing" do
+  describe "Request queuing" do
     test "queueDuration is included in the transaction (in seconds)" do
       TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
@@ -387,6 +387,25 @@ defmodule TransactionTest do
       [[_, event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
 
       assert event[:queueDuration] == 0
+    end
+
+    test "Controlled via config" do
+      reset_features = TestHelper.update(:nr_features, request_queuing_metrics: false)
+      TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+
+      request_start = System.system_time(:microsecond) - 1_500_000
+
+      conn =
+        conn(:get, "/total_time")
+        |> put_req_header("x-request-start", "t=#{request_start}")
+
+      TestHelper.request(TestPlugApp, conn)
+
+      [[_, event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+
+      refute event[:queueDuration]
+
+      reset_features.()
     end
   end
 end

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -328,8 +328,7 @@ defmodule TransactionTraceTest do
 
   test "Don't trace arguments when disabled" do
     reset_config = TestHelper.update(:nr_config, license_key: "dummy_key", harvest_enabled: true)
-
-    Application.put_env(:new_relic_agent, :function_argument_collection_enabled, false)
+    reset_features = TestHelper.update(:nr_features, function_argument_collection: false)
 
     TestHelper.request(TestPlugApp, conn(:get, "/huge_args"))
 
@@ -341,8 +340,8 @@ defmodule TransactionTraceTest do
 
     assert span[:args] == "[DISABLED]"
 
-    Application.delete_env(:new_relic_agent, :function_argument_collection_enabled)
     reset_config.()
+    reset_features.()
   end
 
   test "Don't trace arguments when opted-out on individual function" do


### PR DESCRIPTION
This PR enables configuration of the request queuing metric & attribute collection.

Alongside, it moves feature state storage to `persistent_term`