### PR TITLE
Fix logs in context region URL

### DIFF
--- a/lib/new_relic/harvest/telemetry_sdk/config.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/config.ex
@@ -13,10 +13,11 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
   def determine_hosts(host, region) do
     env = host && Regex.named_captures(@env_matcher, host)["env"]
     env = env && env <> "-"
+    log_region = region && String.replace(region, ~r/\d/, "") <> "."
     region = region && region <> "."
 
     %{
-      log: "https://#{env}log-api.#{region}newrelic.com/log/v1",
+      log: "https://#{env}log-api.#{log_region}newrelic.com/log/v1",
       trace: trace_domain(env, region)
     }
   end

--- a/test/telemetry_sdk/config_test.exs
+++ b/test/telemetry_sdk/config_test.exs
@@ -9,7 +9,7 @@ defmodule TelemetrySdk.ConfigTest do
            } = TelemetrySdk.Config.determine_hosts(nil, nil)
 
     assert %{
-             log: "https://log-api.eu01.newrelic.com/log/v1",
+             log: "https://log-api.eu.newrelic.com/log/v1",
              trace: "https://trace-api.eu01.newrelic.com/trace/v1"
            } = TelemetrySdk.Config.determine_hosts(nil, "eu01")
 


### PR DESCRIPTION
The region extracted from licence keys such as `eu01xx________` is `eu01`, which works for the tracing, but not for logging in context. The [logging API docs](https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/#endpoint) require `https://log-api.eu.newrelic.com/log/v1`, but currently, the URL ends up as `https://log-api.eu01.newrelic.com/log/v1` which fails to report any data.

