### PR TITLE
Ensure Task is loaded before running function_exported?/3

### DIFF
--- a/lib/new_relic/instrumented/task.ex
+++ b/lib/new_relic/instrumented/task.ex
@@ -25,7 +25,7 @@ defmodule NewRelic.Instrumented.Task do
   defdelegate await(task, timeout \\ 5000),
     to: Task
 
-  if Kernel.function_exported?(Task, :await_many, 2) do
+  if Code.ensure_loaded?(Task) && Kernel.function_exported?(Task, :await_many, 2) do
     defdelegate await_many(tasks, timeout \\ 5000),
       to: Task
   end


### PR DESCRIPTION
There can be a race condition when the compiler is evaluating these
lines of code, that allow for function_exported? to return false. This
is because the Task module hasn't been loaded yet.

Running `Code.ensure_loaded?(Task)` before calling `function_exported?`
will make sure that we avoid the race condition.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
