### PR TITLE
Auto require NewRelic in NewRelic.Tracer

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -90,10 +90,25 @@ defmodule NewRelic do
   defdelegate stop_transaction(), to: NewRelic.OtherTransaction
 
   @doc """
-  Define an "Other" transaction within the given block. The return value of
+  Define an "Other" transaction with the given block. The return value of
   the block is returned.
 
-  See `start_transaction` and `stop_transaction` for more details.
+  See `start_transaction` and `stop_transaction` for more details about
+  Transactions.
+
+  Example:
+
+  ```elixir
+  defmodule Worker do
+    use NewRelic.Tracer
+
+    def process_messages do
+      NewRelic.other_transaction("Worker", "ProcessMessages") do
+        # ...
+      end
+    end
+  end
+  ```
   """
   defmacro other_transaction(category, name, do: block) do
     quote do

--- a/lib/new_relic/tracer.ex
+++ b/lib/new_relic/tracer.ex
@@ -85,6 +85,7 @@ defmodule NewRelic.Tracer do
 
   defmacro __using__(_args) do
     quote do
+      require NewRelic
       require NewRelic.Tracer.Macro
       require NewRelic.Tracer.Report
       Module.register_attribute(__MODULE__, :nr_tracers, accumulate: true)


### PR DESCRIPTION
Auto `require NewRelic` as a quick convenience so that `other_transaction` can be used wherever `use NewRelic.Tracer` is already used.