### PR TITLE
Fix DT payload in unknown version handling

### DIFF
--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -16,7 +16,7 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
   def decode(raw_payload) when is_binary(raw_payload) do
     with {:ok, json} <- Base.decode64(raw_payload),
          {:ok, map} <- Jason.decode(json),
-         context <- validate(map) do
+         %Context{} = context <- validate(map) do
       NewRelic.report_metric(:supportability, [:dt, :accept, :success])
       context
     else
@@ -29,7 +29,7 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
 
   def restrict_access(:bad_dt_payload), do: :bad_dt_payload
 
-  def restrict_access(context) do
+  def restrict_access(%Context{} = context) do
     if (context.trust_key || context.account_id) == AgentRun.trusted_account_key() do
       context
     else


### PR DESCRIPTION
**Problem evidence and investigation**

Our NewRelic stopped receiving transactions' metrics collected by the `NewRelic.Telemetry.Plug`. The following log indicated what could be the cause:
```
Handler {:new_relic, :plug} has failed and has been detached.
Class=:error
Reason=:undef
Stacktrace=[
  {:invalid, :trust_key, [], []},
  {NewRelic.DistributedTrace.NewRelicContext, :restrict_access, 1,
   [file: 'lib/new_relic/distributed_trace/new_relic_context.ex', line: 33]},
  {NewRelic.DistributedTrace, :newrelic_header, 1,
   [file: 'lib/new_relic/distributed_trace.ex', line: 39]},
  {NewRelic.DistributedTrace, :accept_distributed_trace_headers, 2,
   [file: 'lib/new_relic/distributed_trace.ex', line: 25]},
  {NewRelic.DistributedTrace, :determine_context, 2,
   [file: 'lib/new_relic/distributed_trace.ex', line: 18]},
  {NewRelic.DistributedTrace, :start, 2,
   [file: 'lib/new_relic/distributed_trace.ex', line: 13]},
  {NewRelic.Telemetry.Plug, :handle_event, 4,
   [file: 'lib/new_relic/telemetry/plug.ex', line: 96]},
  {:telemetry, :\"-execute/3-fun-0-\", 4,
   [file: '/app/src/deps/telemetry/src/telemetry.erl', line: 135]}
]
```
An exception was raised and the telemetry handler detached and stopped collecting metrics. The statement that raised the error:
```elixir
if (context.trust_key || context.account_id) == AgentRun.trusted_account_key() do
```

Context was supposed to be a `NewRelic.DistributedTrace.Context` struct but was in fact the atom `:invalid`.

Upon further investigation we found that what caused the context to be set to `invalid` was a DT header in a version the agent was not prepared to handle. The header that caused the issue:
```
{
  "v": [0, 2],
  "d": {
    "d.ac": "2497233",
    "d.ap": "488951130",
    "d.id": "8e81319f548742aa",
    "d.ti": 1640202478572,
    "d.tr": "b4799f25a31049eebc2f808732b28e35",
    "d.ty": "Mobile"
  }
}
```

**Problem conclusion**
The `NewRelic.Telemetry.Plug` failed to handle distributed trace payload in an unknown version correctly. The expected behaviour would be to ignore the header in that case instead of crashing the telemetry handler.

**Solution**
Correctly handle New Relic distributed trace payload in an unknown
version by ignoring it the same way an invalid json payload would be.



<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
