### PR TITLE
Handle exception when inspecting remote process

### DIFF
--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -18,6 +18,9 @@ defmodule NewRelic.Util do
       {:registered_name, []} -> nil
       {:registered_name, name} -> name
     end
+  rescue
+    # `Process.info/2` will raise when given a pid from a remote node
+    ArgumentError -> nil
   end
 
   def metric_join(segments) when is_list(segments) do


### PR DESCRIPTION
When a process is spawned on a remote node, the transaction monitor tries to get its name by calling `Process.info`, which always raises badarg when the Pid given to it is non-local. This results in the transaction monitor terminating, when it's probably more desirable to just continue without a name.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
