### PR TITLE
Track tracer reductions

### DIFF
--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -211,7 +211,7 @@ defmodule NewRelic.Tracer.Report do
 
   defp inspect_args(arguments, _) do
     if NewRelic.Config.feature?(:function_argument_collection) do
-      inspect(arguments, charlists: :as_lists, limit: 5, printable_limit: 10)
+      inspect(arguments, charlists: :as_lists, limit: 7, printable_limit: 10)
     else
       "[DISABLED]"
     end

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -231,11 +231,14 @@ defmodule InfiniteTracingTest do
     # Other Span attributes get wired up correctly
     assert function_span.attributes[:"duration.ms"] >= 10
     assert function_span.attributes[:"duration.ms"] < 20
+    assert function_span.attributes[:"tracer.reductions"] |> is_number
+    assert function_span.attributes[:"tracer.reductions"] > 1
+
     assert task_span.attributes[:"duration.ms"] >= 15
     assert task_span.attributes[:"duration.ms"] < 25
+
     assert nested_external_span.attributes[:"duration.ms"] >= 10
     assert nested_external_span.attributes[:"duration.ms"] < 20
-
     assert nested_external_span.attributes[:category] == "http"
     assert nested_external_span.attributes[:name] == "External/example.com/HTTPoison/GET"
     assert nested_external_span.attributes[:"http.url"] == "http://example.com"
@@ -243,12 +246,16 @@ defmodule InfiniteTracingTest do
     assert nested_external_span.attributes[:"span.kind"] == "client"
     assert nested_external_span.attributes[:component] == "HTTPoison"
     assert nested_external_span.attributes[:"tracer.args"] |> is_binary
+    assert nested_external_span.attributes[:"tracer.reductions"] |> is_number
+    assert nested_external_span.attributes[:"tracer.reductions"] > 1
 
     assert nested_external_span.attributes[:"tracer.function"] ==
              "InfiniteTracingTest.Traced.http_request/0"
 
     assert nested_function_span.attributes[:category] == "generic"
     assert nested_function_span.attributes[:name] == "InfiniteTracingTest.Traced.do_hello/0"
+    assert nested_function_span.attributes[:"tracer.reductions"] |> is_number
+    assert nested_function_span.attributes[:"tracer.reductions"] > 1
 
     # Automatic attributes assigned to the Transaction and Spansaction
     assert tx_event[:auto] == "attribute"

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -242,6 +242,8 @@ defmodule SpanEventTest do
 
     assert function_event[:duration] > 0.009
     assert function_event[:duration] < 0.020
+    assert function_event[:"tracer.reductions"] |> is_number
+    assert function_event[:"tracer.reductions"] > 1
 
     assert tx_root_process_event[:parentId] == "5f474d64b9cc9b2a"
     assert function_event[:parentId] == tx_root_process_event[:guid]
@@ -258,9 +260,13 @@ defmodule SpanEventTest do
     assert nested_external_event[:"http.method"] == "GET"
     assert nested_external_event[:"span.kind"] == "client"
     assert nested_external_event[:component] == "HTTPoison"
+    assert nested_external_event[:"tracer.reductions"] |> is_number
+    assert nested_external_event[:"tracer.reductions"] > 1
 
     assert nested_function_event[:category] == "generic"
     assert nested_function_event[:name] == "SpanEventTest.Traced.do_hello/0"
+    assert nested_function_event[:"tracer.reductions"] |> is_number
+    assert nested_function_event[:"tracer.reductions"] > 1
 
     # Ensure these will encode properly
     Jason.encode!(tx_event)

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -321,7 +321,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.HelperModule.do_work/1"
       end)
 
-    assert String.length(span[:args]) < 500
+    assert String.length(span[:"tracer.args"]) < 500
 
     reset_config.()
   end
@@ -338,7 +338,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.HelperModule.do_work/1"
       end)
 
-    assert span[:args] == "[DISABLED]"
+    assert span[:"tracer.args"] == "[DISABLED]"
 
     reset_config.()
     reset_features.()
@@ -355,7 +355,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.HelperModule.work_hard/1"
       end)
 
-    assert span[:args] == "[DISABLED]"
+    assert span[:"tracer.args"] == "[DISABLED]"
 
     [span, _, _] =
       TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
@@ -363,7 +363,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.HelperModule.do_work/1"
       end)
 
-    refute span[:args] == "[DISABLED]"
+    refute span[:"tracer.args"] == "[DISABLED]"
 
     reset_config.()
   end
@@ -387,7 +387,7 @@ defmodule TransactionTraceTest do
         sp.name == "TransactionTraceTest.ExternalService.query/1"
       end)
 
-    refute span[:args] == "[DISABLED]"
+    refute span[:"tracer.args"] == "[DISABLED]"
 
     reset_config.()
   end


### PR DESCRIPTION
This PR adds an attribute to Span events that tracks the number of `reductions` done during the function call. This is meaningful since the `reductions` track the "work" done on the CPU whereas `duration` tracks wall clock time (which could be spent waiting)

Also included is a minor tweak to the inspect options used to render the function args