### PR TITLE
Handle Other transaction ended by expected error

### DIFF
--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -187,7 +187,8 @@ defmodule NewRelic.Transaction.Sidecar do
     end_time_mono = System.monotonic_time()
 
     attributes =
-      with {reason, stack} when reason != :shutdown <- down_reason do
+      with {reason, stack} when reason != :shutdown <- down_reason,
+           false <- match?(%{expected: true}, reason) do
         Map.merge(state.attributes, %{
           error: true,
           error_kind: :exit,


### PR DESCRIPTION
This PR updates "Other" Transaction behavior so that when it ends with an _expected_ error, it doesn't mark the complete Transaction as having failed.