### PR TITLE
Include metadata which has been added with a specific log message

### DIFF
--- a/test/logs_in_context_test.exs
+++ b/test/logs_in_context_test.exs
@@ -18,7 +18,7 @@ defmodule LogsInContextTest do
           NewRelic.start_transaction("TransactionCategory", "LogsInContext")
 
           Logger.metadata(foo: :bar, now: DateTime.utc_now())
-          Logger.error("FOO")
+          Logger.error("FOO", baz: :qux)
         end)
         |> Task.await()
       end)
@@ -33,6 +33,7 @@ defmodule LogsInContextTest do
     assert log["trace.id"] |> is_binary
     assert log["metadata.foo"] == "bar"
     assert log["metadata.now"] |> is_binary
+    assert log["metadata.baz"] == "qux"
 
     configure_logs_in_context(:disabled)
   end


### PR DESCRIPTION
Previously only whole-process metadata added via `Logger.metadata()` would be picked up. Now calls like `Logger.error("FOO", baz: :qux)` will send `"metadata.bax": "qux"` to New Relic, whereas previously that would be missing.


