### PR TITLE
Quick tweak of tracer attributes

### DIFF
--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -81,8 +81,8 @@ defmodule NewRelic.Tracer.Report do
           category: "http",
           attributes:
             Map.merge(span_attrs, %{
-              "trace.function": function_arity_name,
-              "trace.args": args
+              "tracer.function": function_arity_name,
+              "tracer.args": args
             })
         )
 
@@ -119,7 +119,7 @@ defmodule NewRelic.Tracer.Report do
           name: function_arity_name,
           edge: [span: id, parent: parent_id],
           category: "http",
-          attributes: Map.put(span_attrs, :"trace.args", args)
+          attributes: Map.put(span_attrs, :"tracer.args", args)
         )
 
         NewRelic.incr_attributes(

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -241,9 +241,9 @@ defmodule InfiniteTracingTest do
     assert nested_external_span.attributes[:"http.method"] == "GET"
     assert nested_external_span.attributes[:"span.kind"] == "client"
     assert nested_external_span.attributes[:component] == "HTTPoison"
-    assert nested_external_span.attributes[:"trace.args"] |> is_binary
+    assert nested_external_span.attributes[:"tracer.args"] |> is_binary
 
-    assert nested_external_span.attributes[:"trace.function"] ==
+    assert nested_external_span.attributes[:"tracer.function"] ==
              "InfiniteTracingTest.Traced.http_request/0"
 
     assert nested_function_span.attributes[:category] == "generic"

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -379,7 +379,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.ExternalService.secret_query/1"
       end)
 
-    assert span[:"trace.args"] == "[DISABLED]"
+    assert span[:"tracer.args"] == "[DISABLED]"
 
     [span, _, _] =
       TestHelper.gather_harvest(Collector.SpanEvent.Harvester)


### PR DESCRIPTION
This PR tweaks the attribute names added in #309 to avoid confusion with the `trace.id` attribute which identifies the overall Distributed Trace, not the individual tracer function.