### PR TITLE
Update Telemetry dependency to allow Telemetry 1.0.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule NewRelic.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:castore, ">= 0.1.0"},
       {:jason, "~> 1.0"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       # Instrumentation:
       {:plug, ">= 1.10.4", optional: true},
       {:plug_cowboy, ">= 2.4.0", optional: true},


### PR DESCRIPTION
Hi team.

Thanks for the great software!

This PR simply allows telemetry 1.0 to be used in addition to >= 0.4.

Thanks!