### PR TITLE
Show both LiveView and action name in transaction when action is given

### DIFF
--- a/lib/new_relic/telemetry/phoenix.ex
+++ b/lib/new_relic/telemetry/phoenix.ex
@@ -84,12 +84,18 @@ defmodule NewRelic.Telemetry.Phoenix do
     :ignore
   end
 
-  defp phoenix_name(%{plug: controller, plug_opts: action}) when is_atom(action) do
-    "/Phoenix/#{inspect(controller)}/#{action}"
+  defp nice_name(atom), do: atom |> Atom.to_string() |> String.replace(~r/^Elixir\./, "")
+
+  defp phoenix_name(%{plug: controller, plug_opts: action, phoenix_live_view: {view, _, _, _}}) when is_atom(action) and action == view do
+    "/Phoenix/#{inspect(controller)}/#{nice_name(action)}"
+  end
+
+  defp phoenix_name(%{plug: controller, plug_opts: action, phoenix_live_view: {view, _, _, _}}) when is_atom(action) do
+    "/Phoenix/#{inspect(controller)}/#{nice_name(view)}/#{action}"
   end
 
   defp phoenix_name(%{conn: %{private: %{phoenix_endpoint: phoenix_endpoint}} = conn}) do
-    "/Phoenix/#{inspect(phoenix_endpoint)}/#{conn.method}"
+    "/Phoenix/#{nice_name(phoenix_endpoint)}/#{conn.method}"
   end
 
   defp phoenix_name(%{conn: conn}) do

--- a/lib/new_relic/telemetry/phoenix.ex
+++ b/lib/new_relic/telemetry/phoenix.ex
@@ -86,12 +86,18 @@ defmodule NewRelic.Telemetry.Phoenix do
 
   defp nice_name(atom), do: atom |> Atom.to_string() |> String.replace(~r/^Elixir\./, "")
 
-  defp phoenix_name(%{plug: controller, plug_opts: action, phoenix_live_view: {view, _, _, _}}) when is_atom(action) and action == view do
-    "/Phoenix/#{inspect(controller)}/#{nice_name(action)}"
+  defp phoenix_name(%{plug_opts: action, phoenix_live_view: live_view}) when is_atom(action) do
+    view = elem(live_view, 0)
+
+    if action == view do
+      "/Phoenix/#{nice_name(action)}"
+    else
+      "/Phoenix/#{nice_name(view)}/#{action}"
+    end
   end
 
-  defp phoenix_name(%{plug: controller, plug_opts: action, phoenix_live_view: {view, _, _, _}}) when is_atom(action) do
-    "/Phoenix/#{inspect(controller)}/#{nice_name(view)}/#{action}"
+  defp phoenix_name(%{plug: controller, plug_opts: action}) when is_atom(action) do
+    "/Phoenix/#{inspect(controller)}/#{nice_name(action)}"
   end
 
   defp phoenix_name(%{conn: %{private: %{phoenix_endpoint: phoenix_endpoint}} = conn}) do


### PR DESCRIPTION
We were having an issue where transactions were very confusingly labeled on LiveViews. Consider the example.

```
live "/stuff", StuffLive, :home
live "/more", MoreLive, :home
live "/home", HomeLive, :do_things
```

Because of the naming logic in the Phoenix tracing, these would log as the following:
```
StuffLive -> Phoenix.LiveView.Plug/home
MoreLive -> Phoenix.LiveView.Plug/home
HomeLive -> Phoenix.LiveView.Plug/do_things
```

If you leave the action off completely, it would just log the name of the LiveView but with `Elixir.` prefixed (fully qualified atom name) which was much nicer.

This change uses both the name of the LiveView as well as the action name if both are given, and also strips the `Elixir.`:
```
StuffLive -> Phoenix.LiveView.Plug/ProjectName.StuffLive/home
MoreLive -> Phoenix.LiveView.Plug/ProjectName.MoreLive/home
HomeLive -> Phoenix.LiveView.Plug/ProjectName.HomeLive/do_things
```


