### PR TITLE
Remove community project badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Community Project header](https://github.com/newrelic/open-source-office/raw/master/examples/categories/images/Community_Project.png)](https://github.com/newrelic/open-source-office/blob/master/examples/categories/index.md#category-community-project)
-
 # New Relic's Elixir Agent
 
 [![Build Status](https://github.com/newrelic/elixir_agent/workflows/CI/badge.svg)](https://github.com/newrelic/elixir_agent/actions?query=workflow%3ACI)


### PR DESCRIPTION
We don't have anyone at NR working on this project in any official way. This badge could be misleading. Please see the Support Statement in the README for the current state of support.

