### PR TITLE
trying something

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   unit_test:
     name: Unit Tests - Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Our github actions have been working fine up to September 2022, the last PR to merge.  I think there have been changes with the [setup action](https://github.com/erlef/setup-beam/releases/tag/v1.13.0) and now certain combinations of erlang are throwing errors. 

This [issue comment](https://github.com/erlef/setup-beam/issues/187#issuecomment-1509885275)  shows that the latest ubuntu 22.04 was not built for OTP 23.  

🤔  It makes me wonder how the github action was successful in the past. The logs have expired so can't go back and see what exactly happened with OTP 23, what version of ubuntu was actually used. 

The CI tests are now running.  It is most likely possible to separate out OTP 23 from OTP 24 and have it run on a different ubuntu version. I would need to explore Github actions api and figure out how that works.  Is that a priority?