### PR TITLE
Update Phoenix dependency to allow Phoenix 1.6.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule NewRelic.Mixfile do
       # Instrumentation:
       {:plug, ">= 1.10.4", optional: true},
       {:plug_cowboy, ">= 2.4.0", optional: true},
-      {:phoenix, ">= 1.5.5", optional: true},
+      {:phoenix, ">= 1.5.5 or ~> 1.6.0", optional: true},
       {:ecto_sql, ">= 3.4.0", optional: true},
       {:ecto, ">= 3.4.1", optional: true},
       {:redix, ">= 0.11.0", optional: true}


### PR DESCRIPTION
Hey folks.

This PR loosens the Phoenix dependency to allow Phoenix to be upgraded to 1.6 while `new_relic_agent` is installed.

Thanks!