### PR TITLE
Add support for HSM v2

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -97,6 +97,28 @@ defmodule NewRelic.Config do
     do: get(:labels)
 
   @doc """
+  Enables High Security Mode; when enabled this prevents any potentially
+  sensitive information being reported to New Relic. You can enable this
+  behavior in two ways:
+
+  * Environment variables `NEW_RELIC_HIGH_SECURITY=true`
+  * Application config: `config :new_relic_agent, high_security: true`
+
+  The configuration setting here must match your New Relic account setting;
+  otherwise the agent's connection attempt will be rejected and the agent will
+  shut down. This will prevent the agent from reporting any metrics to New Relic,
+  but will not shut down your application.
+
+  Enabling High Security Mode has significant implications for all applications
+  reporting to your New Relic account. Please read the High Security Mode
+  documentation for further details:
+
+  https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode/
+  """
+  def high_security,
+    do: get(:high_security)
+
+  @doc """
   Some Agent features can be toggled via configuration.
 
   ### Security
@@ -105,7 +127,7 @@ defmodule NewRelic.Config do
     * Toggles collection of any Error traces or metrics
   * `:db_query_collection_enabled` (default `true`)
     * Toggles collection of Database query strings
-  * `function_argument_collection_enabled` (default `true`)
+  * `:function_argument_collection_enabled` (default `true`)
     * Toggles collection of traced function arguments
 
   ### Instrumentation

--- a/lib/new_relic/harvest/collector/connect.ex
+++ b/lib/new_relic/harvest/collector/connect.ex
@@ -16,7 +16,8 @@ defmodule NewRelic.Harvest.Collector.Connect do
         event_harvest_config: NewRelic.Config.event_harvest_config(),
         metadata: NewRelic.Util.metadata(),
         environment: NewRelic.Util.elixir_environment(),
-        agent_version: NewRelic.Config.agent_version()
+        agent_version: NewRelic.Config.agent_version(),
+        high_security: NewRelic.Config.high_security()
       }
     ]
   end

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -35,6 +35,7 @@ defmodule NewRelic.Init do
       app_name: determine_config(:app_name) |> parse_app_names,
       license_key: license_key,
       harvest_enabled: determine_config(:harvest_enabled, true) |> parse_bool,
+      high_security: determine_config(:high_security) || false,
       collector_host: collector_host,
       region_prefix: region_prefix,
       automatic_attributes: determine_automatic_attributes(),


### PR DESCRIPTION
The Elixir New Relic Agent doesn't currently support High Security Mode (HSM) in any shape or form. Ideally the setting is not enabled on the NR account and we get the full scope and breadth of reported metrics and spans, but..

Our New Relic account at Afterpay is configured to use HSM and, given that our services are built to assume this, the proposition of disabling HSM account-wide is incredibly dicey. The New Relic agent would immediate get forcefully disconnected because the NR server would assume we were an insecure agent under (deprecated) [HSMv1 requirements](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode/#version1description). This was a blocking issue for setting up metrics reporting for the Elixir service I maintain here, but we found that [we could upgrade metrics reporting to work with HSMv2](https://docs.newrelic.com/docs/agents/manage-apm-agents/configuration/high-security-mode/#migrating) by monkeypatching the `NewRelic.Harvest.Collector.Connect` module to include a `high_security: true` parameter in the payload.

Once under HSMv2, the agent is allowed to continue to connect and any potentially sensitive information is stripped out on the New Relic side before showing up in collected metrics.

This PR formalizes that into an actual configuration setting and should have no impact for any New Relic agents reporting to non-HSM accounts. I would like to do further work to support high security mode-- the current implementation seems to strip a lot of useful information present in, e.g., Python-reported metrics to the same account-- but the actual protocol/reporting-level implications of HSM aren't documented anywhere that I can find. 

At the very least, adding this configuration should enable anyone blocked on #260 to use the NR agent with an Elixir service. Please let me know if there is anything further y'all would like me to do before merging this; I'd love to be able to remove the kind-of-hacky module replacement I'm doing within my own service and any other Elixir services other teams here might set up :)