### PR TITLE
Inspect failed output going to log

### DIFF
--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -19,7 +19,7 @@ defmodule NewRelic.Util.HTTP do
         post(url, body, headers)
 
       {:error, message} ->
-        NewRelic.log(:debug, "Unable to JSON encode: #{body}")
+        NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
         {:error, message}
     end
   end


### PR DESCRIPTION
When bad data has wound up in the payload, we need to safely log it

