### PR TITLE
Add automatic attributes to the Spansaction

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -228,7 +228,9 @@ defmodule NewRelic.Transaction.Complete do
         timestamp: tx_attrs[:start_time],
         duration: tx_attrs[:duration_s],
         category_attributes:
-          Map.drop(tx_attrs, @spansaction_exclude_attrs)
+          tx_attrs
+          |> Map.drop(@spansaction_exclude_attrs)
+          |> Map.merge(NewRelic.Config.automatic_attributes())
           |> maybe_add(:tracingVendors, tx_attrs[:tracingVendors])
           |> maybe_add(:trustedParentId, tx_attrs[:trustedParentId])
       },

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -13,7 +13,8 @@ defmodule InfiniteTracingTest do
       TestHelper.update(:nr_config,
         license_key: "dummy_key",
         harvest_enabled: true,
-        trace_mode: :infinite
+        trace_mode: :infinite,
+        automatic_attributes: %{auto: "attribute"}
       )
 
     send(DistributedTrace.BackoffSampler, :reset)
@@ -248,6 +249,10 @@ defmodule InfiniteTracingTest do
 
     assert nested_function_span.attributes[:category] == "generic"
     assert nested_function_span.attributes[:name] == "InfiniteTracingTest.Traced.do_hello/0"
+
+    # Automatic attributes assigned to the Transaction and Spansaction
+    assert tx_event[:auto] == "attribute"
+    assert tx_span.attributes[:auto] == "attribute"
 
     # Ensure these will encode properly
     Jason.encode!(tx_event)


### PR DESCRIPTION
This PR makes sure the `automatic_attributes` are put on the `Span` event generated for a Transaction when Infinite Tracing is on.