### PR TITLE
Don't blow when bad data gets in

### DIFF
--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -13,8 +13,16 @@ defmodule NewRelic.Util.HTTP do
     end
   end
 
-  def post(url, body, headers),
-    do: post(url, Jason.encode!(body), headers)
+  def post(url, body, headers) do
+    case Jason.encode(body) do
+      {:ok, body} ->
+        post(url, body, headers)
+
+      {:error, message} ->
+        NewRelic.log(:debug, "Unable to JSON encode: #{body}")
+        {:error, message}
+    end
+  end
 
   @doc """
   Certs are pulled from Mozilla exactly as Hex does:


### PR DESCRIPTION
The agent does it's best to ensure that bad data can't make it into a payload sent to New Relic, but since we accept attributes and input from outside sources, we aren't catching 100%. This PR ensures that when we can't encode the payload, we handle and log instead of raise.

closes #266 