### PR TITLE
use `System.pid/0`

### DIFF
--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -7,7 +7,7 @@ defmodule NewRelic.Util do
     maybe_heroku_dyno_hostname() || get_hostname()
   end
 
-  def pid, do: System.get_pid() |> String.to_integer()
+  def pid, do: System.pid() |> String.to_integer()
 
   def time_to_ms({megasec, sec, microsec}),
     do: (megasec * 1_000_000 + sec) * 1_000 + round(microsec / 1_000)


### PR DESCRIPTION
instead of `System.get_pid/0`

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
