### PR TITLE
Add more versions to environment values

### DIFF
--- a/lib/new_relic/signal_handler.ex
+++ b/lib/new_relic/signal_handler.ex
@@ -8,14 +8,14 @@ defmodule NewRelic.SignalHandler do
 
   def start do
     case Process.whereis(:erl_signal_server) do
-      :undefined ->
-        :ok
-
-      _ ->
+      pid when is_pid(pid) ->
         # Get our signal handler installed before erlang's
         :gen_event.delete_handler(:erl_signal_server, :erl_signal_handler, :ok)
         :gen_event.add_handler(:erl_signal_server, __MODULE__, [])
         :gen_event.add_handler(:erl_signal_server, :erl_signal_handler, [])
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -103,8 +103,9 @@ defmodule NewRelic.Util do
     [
       ["Language", "Elixir"],
       ["Elixir Version", build_info[:version]],
-      ["OTP Version", build_info[:otp_release]],
-      ["Elixir build", build_info[:build]]
+      ["Elixir build", build_info[:build]],
+      ["OTP Version", :erlang.system_info(:otp_release) |> to_string],
+      ["ERTS Version", :erlang.system_info(:version) |> to_string]
     ]
   end
 

--- a/test/collector_protocol_test.exs
+++ b/test/collector_protocol_test.exs
@@ -28,5 +28,13 @@ defmodule CollectorProtocolTest do
 
     assert get_in(payload, [:metadata])
            |> is_map
+
+    assert get_in(payload, [:environment])
+           |> Enum.find(&match?(["OTP Version", _], &1))
+
+    assert get_in(payload, [:environment])
+           |> Enum.find(&match?(["ERTS Version", _], &1))
+
+    Jason.encode!(payload)
   end
 end


### PR DESCRIPTION
This PR updates the environment reported up to New Relic:
* Add runtime `ERTS Version`
* Update `OTP Version` to the runtime OTP version (`Elixir build` includes the OTP version used during Elixir compilation)