### PR TITLE
Infinite tracing

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -201,7 +201,7 @@ defmodule NewRelic do
   defdelegate report_sample(category, values), to: NewRelic.Sampler.Reporter
 
   @doc false
-  defdelegate report_span(span), to: NewRelic.Harvest.Collector.SpanEvent.Harvester
+  defdelegate report_span(span), to: NewRelic.Span.Reporter
 
   @doc false
   defdelegate report_metric(identifier, values), to: NewRelic.Harvest.Collector.Metric.Harvester

--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -168,6 +168,16 @@ defmodule NewRelic.Config do
   Logs In Context can be configured in two ways:
   * Environment variable `NEW_RELIC_LOGS_IN_CONTEXT=forwarder`
   * Application config `config :new_relic_agent, logs_in_context: :forwarder`
+
+  ### Infinite Tracing
+
+  [Infinite Tracing](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing)
+  gives you more control of sampling by collecting 100% of Spans and sending them
+  to a Trace Observer for processing.
+
+  You can configure your Trace Observer in two ways:
+  * Environment variable `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST=trace-observer.host`
+  * Application config `config :new_relic_agent, infinite_tracing_trace_observer_host: "trace-observer.host"`
   """
   def feature(configurable_agent_feature)
 
@@ -178,6 +188,10 @@ defmodule NewRelic.Config do
       "direct" -> :direct
       other -> other
     end
+  end
+
+  def feature(:infinite_tracing) do
+    get(:trace_mode)
   end
 
   @doc false

--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -199,6 +199,13 @@ defmodule NewRelic.DistributedTrace do
     Process.put(:nr_current_span_attrs, %{url: url, method: method, component: component})
   end
 
+  def set_span(:error, message: message) do
+    Process.put(
+      :nr_current_span_attrs,
+      Map.merge(get_span_attrs(), %{error: true, "error.message": message})
+    )
+  end
+
   def set_span(
         :datastore,
         statement: statement,

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -185,6 +185,14 @@ defmodule NewRelic.Harvest.Collector.Protocol do
       (Collector.AgentRun.request_headers() || [])
   end
 
+  def determine_host(manual_config_host, region_prefix) do
+    cond do
+      manual_config_host -> manual_config_host
+      region_prefix -> "collector.#{region_prefix}.nr-data.net"
+      true -> "collector.newrelic.com"
+    end
+  end
+
   defp default_collector_params,
     do: %{
       license_key: NewRelic.Config.license_key(),

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -10,12 +10,13 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
   alias NewRelic.Util
 
   def start_link(_) do
-    GenServer.start_link(__MODULE__, [])
+    GenServer.start_link(__MODULE__, mode: NewRelic.Config.get(:trace_mode))
   end
 
-  def init(_) do
+  def init(mode: mode) do
     {:ok,
      %{
+       mode: mode,
        start_time: System.system_time(),
        start_time_mono: System.monotonic_time(),
        end_time_mono: nil,
@@ -51,10 +52,13 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
       duration: duration_s,
       name: name,
       category: category,
-      category_attributes: Util.coerce_attributes(attributes)
+      category_attributes: attributes
     }
     |> report_span_event(DistributedTrace.get_tracing_context(), edge)
   end
+
+  def report_span(%Event{} = event),
+    do: report_span_event(event)
 
   def report_span_event(%Event{} = _event, nil = _context, _mfa), do: :no_transaction
 

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -10,7 +10,7 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
   alias NewRelic.Util
 
   def start_link(_) do
-    GenServer.start_link(__MODULE__, mode: NewRelic.Config.get(:trace_mode))
+    GenServer.start_link(__MODULE__, mode: NewRelic.Config.feature(:infinite_tracing))
   end
 
   def init(mode: mode) do

--- a/lib/new_relic/harvest/harvest_cycle.ex
+++ b/lib/new_relic/harvest/harvest_cycle.ex
@@ -37,6 +37,10 @@ defmodule NewRelic.Harvest.HarvestCycle do
 
   def current_harvester(harvest_cycle), do: HarvesterStore.current(harvest_cycle)
 
+  def cycle(harvest_cycle) do
+    send(harvest_cycle, :harvest_cycle)
+  end
+
   def manual_shutdown(harvest_cycle) do
     case current_harvester(harvest_cycle) do
       nil ->
@@ -69,6 +73,7 @@ defmodule NewRelic.Harvest.HarvestCycle do
   end
 
   def handle_info(:harvest_cycle, state) do
+    stop_harvest_cycle(state.timer)
     harvester = swap_harvester(state)
     timer = trigger_harvest_cycle(state)
     {:noreply, %{state | harvester: harvester, timer: timer}}

--- a/lib/new_relic/harvest/supervisor.ex
+++ b/lib/new_relic/harvest/supervisor.ex
@@ -12,7 +12,9 @@ defmodule NewRelic.Harvest.Supervisor do
     Harvest.Collector.SpanEvent.HarvestCycle,
     Harvest.Collector.TransactionErrorEvent.HarvestCycle,
     Harvest.Collector.CustomEvent.HarvestCycle,
-    Harvest.Collector.ErrorTrace.HarvestCycle
+    Harvest.Collector.ErrorTrace.HarvestCycle,
+    Harvest.TelemetrySdk.Logs.HarvestCycle,
+    Harvest.TelemetrySdk.Spans.HarvestCycle
   ]
 
   def start_link(_) do

--- a/lib/new_relic/harvest/telemetry_sdk/api.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/api.ex
@@ -9,6 +9,14 @@ defmodule NewRelic.Harvest.TelemetrySdk.API do
     |> maybe_retry(url, payload)
   end
 
+  def span(spans) do
+    url = url(:trace)
+    payload = {:spans, spans, generate_request_id()}
+
+    request(url, payload)
+    |> maybe_retry(url, payload)
+  end
+
   def request(url, payload) do
     post(url, payload)
   end

--- a/lib/new_relic/harvest/telemetry_sdk/config.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/config.ex
@@ -2,9 +2,35 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
   @moduledoc false
 
   @default %{
-    logs_harvest_cycle: 5_000
+    logs_harvest_cycle: 5_000,
+    spans_harvest_cycle: 5_000
   }
   def lookup(key) do
-    Application.get_env(:new_relic_agent, key) || @default[key]
+    Application.get_env(:new_relic_agent, key, @default[key])
+  end
+
+  @env_matcher ~r/^(?<env>.+)-collector/
+  def determine_hosts(host, region) do
+    env = host && Regex.named_captures(@env_matcher, host)["env"]
+    env = env && env <> "-"
+    region = region && region <> "."
+
+    %{
+      log: "https://#{env}log-api.#{region}newrelic.com/log/v1",
+      trace: trace_domain(env, region)
+    }
+  end
+
+  defp trace_domain(env, region) do
+    infinite_tracing_host = NewRelic.Init.determine_config(:infinite_tracing_trace_observer_host)
+    trace_domain(env, region, infinite_tracing_host)
+  end
+
+  defp trace_domain(env, region, nil) do
+    "https://#{env}trace-api.#{region}newrelic.com/trace/v1"
+  end
+
+  defp trace_domain(_env, _region, infinite_tracing_host) do
+    "https://#{infinite_tracing_host}/trace/v1"
   end
 end

--- a/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
@@ -17,7 +17,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Logs.Harvester do
        start_time_mono: System.monotonic_time(),
        end_time_mono: nil,
        sampling: %{
-         reservoir_size: Application.get_env(:new_relic_agent, :log_reservior_size, 5_000),
+         reservoir_size: Application.get_env(:new_relic_agent, :log_reservoir_size, 5_000),
          logs_seen: 0
        },
        logs: []

--- a/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
@@ -80,7 +80,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Logs.Harvester do
   def log_harvest(harvest_size, logs_seen, reservoir_size) do
     NewRelic.log(
       :debug,
-      "Completed Log harvest - " <>
+      "Completed TelemetrySdk.Logs harvest - " <>
         "size: #{harvest_size}, seen: #{logs_seen}, max: #{reservoir_size}"
     )
   end

--- a/lib/new_relic/harvest/telemetry_sdk/span/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/span/harvester.ex
@@ -1,0 +1,188 @@
+defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
+  use GenServer
+
+  @moduledoc false
+
+  alias NewRelic.Harvest
+  alias NewRelic.Harvest.TelemetrySdk
+  alias NewRelic.DistributedTrace
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, mode: NewRelic.Config.get(:trace_mode))
+  end
+
+  def init(mode: mode) do
+    {:ok,
+     %{
+       trace_mode: mode,
+       start_time: System.system_time(),
+       start_time_mono: System.monotonic_time(),
+       end_time_mono: nil,
+       sampling: %{
+         reservoir_size: Application.get_env(:new_relic_agent, :span_reservior_size, 5_000),
+         spans_seen: 0
+       },
+       spans: []
+     }}
+  end
+
+  # API
+
+  def report_span(
+        timestamp_ms: timestamp_ms,
+        duration_s: duration_s,
+        name: name,
+        edge: [span: span, parent: parent],
+        category: category,
+        attributes: attributes
+      ) do
+    with %{trace_id: trace_id, guid: guid} <-
+           DistributedTrace.get_tracing_context() do
+      report_span(%{
+        id: generate_guid(span),
+        timestamp: timestamp_ms,
+        "trace.id": trace_id,
+        attributes:
+          %{
+            name: name,
+            category: category,
+            "parent.id": generate_guid(parent),
+            transactionId: guid,
+            "duration.ms": duration_s * 1000
+          }
+          |> NewRelic.Span.Event.merge_category_attributes(attributes)
+      })
+    end
+  end
+
+  def report_span(
+        %NewRelic.Span.Event{
+          guid: guid,
+          trace_id: trace_id,
+          timestamp: timestamp
+        } = span
+      ) do
+    report_span(%{
+      id: guid,
+      timestamp: timestamp,
+      "trace.id": trace_id,
+      attributes:
+        %{
+          name: span.name,
+          category: span.category,
+          transactionId: span.transaction_id,
+          "nr.entryPoint": span.entry_point,
+          "duration.ms": span.duration * 1000,
+          "parent.id": span.parent_id
+        }
+        |> NewRelic.Span.Event.merge_category_attributes(span.category_attributes)
+    })
+  end
+
+  def report_span(span) do
+    with :infinite <- NewRelic.Config.get(:trace_mode) do
+      NewRelic.report_metric({:supportability, :infinite_tracing}, spans_seen: 1)
+    end
+
+    TelemetrySdk.Spans.HarvestCycle
+    |> Harvest.HarvestCycle.current_harvester()
+    |> GenServer.cast({:report, span})
+  end
+
+  def gather_harvest,
+    do:
+      TelemetrySdk.Spans.HarvestCycle
+      |> Harvest.HarvestCycle.current_harvester()
+      |> GenServer.call(:gather_harvest)
+
+  def handle_cast(_late_msg, :completed), do: {:noreply, :completed}
+
+  def handle_cast({:report, span}, state) do
+    state =
+      state
+      |> store_sampling
+      |> store_span(span)
+
+    {:noreply, state}
+  end
+
+  def handle_call(_late_msg, _from, :completed), do: {:reply, :completed, :completed}
+
+  def handle_call(:send_harvest, _from, state) do
+    send_harvest(%{state | end_time_mono: System.monotonic_time()})
+    {:reply, :ok, :completed}
+  end
+
+  def handle_call(:gather_harvest, _from, state) do
+    {:reply, build_span_data(state.spans), state}
+  end
+
+  # Helpers
+
+  def store_span(
+        %{trace_mode: :infinite, sampling: %{spans_seen: seen, reservoir_size: size}} = state,
+        span
+      )
+      when seen == size do
+    Harvest.HarvestCycle.cycle(TelemetrySdk.Spans.HarvestCycle)
+    %{state | spans: [span | state.spans]}
+  end
+
+  def store_span(%{trace_mode: :infinite} = state, span) do
+    %{state | spans: [span | state.spans]}
+  end
+
+  def store_span(%{sampling: %{spans_seen: seen, reservoir_size: size}} = state, span)
+      when seen < size do
+    %{state | spans: [span | state.spans]}
+  end
+
+  def store_span(state, _span),
+    do: state
+
+  def store_sampling(%{sampling: sampling} = state),
+    do: %{state | sampling: Map.update!(sampling, :spans_seen, &(&1 + 1))}
+
+  def send_harvest(state) do
+    TelemetrySdk.API.span(build_span_data(state.spans))
+
+    log_harvest(
+      length(state.spans),
+      state.sampling.spans_seen,
+      state.sampling.reservoir_size,
+      state.trace_mode
+    )
+  end
+
+  def log_harvest(harvest_size, spans_seen, reservoir_size, trace_mode) do
+    with :infinite <- trace_mode do
+      NewRelic.report_metric({:supportability, :infinite_tracing}, harvest_size: harvest_size)
+    end
+
+    NewRelic.log(
+      :debug,
+      "Completed TelemetrySdk.Span harvest - " <>
+        "mode: #{trace_mode}, size: #{harvest_size}, seen: #{spans_seen}, max: #{reservoir_size}"
+    )
+  end
+
+  defp generate_guid(:root), do: DistributedTrace.generate_guid(pid: self())
+
+  defp generate_guid({label, ref}),
+    do: DistributedTrace.generate_guid(pid: self(), label: label, ref: ref)
+
+  defp build_span_data(spans) do
+    [
+      %{
+        spans: spans,
+        common: common()
+      }
+    ]
+  end
+
+  defp common() do
+    %{
+      attributes: NewRelic.Harvest.Collector.AgentRun.entity_metadata()
+    }
+  end
+end

--- a/lib/new_relic/harvest/telemetry_sdk/spans/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/spans/harvester.ex
@@ -8,7 +8,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
   alias NewRelic.DistributedTrace
 
   def start_link(_) do
-    GenServer.start_link(__MODULE__, mode: NewRelic.Config.get(:trace_mode))
+    GenServer.start_link(__MODULE__, mode: NewRelic.Config.feature(:infinite_tracing))
   end
 
   def init(mode: mode) do
@@ -19,7 +19,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
        start_time_mono: System.monotonic_time(),
        end_time_mono: nil,
        sampling: %{
-         reservoir_size: Application.get_env(:new_relic_agent, :span_reservior_size, 5_000),
+         reservoir_size: Application.get_env(:new_relic_agent, :span_reservoir_size, 5_000),
          spans_seen: 0
        },
        spans: []
@@ -80,7 +80,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
   end
 
   def report_span(span) do
-    with :infinite <- NewRelic.Config.get(:trace_mode) do
+    with :infinite <- NewRelic.Config.feature(:infinite_tracing) do
       NewRelic.report_metric({:supportability, :infinite_tracing}, spans_seen: 1)
     end
 

--- a/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
@@ -12,7 +12,8 @@ defmodule NewRelic.Harvest.TelemetrySdk.Supervisor do
 
   def init(_) do
     children = [
-      data_supervisor(TelemetrySdk.Logs, :logs_harvest_cycle)
+      data_supervisor(TelemetrySdk.Logs, :logs_harvest_cycle),
+      data_supervisor(TelemetrySdk.Spans, :spans_harvest_cycle)
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/lib/new_relic/metric/metric_data.ex
+++ b/lib/new_relic/metric/metric_data.ex
@@ -434,6 +434,30 @@ defmodule NewRelic.Metric.MetricData do
       }
     ]
 
+  def transform({:supportability, :infinite_tracing}, spans_seen: spans_seen),
+    do: [
+      %Metric{
+        name: :"Supportability/InfiniteTracing/Span/Seen",
+        call_count: spans_seen
+      }
+    ]
+
+  def transform({:supportability, :infinite_tracing}, harvest_size: harvest_size),
+    do: [
+      %Metric{
+        name: :"Supportability/InfiniteTracing/Span/Sent",
+        call_count: harvest_size
+      },
+      %Metric{
+        name: :"Supportability/Elixir/TelemetrySdk/Harvest/Span",
+        call_count: 1
+      },
+      %Metric{
+        name: :"Supportability/Harvest",
+        call_count: 1
+      }
+    ]
+
   def transform({:supportability, harvester},
         events_seen: events_seen,
         reservoir_size: reservoir_size
@@ -457,10 +481,6 @@ defmodule NewRelic.Metric.MetricData do
         name: join(["Supportability/Elixir/Collector/HarvestSize", harvester]),
         call_count: 1,
         total_call_time: harvest_size
-      },
-      %Metric{
-        name: :"Supportability/Elixir/Harvest",
-        call_count: 1
       },
       %Metric{
         name: :"Supportability/Harvest",

--- a/lib/new_relic/span/event.ex
+++ b/lib/new_relic/span/event.ex
@@ -72,7 +72,7 @@ defmodule NewRelic.Span.Event do
       component: category[:component] || "component",
       "span.kind": "client"
     })
-    |> Map.merge(custom)
+    |> Map.merge(NewRelic.Util.coerce_attributes(custom))
   end
 
   def merge_category_attributes(%{category: "datastore"} = span, category_attributes) do
@@ -88,14 +88,14 @@ defmodule NewRelic.Span.Event do
       component: category[:component] || "component",
       "span.kind": "client"
     })
-    |> Map.merge(custom)
+    |> Map.merge(NewRelic.Util.coerce_attributes(custom))
   end
 
   def merge_category_attributes(span, category_attributes),
     do:
       Map.merge(
         span,
-        category_attributes,
+        NewRelic.Util.coerce_attributes(category_attributes),
         # Don't overwrite existing span keys with custom values
         fn _k, v1, _v2 -> v1 end
       )

--- a/lib/new_relic/span/reporter.ex
+++ b/lib/new_relic/span/reporter.ex
@@ -2,7 +2,7 @@ defmodule NewRelic.Span.Reporter do
   @moduledoc false
 
   def report_span(span) do
-    case NewRelic.Config.get(:trace_mode) do
+    case NewRelic.Config.feature(:infinite_tracing) do
       :sampling -> NewRelic.Harvest.Collector.SpanEvent.Harvester.report_span(span)
       :infinite -> NewRelic.Harvest.TelemetrySdk.Spans.Harvester.report_span(span)
     end

--- a/lib/new_relic/span/reporter.ex
+++ b/lib/new_relic/span/reporter.ex
@@ -1,0 +1,10 @@
+defmodule NewRelic.Span.Reporter do
+  @moduledoc false
+
+  def report_span(span) do
+    case NewRelic.Config.get(:trace_mode) do
+      :sampling -> NewRelic.Harvest.Collector.SpanEvent.Harvester.report_span(span)
+      :infinite -> NewRelic.Harvest.TelemetrySdk.Spans.Harvester.report_span(span)
+    end
+  end
+end

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -190,6 +190,18 @@ defmodule NewRelic.Tracer.Macro do
 
       try do
         unquote(body)
+      rescue
+        exception ->
+          message = NewRelic.Util.Error.format_reason(:error, exception)
+          NewRelic.DistributedTrace.set_span(:error, message: message)
+
+          reraise exception, __STACKTRACE__
+      catch
+        :exit, value ->
+          message = NewRelic.Util.Error.format_reason(:exit, value)
+          NewRelic.DistributedTrace.set_span(:error, message: "(EXIT) #{message}")
+
+          exit(value)
       after
         end_time_mono = System.monotonic_time()
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -125,7 +125,15 @@ defmodule NewRelic.Transaction.Complete do
     top_children = List.wrap(function_segments[inspect(pid)])
     segment_tree = Map.update!(segment_tree, :children, &(&1 ++ top_children))
 
-    span_events = extract_span_events(tx_attrs, pid, process_spawns, process_names, process_exits)
+    span_events =
+      extract_span_events(
+        NewRelic.Config.get(:trace_mode),
+        tx_attrs,
+        pid,
+        process_spawns,
+        process_names,
+        process_exits
+      )
 
     apdex = calculate_apdex(tx_attrs, tx_error)
 
@@ -144,12 +152,19 @@ defmodule NewRelic.Transaction.Complete do
     {[segment_tree], tx_attrs, tx_error, span_events, apdex, tx_metrics}
   end
 
-  defp extract_span_events(%{sampled: true} = tx_attrs, pid, spawns, names, exits) do
+  # TODO: Don't create Transaction Root Process for OtherTransaction?
+
+  defp extract_span_events(:infinite, tx_attrs, pid, spawns, names, exits) do
+    spawned_process_span_events(tx_attrs, spawns, names, exits)
+    |> add_spansactions(tx_attrs, pid)
+  end
+
+  defp extract_span_events(:sampling, %{sampled: true} = tx_attrs, pid, spawns, names, exits) do
     spawned_process_span_events(tx_attrs, spawns, names, exits)
     |> add_root_process_span_event(tx_attrs, pid)
   end
 
-  defp extract_span_events(_tx_attrs, _pid, _spawns, _names, _exits) do
+  defp extract_span_events(_trace_mode, _tx_attrs, _pid, _spawns, _names, _exits) do
     []
   end
 
@@ -185,6 +200,50 @@ defmodule NewRelic.Transaction.Complete do
           }
           |> maybe_add(:tracingVendors, tx_attrs[:tracingVendors])
           |> maybe_add(:trustedParentId, tx_attrs[:trustedParentId])
+      }
+      | spans
+    ]
+  end
+
+  @spansaction_exclude_attrs [
+    :guid,
+    :traceId,
+    :start_time,
+    :end_time,
+    :parentId,
+    :parentSpanId,
+    :sampled,
+    :priority,
+    :tracingVendors,
+    :trustedParentId
+  ]
+  defp add_spansactions(spans, tx_attrs, pid) do
+    [
+      %NewRelic.Span.Event{
+        guid: tx_attrs[:guid],
+        transaction_id: tx_attrs[:guid],
+        trace_id: tx_attrs[:traceId],
+        parent_id: tx_attrs[:parentSpanId],
+        name: tx_attrs[:name],
+        category: "Transaction",
+        entry_point: true,
+        timestamp: tx_attrs[:start_time],
+        duration: tx_attrs[:duration_s],
+        category_attributes:
+          Map.drop(tx_attrs, @spansaction_exclude_attrs)
+          |> maybe_add(:tracingVendors, tx_attrs[:tracingVendors])
+          |> maybe_add(:trustedParentId, tx_attrs[:trustedParentId])
+      },
+      %NewRelic.Span.Event{
+        guid: DistributedTrace.generate_guid(pid: pid),
+        transaction_id: tx_attrs[:guid],
+        trace_id: tx_attrs[:traceId],
+        category: "generic",
+        name: "Transaction Root Process",
+        parent_id: tx_attrs[:guid],
+        timestamp: tx_attrs[:start_time],
+        duration: tx_attrs[:duration_s],
+        category_attributes: %{pid: inspect(pid)}
       }
       | spans
     ]
@@ -333,7 +392,7 @@ defmodule NewRelic.Transaction.Complete do
   end
 
   defp report_span_events(span_events) do
-    Enum.each(span_events, &Collector.SpanEvent.Harvester.report_span_event/1)
+    Enum.each(span_events, &NewRelic.report_span/1)
   end
 
   defp report_transaction_event(%{transactionType: :Other} = tx_attrs) do

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -127,7 +127,7 @@ defmodule NewRelic.Transaction.Complete do
 
     span_events =
       extract_span_events(
-        NewRelic.Config.get(:trace_mode),
+        NewRelic.Config.feature(:infinite_tracing),
         tx_attrs,
         pid,
         process_spawns,
@@ -151,8 +151,6 @@ defmodule NewRelic.Transaction.Complete do
 
     {[segment_tree], tx_attrs, tx_error, span_events, apdex, tx_metrics}
   end
-
-  # TODO: Don't create Transaction Root Process for OtherTransaction?
 
   defp extract_span_events(:infinite, tx_attrs, pid, spawns, names, exits) do
     spawned_process_span_events(tx_attrs, spawns, names, exits)

--- a/test/collector_protocol_test.exs
+++ b/test/collector_protocol_test.exs
@@ -37,4 +37,10 @@ defmodule CollectorProtocolTest do
 
     Jason.encode!(payload)
   end
+
+  test "determine correct collector host" do
+    assert "collector.newrelic.com" = Collector.Protocol.determine_host(nil, nil)
+    assert "collector.eu01.nr-data.net" = Collector.Protocol.determine_host(nil, "eu01")
+    assert "cool.newrelic.com" = Collector.Protocol.determine_host("cool.newrelic.com", nil)
+  end
 end

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -1,0 +1,232 @@
+defmodule InfiniteTracingTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias NewRelic.DistributedTrace
+  alias NewRelic.Harvest.TelemetrySdk
+  alias NewRelic.Harvest.Collector
+
+  setup do
+    reset_agent_run = TestHelper.update(:nr_agent_run, trusted_account_key: "190")
+
+    reset_config =
+      TestHelper.update(:nr_config,
+        license_key: "dummy_key",
+        harvest_enabled: true,
+        trace_mode: :infinite
+      )
+
+    send(DistributedTrace.BackoffSampler, :reset)
+
+    on_exit(fn ->
+      reset_agent_run.()
+      reset_config.()
+    end)
+
+    :ok
+  end
+
+  defmodule Traced do
+    use NewRelic.Tracer
+
+    @trace :hello
+    def hello do
+      do_hello()
+    end
+
+    @trace :do_hello
+    def do_hello do
+      Process.sleep(10)
+      "world"
+    end
+
+    @trace :function
+    def function do
+      Process.sleep(10)
+      NewRelic.set_span(:generic, some: "attribute")
+      http_request()
+    end
+
+    @trace {:http_request, category: :external}
+    def http_request do
+      Process.sleep(10)
+      NewRelic.set_span(:http, url: "http://example.com", method: "GET", component: "HTTPoison")
+      "bar"
+    end
+  end
+
+  defmodule TestPlugApp do
+    use Plug.Router
+    use NewRelic.Transaction
+
+    plug(:match)
+    plug(:dispatch)
+
+    get "/hello" do
+      Task.async(fn ->
+        Process.sleep(5)
+        Traced.http_request()
+      end)
+      |> Task.await()
+
+      send_resp(conn, 200, Traced.hello())
+    end
+
+    get "/reset_span" do
+      Traced.function()
+      send_resp(conn, 200, "Yo.")
+    end
+  end
+
+  @dt_header "newrelic"
+  @trace_id "d6b4ba0c3a712ca"
+  @parent_transaction_id "7d3efb1b173fecfa"
+  @parent_span_id "5f474d64b9cc9b2a"
+  def generate_inbound_payload() do
+    """
+    {
+      "v": [0,1],
+      "d": {
+        "ty": "Browser",
+        "ac": "190",
+        "tk": "190",
+        "ap": "2827902",
+        "tx": "#{@parent_transaction_id}",
+        "tr": "#{@trace_id}",
+        "id": "#{@parent_span_id}",
+        "ti": #{System.system_time(:millisecond) - 100},
+        "sa": true,
+        "pr": 0.987654
+      }
+    }
+    """
+    |> Base.encode64()
+  end
+
+  test "report span events via function tracer inside transaction inside a DT" do
+    TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
+    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+
+    TestHelper.request(
+      TestPlugApp,
+      conn(:get, "/hello") |> put_req_header(@dt_header, generate_inbound_payload())
+    )
+
+    [%{spans: spans}] = TestHelper.gather_harvest(TelemetrySdk.Spans.Harvester)
+
+    tx_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:category] == "Transaction"
+      end)
+
+    tx_root_process_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:name] == "Transaction Root Process"
+      end)
+
+    function_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:name] == "InfiniteTracingTest.Traced.hello/0"
+      end)
+
+    nested_function_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:name] == "InfiniteTracingTest.Traced.do_hello/0"
+      end)
+
+    task_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:name] == "Process"
+      end)
+
+    nested_span =
+      Enum.find(spans, fn %{attributes: attr} ->
+        attr[:name] == "InfiniteTracingTest.Traced.http_request/0"
+      end)
+
+    [[_intrinsics, tx_event]] = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
+
+    # IO.inspect({tx_event, tx_span, tx_root_process_span})
+
+
+    # Everything shares the incoming trace.id
+    assert tx_event[:traceId] == @trace_id
+    assert tx_span[:"trace.id"] == @trace_id
+    assert tx_root_process_span[:"trace.id"] == @trace_id
+    assert function_span[:"trace.id"] == @trace_id
+    assert nested_function_span[:"trace.id"] == @trace_id
+    assert task_span[:"trace.id"] == @trace_id
+    assert nested_span[:"trace.id"] == @trace_id
+
+    # We generate a "Transaction" span with the same ID as the Transaction
+    assert tx_event[:guid] == tx_span[:id]
+
+    # All spans point to the new Transaction
+    assert tx_span.attributes[:transactionId] == tx_event[:guid]
+    assert tx_root_process_span.attributes[:transactionId] == tx_event[:guid]
+    assert function_span.attributes[:transactionId] == tx_event[:guid]
+    assert nested_function_span.attributes[:transactionId] == tx_event[:guid]
+    assert task_span.attributes[:transactionId] == tx_event[:guid]
+    assert nested_span.attributes[:transactionId] == tx_event[:guid]
+
+    # The Transaction is new, not the incoming parent Transaction
+    refute tx_event[:guid] == @parent_transaction_id
+    refute tx_span.attributes[:transactionId] == @parent_transaction_id
+
+    # Only the Transaction Event's parent is the incoming parent Transaction
+    assert tx_event[:parentId] == @parent_transaction_id
+    refute tx_span.attributes[:"parent.id"] == @parent_transaction_id
+
+    # The Transaction Span's parent is from the incoming parent Span
+    assert tx_span.attributes[:"parent.id"] == @parent_span_id
+
+    # The rest of the Spans parenting follows their nesting
+    assert tx_root_process_span.attributes[:"parent.id"] == tx_span[:id]
+    assert function_span.attributes[:"parent.id"] == tx_root_process_span[:id]
+    assert nested_function_span.attributes[:"parent.id"] == function_span[:id]
+    assert task_span.attributes[:"parent.id"] == tx_root_process_span[:id]
+    assert nested_span.attributes[:"parent.id"] == task_span[:id]
+
+    # With Infinite Tracing, we don't do sampled or priority on Spans
+    refute Map.has_key?(tx_root_process_span, :sampled)
+    refute Map.has_key?(function_span, :sampled)
+    refute Map.has_key?(nested_function_span, :sampled)
+    refute Map.has_key?(task_span, :sampled)
+    refute Map.has_key?(nested_span, :sampled)
+
+    refute Map.has_key?(tx_root_process_span, :priority)
+    refute Map.has_key?(function_span, :priority)
+    refute Map.has_key?(nested_function_span, :priority)
+    refute Map.has_key?(task_span, :priority)
+    refute Map.has_key?(nested_span, :priority)
+
+    # But the Transaction Event still gets sampled and priority
+    assert tx_event[:sampled] == true
+    assert tx_event[:priority] == 0.987654
+
+    # Other Span attributes get wired up correctly
+    assert function_span.attributes[:"duration.ms"] >= 10
+    assert function_span.attributes[:"duration.ms"] < 20
+    assert task_span.attributes[:"duration.ms"] >= 15
+    assert task_span.attributes[:"duration.ms"] < 25
+    assert nested_span.attributes[:"duration.ms"] >= 10
+    assert nested_span.attributes[:"duration.ms"] < 20
+
+    assert nested_span.attributes[:category] == "http"
+    assert nested_span.attributes[:"http.url"] == "http://example.com"
+    assert nested_span.attributes[:"http.method"] == "GET"
+    assert nested_span.attributes[:"span.kind"] == "client"
+    assert nested_span.attributes[:component] == "HTTPoison"
+    assert nested_span.attributes[:args] |> is_binary
+
+    assert nested_function_span.attributes[:category] == "generic"
+    assert nested_function_span.attributes[:name] == "InfiniteTracingTest.Traced.do_hello/0"
+
+    # Ensure these will encode properly
+    Jason.encode!(tx_event)
+    Jason.encode!(spans)
+
+    TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
+    TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+  end
+end

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -256,7 +256,6 @@ defmodule InfiniteTracingTest do
   @tag :capture_log
   test "error span - exception in traced span" do
     TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
-    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
     {:ok, _} = Plug.Cowboy.http(TestPlugApp, [], port: 7777)
     {:ok, {{_, 500, _}, _, _}} = :httpc.request('http://localhost:7777/error')
@@ -272,13 +271,11 @@ defmodule InfiniteTracingTest do
 
     Plug.Cowboy.shutdown(TestPlugApp.HTTP)
     TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
-    TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 
   @tag :capture_log
   test "error span - exit" do
     TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
-    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
     {:ok, _} = Plug.Cowboy.http(TestPlugApp, [], port: 7788)
     {:ok, {{_, 500, _}, _, _}} = :httpc.request('http://localhost:7788/exit')
@@ -294,6 +291,5 @@ defmodule InfiniteTracingTest do
 
     Plug.Cowboy.shutdown(TestPlugApp.HTTP)
     TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
-    TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 end

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -11,19 +11,6 @@ defmodule InitTest do
     assert "eu01" == NewRelic.Init.determine_region("eu01xeu02x37a29c3982469a3fe9999999999999")
   end
 
-  test "set correct collector host" do
-    assert {"collector.newrelic.com", _} = NewRelic.Init.determine_collector_host(nil, nil)
-
-    assert {"collector.eu01.nr-data.net", _} =
-             NewRelic.Init.determine_collector_host(
-               nil,
-               "eu01xeu02x37a29c3982469a3fe9999999999999"
-             )
-
-    assert {"cool.newrelic.com", _} =
-             NewRelic.Init.determine_collector_host("cool.newrelic.com", nil)
-  end
-
   test "handle config default properly" do
     Application.put_env(:new_relic_agent, :harvest_enabled, true)
     NewRelic.Init.init_config()

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -76,6 +76,26 @@ defmodule IntegrationTest do
     assert resp.status_code == 202
   end
 
+  test "Can post a Span" do
+    {:ok, resp} =
+      NewRelic.Harvest.TelemetrySdk.API.span([
+        %{
+          spans: [
+            %{
+              id: "123",
+              "trace.id": "abc",
+              attributes: %{foo: "BAR"}
+            }
+          ],
+          common: %{
+            attributes: NewRelic.Harvest.Collector.AgentRun.entity_metadata()
+          }
+        }
+      ])
+
+    assert resp.status_code == 202
+  end
+
   test "EnabledSupervisor starts" do
     NewRelic.EnabledSupervisorManager.start_child()
 

--- a/test/logs_in_context_test.exs
+++ b/test/logs_in_context_test.exs
@@ -71,7 +71,7 @@ defmodule LogsInContextTest do
 
   test "prevent overload of log harvester" do
     configure_logs_in_context(:direct)
-    Application.put_env(:new_relic_agent, :log_reservior_size, 3)
+    Application.put_env(:new_relic_agent, :log_reservoir_size, 3)
     TestHelper.restart_harvest_cycle(TelemetrySdk.Logs.HarvestCycle)
 
     capture_log(fn ->
@@ -87,7 +87,7 @@ defmodule LogsInContextTest do
     assert length(harvest[:logs]) == 3
 
     configure_logs_in_context(:disabled)
-    Application.delete_env(:new_relic_agent, :log_reservior_size)
+    Application.delete_env(:new_relic_agent, :log_reservoir_size)
   end
 
   @default_pattern "\n$time $metadata[$level] $levelpad$message\n"

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -101,6 +101,7 @@ defmodule SpanEventTest do
 
   defmodule Traced do
     use NewRelic.Tracer
+
     @trace :hello
     def hello do
       do_hello()

--- a/test/telemetry_sdk/config_test.exs
+++ b/test/telemetry_sdk/config_test.exs
@@ -1,0 +1,21 @@
+defmodule TelemetrySdk.ConfigTest do
+  use ExUnit.Case
+  alias NewRelic.Harvest.TelemetrySdk
+
+  test "determine correct Telemetry API hosts" do
+    assert %{
+             log: "https://log-api.newrelic.com/log/v1",
+             trace: "https://trace-api.newrelic.com/trace/v1"
+           } = TelemetrySdk.Config.determine_hosts(nil, nil)
+
+    assert %{
+             log: "https://log-api.eu01.newrelic.com/log/v1",
+             trace: "https://trace-api.eu01.newrelic.com/trace/v1"
+           } = TelemetrySdk.Config.determine_hosts(nil, "eu01")
+
+    assert %{
+             log: "https://cool-log-api.newrelic.com/log/v1",
+             trace: "https://cool-trace-api.newrelic.com/trace/v1"
+           } = TelemetrySdk.Config.determine_hosts("cool-collector", nil)
+  end
+end

--- a/test/telemetry_sdk/span_harvester_test.exs
+++ b/test/telemetry_sdk/span_harvester_test.exs
@@ -1,0 +1,59 @@
+defmodule TelemetrySdk.SpanHarvesterTest do
+  use ExUnit.Case
+
+  alias NewRelic.Harvest
+  alias NewRelic.Harvest.TelemetrySdk
+
+  test "Harvester collect spans" do
+    {:ok, harvester} =
+      DynamicSupervisor.start_child(
+        TelemetrySdk.Spans.HarvesterSupervisor,
+        TelemetrySdk.Spans.Harvester
+      )
+
+    span1 = %{}
+    GenServer.cast(harvester, {:report, span1})
+
+    spans = GenServer.call(harvester, :gather_harvest)
+    assert length(spans) > 0
+  end
+
+  test "harvest cycle" do
+    Application.put_env(:new_relic_agent, :spans_harvest_cycle, 300)
+    TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
+
+    first = Harvest.HarvestCycle.current_harvester(TelemetrySdk.Spans.HarvestCycle)
+    Process.monitor(first)
+
+    # Wait until harvest swap
+    assert_receive {:DOWN, _ref, _, ^first, :shutdown}, 1000
+
+    second = Harvest.HarvestCycle.current_harvester(TelemetrySdk.Spans.HarvestCycle)
+    Process.monitor(second)
+
+    refute first == second
+    assert Process.alive?(second)
+
+    TestHelper.pause_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
+    Application.delete_env(:new_relic_agent, :spans_harvest_cycle)
+
+    # Ensure the last harvester has shut down
+    assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000
+  end
+
+  test "Ignore late reports" do
+    TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
+
+    harvester =
+      TelemetrySdk.Spans.HarvestCycle
+      |> Harvest.HarvestCycle.current_harvester()
+
+    assert :ok == GenServer.call(harvester, :send_harvest)
+
+    GenServer.cast(harvester, {:report, :late_msg})
+
+    assert :completed == GenServer.call(harvester, :send_harvest)
+
+    TestHelper.pause_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
+  end
+end


### PR DESCRIPTION
This PR adds support for Infinite Tracing! This features significantly improves the Distributed Tracing experience by collecting 100% of Spans and sending them to a dedicated Trace Observer endpoint for processing.

https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/infinite-tracing/introduction-infinite-tracing

This feature is only on when the agent is configured to point to a Trace Observer with either
* `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST= your_trace_observer_host` or
* `config :new_relic_agent, infinite_tracing_trace_observer_host: your_trace_observer_host`