### PR TITLE
Make sure we can always encode priority float

### DIFF
--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -257,7 +257,7 @@ defmodule NewRelic.DistributedTrace do
 
   defp generate_sampling() do
     case {generate_sample?(), generate_priority()} do
-      {true, priority} -> {priority + 1, true}
+      {true, priority} -> {priority + 1.0, true}
       {false, priority} -> {priority, false}
     end
   end

--- a/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
+++ b/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
@@ -204,7 +204,10 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
 
   defp encode_priority(nil), do: ""
 
-  defp encode_priority(priority),
+  defp encode_priority(priority) when is_integer(priority),
+    do: encode_priority(priority / 1)
+
+  defp encode_priority(priority) when is_float(priority),
     do: priority |> :erlang.float_to_binary([:compact, decimals: 6])
 
   defp decode_sampled("1"), do: true


### PR DESCRIPTION
This PR makes sure we can always encode the sampling priority properly as a float even if an integer gets sent in.