### PR TITLE
Add 504 errors to list of retryables

### DIFF
--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -60,7 +60,7 @@ defmodule NewRelic.Harvest.Collector.Protocol do
 
   defp retry_call({:ok, response}, _params, _payload), do: {:ok, response}
 
-  @retryable [408, 429, 500, 503]
+  @retryable [408, 429, 500, 503, 504]
   defp retry_call({:error, status}, params, payload) when status in @retryable,
     do: issue_call(params, payload)
 


### PR DESCRIPTION
We were finding intermittent instances of failed 504 Gateway Timeouts when the agent first tries to connect from a cell-based architecture. This resulted in a healthy instance of our application running, but without agent reporting. Allowing retries in the case of 504s has resolved the issue for us, and we think it may be beneficial for others.
@mattbaker 