### PR TITLE
Update Logger implementation to be purgeable

### DIFF
--- a/lib/new_relic/logger.ex
+++ b/lib/new_relic/logger.ex
@@ -31,7 +31,7 @@ defmodule NewRelic.Logger do
   # Server
 
   def handle_cast({:log, level, message}, %{io_device: Logger} = state) do
-    Logger.log(level, "new_relic_agent - " <> message)
+    elixir_logger(level, "new_relic_agent - " <> message)
     {:noreply, state}
   end
 
@@ -78,6 +78,11 @@ defmodule NewRelic.Logger do
     logfile |> Path.dirname() |> File.mkdir_p!()
     {:ok, _file} = File.open(logfile, [:append, :utf8])
   end
+
+  defp elixir_logger(:debug, message), do: Logger.debug(message)
+  defp elixir_logger(:info, message), do: Logger.info(message)
+  defp elixir_logger(:warn, message), do: Logger.warn(message)
+  defp elixir_logger(:error, message), do: Logger.error(message)
 
   @sep " - "
   def formatted(level, message), do: [formatted(level), @sep, timestamp(), @sep, message, "\n"]


### PR DESCRIPTION
Using Logger.log makes compile time purge matching [not possible](https://hexdocs.pm/logger/1.9.4/Logger.html#log/3) which means logging is all or nothing with regards to purging.

This change would allow compile time purge matching by log level when using the elixir Logger, so one could get rid of debug logging instead of all logging.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
