### PR TITLE
docs: add 'Disabling' section to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ There are a few adapters which leverage this agent to provide library / framewor
 
 #### Disabling
 
-If you want to disable the New Relic's agent, you can do it in two different ways:
+If you want to disable the agent, you can do it in two different ways:
 
 * Application config: `config :new_relic_agent, license_key: nil`
 * Environment variables: `NEW_RELIC_HARVEST_ENABLED=false`

--- a/README.md
+++ b/README.md
@@ -173,3 +173,12 @@ NewRelic.stop_transaction()
 There are a few adapters which leverage this agent to provide library / framework specific instrumentation. Note that these will eventually be replaced with `telemetry` based instrumentation.
 
 * `Absinthe` https://github.com/binaryseed/new_relic_absinthe
+
+#### Disabling
+
+If you want to disable the New Relic's agent, you can do it in two different ways:
+
+* Application config:
+  * `config :new_relic_agent, app_name: nil`
+  * `config :new_relic_agent, license_key: nil`
+* Environment variables: `NEW_RELIC_HARVEST_ENABLED=false`

--- a/README.md
+++ b/README.md
@@ -178,7 +178,5 @@ There are a few adapters which leverage this agent to provide library / framewor
 
 If you want to disable the New Relic's agent, you can do it in two different ways:
 
-* Application config:
-  * `config :new_relic_agent, app_name: nil`
-  * `config :new_relic_agent, license_key: nil`
+* Application config: `config :new_relic_agent, license_key: nil`
 * Environment variables: `NEW_RELIC_HARVEST_ENABLED=false`


### PR DESCRIPTION
I was reading the docs looking through how to disable the agent to do some test, but couldn't find it anywhere besides the implementation (https://github.com/newrelic/elixir_agent/blob/master/lib/new_relic/config.ex#L209).

This PR adds this topic to the documentation.