### PR TITLE
Fix other transaction leak

### DIFF
--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -218,6 +218,7 @@ defmodule NewRelic.Transaction.Sidecar do
 
   def handle_continue(:complete, state) do
     cleanup(context: self())
+    cleanup(lookup: state.parent)
     Enum.each(state.offspring, &cleanup(lookup: &1))
     run_complete(state)
     counter(:sub)


### PR DESCRIPTION
This PR fixes a leak in "Other" transactions that happens when they aren't closed manually.