### PR TITLE
Fix parsing of other SELECTs

### DIFF
--- a/lib/new_relic/telemetry/ecto/handler.ex
+++ b/lib/new_relic/telemetry/ecto/handler.ex
@@ -29,7 +29,7 @@ defmodule NewRelic.Telemetry.Ecto.Handler do
     id = {:ecto_sql_query, make_ref()}
     parent_id = Process.get(:nr_current_span) || :root
 
-    with {datastore, {table, operation}} <- Metadata.parse(metadata) do
+    with {datastore, {operation, table}} <- Metadata.parse(metadata) do
       metric_name = "Datastore/statement/#{datastore}/#{table}/#{operation}"
       secondary_name = "#{inspect(repo)} #{hostname}:#{port}/#{database}"
 

--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -2,30 +2,19 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
   @moduledoc false
 
   def parse(%{result: {:ok, %{__struct__: Postgrex.Cursor}}}), do: :ignore
+  def parse(%{result: {:ok, %{__struct__: MyXQL.Cursor}}}), do: :ignore
 
-  def parse(%{
-        query: query,
-        result: {_ok_or_error, %{__struct__: struct}}
-      })
+  def parse(%{query: query, result: {_ok_err, %{__struct__: struct}}})
       when struct in [Postgrex.Result, Postgrex.Error] do
     {"Postgres", parse_query(query)}
   end
 
-  def parse(%{result: {:ok, %{__struct__: MyXQL.Cursor}}}), do: :ignore
-
-  def parse(%{
-        query: query,
-        result: {_ok_or_error, %{__struct__: struct}}
-      })
+  def parse(%{query: query, result: {_ok_err, %{__struct__: struct}}})
       when struct in [MyXQL.Result, MyXQL.Error] do
     {"MySQL", parse_query(query)}
   end
 
-  def parse(%{
-        query: query,
-        repo: repo,
-        result: {_ok_or_error, %{__struct__: _result_struct}}
-      }) do
+  def parse(%{query: query, repo: repo, result: {_ok_err, %{__struct__: _struct}}}) do
     [adaapter | _] = repo.__adapter__() |> Module.split() |> Enum.reverse()
     {adaapter, parse_query(query)}
   end
@@ -33,21 +22,18 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
   def parse(%{result: {:ok, _}}), do: :ignore
   def parse(%{result: {:error, _}}), do: :ignore
 
-  defp parse_query(query) do
-    {operation, table} =
-      case query do
-        "SELECT" <> _ -> {"select", table_name(:select, query)}
-        "INSERT" <> _ -> {"insert", table_name(:insert, query)}
-        "UPDATE" <> _ -> {"update", table_name(:update, query)}
-        "DELETE" <> _ -> {"delete", table_name(:delete, query)}
-        "CREATE TABLE" <> _ -> {"create", table_name(:create, query)}
-        "begin" -> {"begin", "other"}
-        "commit" -> {"commit", "other"}
-        "rollback" -> {"rollback", "other"}
-        _ -> {"other", "other"}
-      end
-
-    {table, operation}
+  def parse_query(query) do
+    case query do
+      "SELECT" <> _ -> parse_query(:select, query)
+      "INSERT" <> _ -> parse_query(:insert, query)
+      "UPDATE" <> _ -> parse_query(:update, query)
+      "DELETE" <> _ -> parse_query(:delete, query)
+      "CREATE TABLE" <> _ -> parse_query(:create, query)
+      "begin" -> {:begin, :other}
+      "commit" -> {:commit, :other}
+      "rollback" -> {:rollback, :other}
+      _ -> {:other, :other}
+    end
   end
 
   # Table name escaping
@@ -64,8 +50,10 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
     delete: ~r/FROM (?<table>\S+)/,
     create: ~r/CREATE TABLE( IF NOT EXISTS)? (?<table>\S+)/
   }
-  defp table_name(query_type, query) do
-    Regex.named_captures(@capture[query_type], query)["table"]
-    |> String.replace(@esc, "")
+  def parse_query(operation, query) do
+    case Regex.named_captures(@capture[operation], query) do
+      %{"table" => table} -> {operation, String.replace(table, @esc, "")}
+      _ -> {:other, :other}
+    end
   end
 end


### PR DESCRIPTION
Fix an edge case parsing the table name out of queries like `SELECT my_lock()`. Also includes a bit more code cleanup in this area.