### PR TITLE
Increase timestamp resolution

### DIFF
--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -152,8 +152,8 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
   defp get(counter, index), do: :counters.get(counter, index)
 
   # counters store integers, so we encode values
-  # into integers keeping 3 decimal places of precision
-  @precision 1_000
+  # into integers keeping 4 decimal places of precision
+  @precision 10_000
   @compile {:inline, encode: 1, decode: 1}
   defp encode(val), do: round(val * @precision)
   defp decode(val), do: val / @precision

--- a/lib/new_relic/telemetry/ecto/handler.ex
+++ b/lib/new_relic/telemetry/ecto/handler.ex
@@ -100,7 +100,7 @@ defmodule NewRelic.Telemetry.Ecto.Handler do
   end
 
   defp to_ms(nil), do: nil
-  defp to_ms(ns), do: System.convert_time_unit(ns, :nanosecond, :millisecond)
+  defp to_ms(ns), do: System.convert_time_unit(ns, :nanosecond, :microsecond) / 1000
 
   defp maybe_add(map, _, nil), do: map
   defp maybe_add(map, key, value), do: Map.put(map, key, value)

--- a/lib/new_relic/telemetry/ecto/handler.ex
+++ b/lib/new_relic/telemetry/ecto/handler.ex
@@ -9,7 +9,7 @@ defmodule NewRelic.Telemetry.Ecto.Handler do
         %{type: :ecto_sql_query, repo: repo} = metadata,
         config
       ) do
-    end_time = System.system_time(:millisecond)
+    end_time = System.system_time(:microsecond) / 1000
 
     duration_ms = total_time |> to_ms
     duration_s = duration_ms / 1000

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -213,7 +213,7 @@ defmodule NewRelic.Telemetry.Plug do
   end
 
   defp to_ms(duration),
-    do: System.convert_time_unit(duration, :native, :millisecond)
+    do: System.convert_time_unit(duration, :native, :microsecond) / 1000
 
   @request_start_header "x-request-start"
   defp maybe_report_queueing(meta) do

--- a/lib/new_relic/telemetry/redix.ex
+++ b/lib/new_relic/telemetry/redix.ex
@@ -90,8 +90,8 @@ defmodule NewRelic.Telemetry.Redix do
         %{commands: commands} = meta,
         config
       ) do
-    end_time_ms = System.system_time(:millisecond)
-    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+    end_time_ms = System.system_time(:microsecond) / 1000
+    duration_ms = System.convert_time_unit(duration, :native, :microsecond) / 1000
     duration_s = duration_ms / 1000
     start_time_ms = end_time_ms - duration_ms
 

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -214,7 +214,7 @@ defmodule NewRelic.Tracer.Macro do
           end
 
         duration_ms =
-          System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
+          System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1000
 
         duration_acc = Process.get({:nr_duration_acc, parent_ref}, 0)
         Process.put({:nr_duration_acc, parent_ref}, duration_acc + duration_ms)

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -218,7 +218,7 @@ defmodule NewRelic.Tracer.Report do
   end
 
   defp duration_ms(start_time_mono, end_time_mono),
-    do: System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
+    do: System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1000
 
   defp function_name({m, f}, f), do: "#{inspect(m)}.#{f}"
   defp function_name({m, f}, i), do: "#{inspect(m)}.#{f}:#{i}"

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -43,7 +43,8 @@ defmodule NewRelic.Transaction.Complete do
   defp transform_time_attrs(%{system_time: system_time, duration: duration} = tx) do
     start_time_ms = System.convert_time_unit(system_time, :native, :millisecond)
     duration_us = System.convert_time_unit(duration, :native, :microsecond)
-    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+    duration_ms = duration_us / 1000
+    duration_s = duration_ms / 1000
 
     tx
     |> Map.drop([:system_time, :duration, :end_time_mono])
@@ -52,7 +53,7 @@ defmodule NewRelic.Transaction.Complete do
       end_time: start_time_ms + duration_ms,
       duration_us: duration_us,
       duration_ms: duration_ms,
-      duration_s: duration_ms / 1000
+      duration_s: duration_s
     })
   end
 
@@ -62,7 +63,8 @@ defmodule NewRelic.Transaction.Complete do
        ) do
     start_time_ms = System.convert_time_unit(start_time, :native, :millisecond)
     duration_us = System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond)
-    duration_ms = System.convert_time_unit(end_time_mono - start_time_mono, :native, :millisecond)
+    duration_ms = duration_us / 1000
+    duration_s = duration_ms / 1000
 
     tx
     |> Map.drop([:start_time_mono, :end_time_mono])
@@ -71,7 +73,7 @@ defmodule NewRelic.Transaction.Complete do
       end_time: start_time_ms + duration_ms,
       duration_us: duration_us,
       duration_ms: duration_ms,
-      duration_s: duration_ms / 1000
+      duration_s: duration_s
     })
   end
 

--- a/test/other_transaction_test.exs
+++ b/test/other_transaction_test.exs
@@ -56,7 +56,7 @@ defmodule OtherTransactionTest do
     ] = event
 
     assert name == "OtherTransaction/TransactionCategory/MyTaskName"
-    assert end_time - start_time == duration_ms
+    assert_in_delta end_time - start_time, duration_ms, 1
 
     assert duration_ms >= 60
     assert total_time_s >= (60 + 50) / 1000


### PR DESCRIPTION
This PR increases the "resolution" of some of the timestamp processing.

This need was discovered when we saw some Redix calls were coming in at `0ms`. They are so fast that they were getting rounded down to 0 by `System.convert_time_unit(time, :native, :millisecond)`