### PR TITLE
Changes default custom event per minute to 10_000

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -218,7 +218,8 @@ defmodule NewRelic.Config do
       harvest_limits: %{
         analytic_event_data:
           Application.get_env(:new_relic_agent, :analytic_event_per_minute, 1000),
-        custom_event_data: Application.get_env(:new_relic_agent, :custom_event_per_minute, 1000),
+        custom_event_data:
+          Application.get_env(:new_relic_agent, :custom_event_per_minute, 10_000),
         error_event_data: Application.get_env(:new_relic_agent, :error_event_per_minute, 100),
         span_event_data: Application.get_env(:new_relic_agent, :span_event_per_minute, 1000)
       }


### PR DESCRIPTION
This changes the default custom event per minutes from 1000 to 10000 to
match the [Java agent](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/#java-att) defaults.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
