### PR TITLE
Allow custom httpc request options to be set

### DIFF
--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -42,6 +42,8 @@ defmodule NewRelic.Util.HTTP do
   https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
   """
   def http_options(opts \\ []) do
+    env_opts = Application.get_env(:new_relic_agent, :httpc_request_options, [])
+
     [
       connect_timeout: 1000,
       ssl: [
@@ -53,5 +55,6 @@ defmodule NewRelic.Util.HTTP do
       ]
     ]
     |> Keyword.merge(opts)
+    |> Keyword.merge(env_opts)
   end
 end


### PR DESCRIPTION
We're seeing http connection timeouts due to slow server responses. This
allows users to define custom configuration for the httpc request
options so they can pass in a timeout that is relevant for their servers.

Fixes https://github.com/newrelic/elixir_agent/issues/390