### PR TITLE
Support per-log message metadata

### DIFF
--- a/lib/new_relic/logs_in_context.ex
+++ b/lib/new_relic/logs_in_context.ex
@@ -91,14 +91,9 @@ defmodule NewRelic.LogsInContext do
     }
   end
 
+  @ignored [:domain, :file, :gl, :line, :mfa, :pid, :time]
   defp custom_metadata(log) do
-    ignored_keys = [:domain, :file, :gl, :line, :mfa, :pid, :time]
-
-    custom_metadata =
-      Enum.reject(log.meta, fn {k, _v} -> k in ignored_keys end)
-      |> Map.new()
-
-    [metadata: custom_metadata]
+    [metadata: Map.drop(log.meta, @ignored)]
     |> NewRelic.Util.deep_flatten()
     |> NewRelic.Util.coerce_attributes()
     |> Map.new()

--- a/test/logs_in_context_test.exs
+++ b/test/logs_in_context_test.exs
@@ -18,7 +18,7 @@ defmodule LogsInContextTest do
           NewRelic.start_transaction("TransactionCategory", "LogsInContext")
 
           Logger.metadata(foo: :bar, now: DateTime.utc_now())
-          Logger.error("FOO")
+          Logger.error("FOO", baz: :qux)
         end)
         |> Task.await()
       end)
@@ -33,6 +33,7 @@ defmodule LogsInContextTest do
     assert log["trace.id"] |> is_binary
     assert log["metadata.foo"] == "bar"
     assert log["metadata.now"] |> is_binary
+    assert log["metadata.baz"] == "qux"
 
     configure_logs_in_context(:disabled)
   end


### PR DESCRIPTION
This PR adds support for per-log message metadata.

Continued from #328 