### PR TITLE
Handle IO lists so that the new relic logs show strings, rather than lists in the UI

### DIFF
--- a/lib/new_relic/logs_in_context.ex
+++ b/lib/new_relic/logs_in_context.ex
@@ -60,7 +60,7 @@ defmodule NewRelic.LogsInContext do
 
   defp prepare_log(%{msg: {:string, msg}} = log) do
     %{
-      message: msg,
+      message: IO.iodata_to_binary(msg),
       timestamp: System.convert_time_unit(log.meta.time, :microsecond, :millisecond),
       "log.level": log.level
     }


### PR DESCRIPTION
Before:

<img width="631" alt="Screenshot 2021-03-14 at 23 18 20" src="https://user-images.githubusercontent.com/503900/111087816-a4c64300-851b-11eb-9912-9f19c9afd921.png">


After:

<img width="640" alt="Screenshot 2021-03-14 at 23 18 30" src="https://user-images.githubusercontent.com/503900/111087824-ab54ba80-851b-11eb-8ebb-8e1e0f98b63c.png">
