### PR TITLE
Fix table name escaping parsing

### DIFF
--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -33,26 +33,14 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
   def parse(%{result: {:ok, _}}), do: :ignore
   def parse(%{result: {:error, _}}), do: :ignore
 
-  # Escape chars
-  #   Postgrex: "
-  #   MyXQL: `
-  #   Tds: [
-  #   Exqlite: none
-  @esc ~s(["`\[]?)
-
-  @select ~r/FROM #{@esc}(?<table>\w+)#{@esc}/
-  @insert ~r/INSERT INTO #{@esc}(?<table>\w+)#{@esc}/
-  @update ~r/UPDATE #{@esc}(?<table>\w+)#{@esc}/
-  @delete ~r/FROM #{@esc}(?<table>\w+)#{@esc}/
-  @create ~r/CREATE TABLE( IF NOT EXISTS)? #{@esc}(?<table>\w+)#{@esc}/
   defp parse_query(query) do
     {operation, table} =
       case query do
-        "SELECT" <> _ -> {"select", capture(@select, query, "table")}
-        "INSERT" <> _ -> {"insert", capture(@insert, query, "table")}
-        "UPDATE" <> _ -> {"update", capture(@update, query, "table")}
-        "DELETE" <> _ -> {"delete", capture(@delete, query, "table")}
-        "CREATE TABLE" <> _ -> {"create", capture(@create, query, "table")}
+        "SELECT" <> _ -> {"select", table_name(:select, query)}
+        "INSERT" <> _ -> {"insert", table_name(:insert, query)}
+        "UPDATE" <> _ -> {"update", table_name(:update, query)}
+        "DELETE" <> _ -> {"delete", table_name(:delete, query)}
+        "CREATE TABLE" <> _ -> {"create", table_name(:create, query)}
         "begin" -> {"begin", "other"}
         "commit" -> {"commit", "other"}
         "rollback" -> {"rollback", "other"}
@@ -62,7 +50,22 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
     {table, operation}
   end
 
-  defp capture(regex, query, match) do
-    Regex.named_captures(regex, query)[match]
+  # Table name escaping
+  #   Postgrex: "table"
+  #   MyXQL: `table`
+  #   Tds: [table]
+  #   Exqlite: table
+  @esc ~w(" ` [ ])
+
+  @capture %{
+    select: ~r/FROM (?<table>\S+)/,
+    insert: ~r/INSERT INTO (?<table>\S+)/,
+    update: ~r/UPDATE (?<table>\S+)/,
+    delete: ~r/FROM (?<table>\S+)/,
+    create: ~r/CREATE TABLE( IF NOT EXISTS)? (?<table>\S+)/
+  }
+  defp table_name(query_type, query) do
+    Regex.named_captures(@capture[query_type], query)["table"]
+    |> String.replace(@esc, "")
   end
 end


### PR DESCRIPTION
This PR fixes an edge case with Ecto table name escape char parsing while generalizing it a bit further