### PR TITLE
Add ability to increment custom metrics

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -194,6 +194,16 @@ defmodule NewRelic do
   defdelegate report_custom_metric(name, value),
     to: NewRelic.Harvest.Collector.Metric.Harvester
 
+  @doc """
+  Increment a Custom metric.
+
+  ```elixir
+  NewRelic.increment_custom_metric("My/Metric")
+  ```
+  """
+  defdelegate increment_custom_metric(name, count \\ 1),
+    to: NewRelic.Harvest.Collector.Metric.Harvester
+
   @doc false
   defdelegate report_aggregate(meta, values), to: NewRelic.Aggregate.Reporter
 

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -26,6 +26,9 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
   def report_custom_metric(name, value),
     do: report_metric({:custom, name}, count: 1, value: value)
 
+  def increment_custom_metric(name, count),
+    do: report_metric({:custom, name}, count: count)
+
   def report_metric(identifier, values),
     do:
       Collector.Metric.HarvestCycle

--- a/lib/new_relic/metric/metric_data.ex
+++ b/lib/new_relic/metric/metric_data.ex
@@ -5,6 +5,12 @@ defmodule NewRelic.Metric.MetricData do
 
   alias NewRelic.Metric
 
+  def transform({:custom, name}, count: count),
+    do: %Metric{
+      name: join(["Custom", name]),
+      call_count: count
+    }
+
   def transform({:custom, name}, count: count, value: value),
     do: %Metric{
       name: join(["Custom", name]),

--- a/test/metric_test.exs
+++ b/test/metric_test.exs
@@ -18,4 +18,19 @@ defmodule MetricTest do
 
     TestHelper.pause_harvest_cycle(NewRelic.Harvest.Collector.Metric.HarvestCycle)
   end
+
+  test "increment custom metrics" do
+    TestHelper.restart_harvest_cycle(NewRelic.Harvest.Collector.Metric.HarvestCycle)
+
+    NewRelic.increment_custom_metric("Foo/Bar")
+    NewRelic.increment_custom_metric("Foo/Bar", 2)
+
+    metrics = TestHelper.gather_harvest(NewRelic.Harvest.Collector.Metric.Harvester)
+
+    [_, [count, _, _, _, _, _]] = TestHelper.find_metric(metrics, "Custom/Foo/Bar", 3)
+
+    assert count == 3
+
+    TestHelper.pause_harvest_cycle(NewRelic.Harvest.Collector.Metric.HarvestCycle)
+  end
 end


### PR DESCRIPTION
So that you can have a simple counter which can then be graphed. It
defaults to incrementing by 1 unless a value is passed in. Which enables
it to be incremented by any number.

This follows a similar method signature to the [Ruby][1] and [Node.js][2]
agents.

[1]: https://docs.newrelic.com/docs/agents/ruby-agent/api-guides/ruby-custom-metrics#increment_metric
[2]: https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#increment_metric
