### PR TITLE
Ensure instrumentation calls don't fail if app not started

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -79,4 +79,5 @@ jobs:
         mix deps.get
         mix format --check-formatted
         mix test
-        MIX_ENV=test mix instrumented_task.example_task
+        MIX_ENV=test mix instrumented_task
+        MIX_ENV=test mix uninstrumented_task

--- a/examples/apps/instrumented_task/lib/example_task.ex
+++ b/examples/apps/instrumented_task/lib/example_task.ex
@@ -1,8 +1,0 @@
-defmodule Mix.Tasks.InstrumentedTask.ExampleTask do
-  use Mix.Task
-  use NewRelic.Instrumented.Mix.Task
-
-  def run(_) do
-    IO.puts("Task exectued")
-  end
-end

--- a/examples/apps/instrumented_task/lib/instrumented_task.ex
+++ b/examples/apps/instrumented_task/lib/instrumented_task.ex
@@ -1,0 +1,8 @@
+defmodule Mix.Tasks.InstrumentedTask do
+  use Mix.Task
+  use NewRelic.Instrumented.Mix.Task
+
+  def run(_) do
+    IO.puts("Instrumented Task exectued")
+  end
+end

--- a/examples/apps/instrumented_task/lib/uninstrumented_task.ex
+++ b/examples/apps/instrumented_task/lib/uninstrumented_task.ex
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.UninstrumentedTask do
+  use Mix.Task
+
+  @moduledoc """
+  If the new_relic_agent application isn't even started,
+  calls to instrumentation functions should not fail
+  """
+  def run(_) do
+    NewRelic.report_custom_metric("My/Metric", 123)
+
+    IO.puts("Uninstrumented Task exectued")
+  end
+end

--- a/examples/apps/test_support/mix.exs
+++ b/examples/apps/test_support/mix.exs
@@ -22,6 +22,6 @@ defmodule TestSupport.MixProject do
   end
 
   defp deps do
-    []
+    [{:new_relic_agent, path: "../../../"}]
   end
 end

--- a/lib/new_relic/harvest/harvester_store.ex
+++ b/lib/new_relic/harvest/harvester_store.ex
@@ -20,6 +20,8 @@ defmodule NewRelic.Harvest.HarvesterStore do
       [{^harvester, pid}] -> pid
       _ -> nil
     end
+  rescue
+    _ -> nil
   end
 
   def update(harvester, pid) do


### PR DESCRIPTION
This PR ensures that even if the `new_relic_agent` application wasn't started (ex: in a mix task), calls to instrumentation functions will not fail.