### PR TITLE
Aggregate dimensional metrics

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -230,6 +230,17 @@ defmodule NewRelic do
     to: NewRelic.Harvest.Collector.CustomEvent.Harvester
 
   @doc """
+  Report a Dimensional Metric.
+  Valid types: `:count`, `:gauge`, and `:summary`.
+
+  ```elixir
+  NewRelic.report_dimensional_metric(:count, "my_metric_name", 1, %{some: "attributes"})
+  ```
+  """
+  defdelegate report_dimensional_metric(type, name, value, attributes \\ %{}),
+    to: NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester
+
+  @doc """
   Report a Custom metric.
 
   ```elixir

--- a/lib/new_relic/harvest/supervisor.ex
+++ b/lib/new_relic/harvest/supervisor.ex
@@ -14,7 +14,8 @@ defmodule NewRelic.Harvest.Supervisor do
     Harvest.Collector.CustomEvent.HarvestCycle,
     Harvest.Collector.ErrorTrace.HarvestCycle,
     Harvest.TelemetrySdk.Logs.HarvestCycle,
-    Harvest.TelemetrySdk.Spans.HarvestCycle
+    Harvest.TelemetrySdk.Spans.HarvestCycle,
+    Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle
   ]
 
   def start_link(_) do

--- a/lib/new_relic/harvest/telemetry_sdk/api.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/api.ex
@@ -17,6 +17,14 @@ defmodule NewRelic.Harvest.TelemetrySdk.API do
     |> maybe_retry(url, payload)
   end
 
+  def dimensional_metric(metrics) do
+    url = url(:metric)
+    payload = {:metrics, metrics, generate_request_id()}
+
+    request(url, payload)
+    |> maybe_retry(url, payload)
+  end
+
   def request(url, payload) do
     post(url, payload)
   end

--- a/lib/new_relic/harvest/telemetry_sdk/config.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/config.ex
@@ -3,7 +3,8 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
 
   @default %{
     logs_harvest_cycle: 5_000,
-    spans_harvest_cycle: 5_000
+    spans_harvest_cycle: 5_000,
+    dimensional_metrics_harvest_cycle: 5_000
   }
   def lookup(key) do
     Application.get_env(:new_relic_agent, key, @default[key])
@@ -18,7 +19,8 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
 
     %{
       log: "https://#{env}log-api.#{region}newrelic.com/log/v1",
-      trace: trace_domain(env, region)
+      trace: trace_domain(env, region),
+      metric: metric_domain(env, region)
     }
   end
 
@@ -33,5 +35,9 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
 
   defp trace_domain(_env, _region, infinite_tracing_host) do
     "https://#{infinite_tracing_host}/trace/v1"
+  end
+
+  defp metric_domain(env, region) do
+    "https://#{env}metric-api.#{region}newrelic.com/metric/v1"
   end
 end

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -77,14 +77,12 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
          %{type: :count, name: name, value: new_value, attributes: attributes} = metric,
          metrics_acc
        ) do
-    attributes_hash = :erlang.phash2(attributes)
-
-    case Map.get(metrics_acc, {:count, name, attributes_hash}) do
+    case Map.get(metrics_acc, {:count, name, attributes}) do
       nil ->
-        Map.put(metrics_acc, {:count, name, attributes_hash}, metric)
+        Map.put(metrics_acc, {:count, name, attributes}, metric)
 
       %{type: :count, value: current_value} = current_metric ->
-        Map.put(metrics_acc, {:count, name, attributes_hash}, %{
+        Map.put(metrics_acc, {:count, name, attributes}, %{
           current_metric
           | value: current_value + new_value
         })
@@ -95,14 +93,12 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
          %{type: :gauge, name: name, value: new_value, attributes: attributes} = metric,
          metrics_acc
        ) do
-    attributes_hash = :erlang.phash2(attributes)
-
-    case Map.get(metrics_acc, {:gauge, name, attributes_hash}) do
+    case Map.get(metrics_acc, {:gauge, name, attributes}) do
       nil ->
-        Map.put(metrics_acc, {:gauge, name, attributes_hash}, metric)
+        Map.put(metrics_acc, {:gauge, name, attributes}, metric)
 
       %{type: :gauge} = current_metric ->
-        Map.put(metrics_acc, {:gauge, name, attributes_hash}, %{current_metric | value: new_value})
+        Map.put(metrics_acc, {:gauge, name, attributes}, %{current_metric | value: new_value})
     end
   end
 
@@ -110,9 +106,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
          %{type: :summary, name: name, value: new_value, attributes: attributes},
          metrics_acc
        ) do
-    attributes_hash = :erlang.phash2(attributes)
-
-    case Map.get(metrics_acc, {:summary, name, attributes_hash}) do
+    case Map.get(metrics_acc, {:summary, name, attributes}) do
       nil ->
         new_summary = %{
           type: :summary,
@@ -126,12 +120,12 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
           attributes: attributes
         }
 
-        Map.put(metrics_acc, {:summary, name, attributes_hash}, new_summary)
+        Map.put(metrics_acc, {:summary, name, attributes}, new_summary)
 
       %{type: :summary} = current_metric ->
         Map.put(
           metrics_acc,
-          {:summary, name, attributes_hash},
+          {:summary, name, attributes},
           %{current_metric | value: update_summary_value_map(current_metric, new_value)}
         )
     end

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -85,31 +85,23 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
             Map.put(metrics_acc, {type, name, attributes_hash}, metric)
         end
 
-      %{type: :count, name: name, value: current_value, attributes: attributes} ->
-        updated_metric = %{
-          type: :count,
-          name: name,
-          value: current_value + new_value,
-          attributes: attributes
-        }
-
+      %{type: :count, value: current_value} = current_metric ->
+        updated_metric = %{current_metric | value: current_value + new_value}
         Map.put(metrics_acc, {type, name, attributes_hash}, updated_metric)
 
-      %{type: :gauge, name: name, value: _current_value, attributes: attributes} ->
-        updated_metric = %{type: :gauge, name: name, value: new_value, attributes: attributes}
+      %{type: :gauge} = current_metric ->
+        updated_metric = %{current_metric | value: new_value}
         Map.put(metrics_acc, {type, name, attributes_hash}, updated_metric)
 
-      %{
-        type: :summary,
-        name: name,
-        count: current_value,
-        min: min,
-        max: max,
-        sum: sum,
-        attributes: attributes
-      } ->
-        # TODO
-        metrics_acc
+      %{type: :summary, min: min, max: max, count: count, sum: sum} = current_metric ->
+        updated_sum = %{current_metric | sum: sum + new_value}
+        updated_count = %{updated_sum | count: count + 1}
+
+        updated_min =
+          if new_value < min, do: %{updated_count | min: new_value}, else: updated_count
+
+        all_updated = if new_value > max, do: %{updated_min | max: new_value}, else: updated_min
+        Map.put(metrics_acc, {type, name, attributes_hash}, all_updated)
     end
   end
 

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -1,0 +1,87 @@
+defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
+  use GenServer
+
+  @moduledoc false
+
+  alias NewRelic.Harvest
+  alias NewRelic.Harvest.TelemetrySdk
+
+  @interval_ms 5_000
+
+  @valid_types [:count, :gauge, :summary]
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init(_) do
+    {:ok,
+     %{
+       start_time_ms: System.system_time(:millisecond),
+       metrics: []
+     }}
+  end
+
+  # API
+
+  @spec report_dimensional_metric(:count | :gauge | :summary, atom() | binary(), any, map()) ::
+          :ok
+  def report_dimensional_metric(type, name, value, attributes) when type in @valid_types do
+    TelemetrySdk.DimensionalMetrics.HarvestCycle
+    |> Harvest.HarvestCycle.current_harvester()
+    |> GenServer.cast({:report, %{type: type, name: name, value: value, attributes: attributes}})
+  end
+
+  def gather_harvest,
+    do:
+      TelemetrySdk.DimensionalMetrics.HarvestCycle
+      |> Harvest.HarvestCycle.current_harvester()
+      |> GenServer.call(:gather_harvest)
+
+  # do not accept more report messages when harvest has already been reported
+  def handle_cast(_late_msg, :completed), do: {:noreply, :completed}
+
+  def handle_cast({:report, metric}, state) do
+    # TODO: merge metrics with the same type/name/attributes?
+    {:noreply, %{state | metrics: [metric | state.metrics]}}
+  end
+
+  # do not resend metrics when harvest has already been reported
+  def handle_call(_late_msg, _from, :completed), do: {:reply, :completed, :completed}
+
+  def handle_call(:send_harvest, _from, state) do
+    send_harvest(state)
+    {:reply, :ok, :completed}
+  end
+
+  def handle_call(:gather_harvest, _from, state) do
+    {:reply, build_dimensional_metric_data(state.metrics, state), state}
+  end
+
+  # Helpers
+
+  defp send_harvest(state) do
+    TelemetrySdk.API.log(build_dimensional_metric_data(state.metrics, state))
+    log_harvest(length(state.metrics))
+  end
+
+  defp log_harvest(harvest_size) do
+    NewRelic.log(
+      :debug,
+      "Completed TelemetrySdk.DimensionalMetrics harvest - size: #{harvest_size}"
+    )
+  end
+
+  defp build_dimensional_metric_data(metrics, state) do
+    [
+      %{
+        metrics: metrics,
+        common: common(state)
+      }
+    ]
+  end
+
+  defp common(%{start_time_ms: start_time_ms}) do
+    %{"timestamp" => start_time_ms, "interval.ms" => @interval_ms}
+  end
+end

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -99,16 +99,17 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
         updated_metric = %{type: :gauge, name: name, value: new_value, attributes: attributes}
         Map.put(metrics_acc, {type, name, attributes_hash}, updated_metric)
 
-        # TODO aggregate summary metric
-        %{
-          type: type,
-          name: name,
-          count: current_value,
-          min: min,
-          max: max,
-          sum: sum,
-          attributes: attributes
-        } = metrics_acc
+      %{
+        type: :summary,
+        name: name,
+        count: current_value,
+        min: min,
+        max: max,
+        sum: sum,
+        attributes: attributes
+      } ->
+        # TODO
+        metrics_acc
     end
   end
 

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -18,8 +18,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
     {:ok,
      %{
        start_time_ms: System.system_time(:millisecond),
-       metrics: %{},
-       attributes: %{}
+       metrics: []
      }}
   end
 
@@ -43,15 +42,10 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
   def handle_cast(_late_msg, :completed), do: {:noreply, :completed}
 
   def handle_cast({:report, metric}, state) do
-    # convert metric to tuple key
-    key = metric_key(metric)
-
-    {:noreply,
-     %{
-       state
-       | metrics: merge(state.metrics, key, metric),
-         attributes: Map.put_new(state.attributes, key, metric[:attributes])
-     }}
+    # TODO: merge metrics with the same type/name/attributes?
+    # Take phash2 of attributes and store them as a map with the
+    # key being {type, name, phash2(attributes)} => [metrics]
+    {:noreply, %{state | metrics: [metric | state.metrics]}}
   end
 
   # do not resend metrics when harvest has already been reported
@@ -67,32 +61,6 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
   end
 
   # Helpers
-
-  defp merge(metrics, key, metric) do
-    # put or update counter
-    Map.update(metrics, key, default(metric), &update(&1, metric))
-  end
-
-  @size 1
-  defp default(metric) do
-    @size
-    |> :counters.new([])
-    |> update(metric)
-  end
-
-  @index 1
-  defp update(counters, metric) do
-    :counters.add(counters, @index, metric[:value])
-  end
-
-  @spec metric_key(%{
-          required(:type) => atom(),
-          required(:name) => binary(),
-          required(:attributes) => map()
-        }) :: {atom(), binary(), non_neg_integer()}
-  defp metric_key(%{type: type, name: name, attributes: attributes}) do
-    {type, name, :erlang.phash2(attributes)}
-  end
 
   defp send_harvest(state) do
     TelemetrySdk.API.log(build_dimensional_metric_data(state.metrics, state))

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -6,7 +6,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
   alias NewRelic.Harvest
   alias NewRelic.Harvest.TelemetrySdk
 
-  @interval_ms 5_000
+  @interval_ms TelemetrySdk.Config.lookup(:dimensional_metrics_harvest_cycle)
 
   @valid_types [:count, :gauge, :summary]
 

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -69,9 +69,20 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
       nil ->
         case type do
           :summary ->
-            new_summary = %{type: type, name: name, count: 1, min: new_value, max: new_value, sum: new_value, attributes: attributes}
+            new_summary = %{
+              type: type,
+              name: name,
+              count: 1,
+              min: new_value,
+              max: new_value,
+              sum: new_value,
+              attributes: attributes
+            }
+
             Map.put(metrics_acc, {type, name, attributes_hash}, new_summary)
-          _ -> Map.put(metrics_acc, {type, name, attributes_hash}, metric)
+
+          _ ->
+            Map.put(metrics_acc, {type, name, attributes_hash}, metric)
         end
 
       %{type: :count, name: name, value: current_value, attributes: attributes} ->
@@ -88,9 +99,16 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
         updated_metric = %{type: :gauge, name: name, value: new_value, attributes: attributes}
         Map.put(metrics_acc, {type, name, attributes_hash}, updated_metric)
 
-      %{type: type, name: name, count: current_value, min: min, max: max, sum: sum, attributes: attributes} =
-       #TODO aggregate summary metric
-        metrics_acc
+        # TODO aggregate summary metric
+        %{
+          type: type,
+          name: name,
+          count: current_value,
+          min: min,
+          max: max,
+          sum: sum,
+          attributes: attributes
+        } = metrics_acc
     end
   end
 

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -113,7 +113,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
   end
 
   defp send_harvest(state) do
-    metrics = Map.to_list(state.metrics)
+    metrics = Map.values(state.metrics)
     TelemetrySdk.API.log(build_dimensional_metric_data(metrics, state))
     log_harvest(length(metrics))
   end

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -17,7 +17,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
   def init(_) do
     {:ok,
      %{
-       start_time_ms: System.system_time(:millisecond),
+       start_time: get_start_time(),
        metrics: %{}
      }}
   end
@@ -153,12 +153,22 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
     [
       %{
         metrics: metrics,
-        common: common(state)
+        common: common(state.start_time)
       }
     ]
   end
 
-  defp common(%{start_time_ms: start_time_ms}) do
-    %{"timestamp" => start_time_ms, "interval.ms" => @interval_ms}
+  defp common(%{system: start_system_time, mono: start_mono}) do
+    %{
+      "timestamp" => start_system_time,
+      "interval.ms" => System.monotonic_time(:millisecond) - start_mono
+    }
+  end
+
+  defp get_start_time() do
+    %{
+      system: System.system_time(:millisecond),
+      mono: System.monotonic_time(:millisecond)
+    }
   end
 end

--- a/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/dimensional_metrics/harvester.ex
@@ -117,7 +117,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester do
 
   defp send_harvest(state) do
     metrics = Map.values(state.metrics)
-    TelemetrySdk.API.log(build_dimensional_metric_data(metrics, state))
+    TelemetrySdk.API.dimensional_metric(build_dimensional_metric_data(metrics, state))
     log_harvest(length(metrics))
   end
 

--- a/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
@@ -13,7 +13,8 @@ defmodule NewRelic.Harvest.TelemetrySdk.Supervisor do
   def init(_) do
     children = [
       data_supervisor(TelemetrySdk.Logs, :logs_harvest_cycle),
-      data_supervisor(TelemetrySdk.Spans, :spans_harvest_cycle)
+      data_supervisor(TelemetrySdk.Spans, :spans_harvest_cycle),
+      data_supervisor(TelemetrySdk.DimensionalMetrics, :dimensional_metrics_harvest_cycle)
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/test/dimensional_metric_test.exs
+++ b/test/dimensional_metric_test.exs
@@ -9,19 +9,20 @@ defmodule DimensionalMetricTest do
     NewRelic.report_dimensional_metric(:count, "memory.foo_baz", 100, %{cpu: 1000})
     NewRelic.report_dimensional_metric(:summary, "memory.foo_bar", 50, %{cpu: 2000})
 
-    [%{common: common, metrics: metrics}] =
+    [%{common: common, metrics: metrics_map}] =
       TestHelper.gather_harvest(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester)
 
+    metrics = Map.values(metrics_map)
     assert common["interval.ms"] > 0
     assert common["timestamp"] > 0
 
     assert length(metrics) == 2
     [metric1, metric2] = metrics
-    assert metric1.name == "memory.foo_bar"
-    assert metric1.type == :summary
+    assert metric1.name == "memory.foo_baz"
+    assert metric1.type == :count
 
-    assert metric2.name == "memory.foo_baz"
-    assert metric2.type == :count
+    assert metric2.name == "memory.foo_bar"
+    assert metric2.type == :summary
 
     TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
   end

--- a/test/dimensional_metric_test.exs
+++ b/test/dimensional_metric_test.exs
@@ -99,27 +99,4 @@ defmodule DimensionalMetricTest do
 
     TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
   end
-
-  test "metric with nil attribute values are rejected" do
-    TestHelper.restart_harvest_cycle(
-      NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle
-    )
-
-    NewRelic.report_dimensional_metric(:count, "OOM", 1, %{cpu: 1000, oops: nil})
-    NewRelic.report_dimensional_metric(:count, "Hits", 10, %{cpu: 1000})
-    NewRelic.report_dimensional_metric(:count, "OOM", 2, %{cpu: nil})
-
-    [%{metrics: metrics_map}] =
-      TestHelper.gather_harvest(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester)
-
-    metrics = Map.values(metrics_map)
-
-    assert length(metrics) == 1
-    [metric] = metrics
-    assert metric.name == "Hits"
-    assert metric.type == :count
-    assert metric.value == 10
-
-    TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
-  end
 end

--- a/test/dimensional_metric_test.exs
+++ b/test/dimensional_metric_test.exs
@@ -92,10 +92,10 @@ defmodule DimensionalMetricTest do
     [metric] = metrics
     assert metric.name == "duration"
     assert metric.type == :summary
-    assert metric.sum == 126
-    assert metric.min == 9.5
-    assert metric.max == 55.5
-    assert metric.count == 4
+    assert metric.value.sum == 126
+    assert metric.value.min == 9.5
+    assert metric.value.max == 55.5
+    assert metric.value.count == 4
 
     TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
   end

--- a/test/dimensional_metric_test.exs
+++ b/test/dimensional_metric_test.exs
@@ -1,0 +1,28 @@
+defmodule DimensionalMetricTest do
+  use ExUnit.Case
+
+  test "reports dimensional metrics" do
+    TestHelper.restart_harvest_cycle(
+      NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle
+    )
+
+    NewRelic.report_dimensional_metric(:count, "memory.foo_baz", 100, %{cpu: 1000})
+    NewRelic.report_dimensional_metric(:summary, "memory.foo_bar", 50, %{cpu: 2000})
+
+    [%{common: common, metrics: metrics}] =
+      TestHelper.gather_harvest(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester)
+
+    assert common["interval.ms"] > 0
+    assert common["timestamp"] > 0
+
+    assert length(metrics) == 2
+    [metric1, metric2] = metrics
+    assert metric1.name == "memory.foo_bar"
+    assert metric1.type == :summary
+
+    assert metric2.name == "memory.foo_baz"
+    assert metric2.type == :count
+
+    TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
+  end
+end

--- a/test/dimensional_metric_test.exs
+++ b/test/dimensional_metric_test.exs
@@ -99,4 +99,27 @@ defmodule DimensionalMetricTest do
 
     TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
   end
+
+  test "metric with nil attribute values are rejected" do
+    TestHelper.restart_harvest_cycle(
+      NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle
+    )
+
+    NewRelic.report_dimensional_metric(:count, "OOM", 1, %{cpu: 1000, oops: nil})
+    NewRelic.report_dimensional_metric(:count, "Hits", 10, %{cpu: 1000})
+    NewRelic.report_dimensional_metric(:count, "OOM", 2, %{cpu: nil})
+
+    [%{metrics: metrics_map}] =
+      TestHelper.gather_harvest(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.Harvester)
+
+    metrics = Map.values(metrics_map)
+
+    assert length(metrics) == 1
+    [metric] = metrics
+    assert metric.name == "Hits"
+    assert metric.type == :count
+    assert metric.value == 10
+
+    TestHelper.pause_harvest_cycle(NewRelic.Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle)
+  end
 end

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -96,6 +96,25 @@ defmodule IntegrationTest do
     assert resp.status_code == 202
   end
 
+  test "Can post a dimensional metric" do
+    {:ok, resp} =
+      NewRelic.Harvest.TelemetrySdk.API.dimensional_metric([
+        %{
+          metrics: [
+            %{
+              attributes: %{cpu: 1000},
+              name: "mem_percent.foo_baz",
+              type: :gauge,
+              value: 90
+            }
+          ],
+          common: %{"timestamp" => System.system_time(:millisecond), "interval.ms" => 5000}
+        }
+      ])
+
+    assert resp.status_code == 202
+  end
+
   test "EnabledSupervisor starts" do
     NewRelic.EnabledSupervisorManager.start_child()
 

--- a/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
+++ b/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
@@ -11,7 +11,7 @@ defmodule TelemetrySdk.DimensionalMetricsHarvesterTest do
         TelemetrySdk.DimensionalMetrics.Harvester
       )
 
-    metric1 = %{}
+    metric1 = %{type: :gauge, name: "cpu", value: 10, attributes: %{k8: true, id: 123}}
     GenServer.cast(harvester, {:report, metric1})
 
     metrics = GenServer.call(harvester, :gather_harvest)

--- a/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
+++ b/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
@@ -1,0 +1,59 @@
+defmodule TelemetrySdk.DimensionalMetricsHarvesterTest do
+  use ExUnit.Case
+
+  alias NewRelic.Harvest
+  alias NewRelic.Harvest.TelemetrySdk
+
+  test "Harvester collects dimensional metrics" do
+    {:ok, harvester} =
+      DynamicSupervisor.start_child(
+        TelemetrySdk.DimensionalMetrics.HarvesterSupervisor,
+        TelemetrySdk.DimensionalMetrics.Harvester
+      )
+
+    metric1 = %{}
+    GenServer.cast(harvester, {:report, metric1})
+
+    metrics = GenServer.call(harvester, :gather_harvest)
+    assert length(metrics) > 0
+  end
+
+  test "harvest cycle" do
+    Application.put_env(:new_relic_agent, :dimensional_metrics_harvest_cycle, 300)
+    TestHelper.restart_harvest_cycle(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+
+    first = Harvest.HarvestCycle.current_harvester(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+    Process.monitor(first)
+
+    # Wait until harvest swap
+    assert_receive {:DOWN, _ref, _, ^first, :shutdown}, 1000
+
+    second = Harvest.HarvestCycle.current_harvester(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+    Process.monitor(second)
+
+    refute first == second
+    assert Process.alive?(second)
+
+    TestHelper.pause_harvest_cycle(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+    Application.delete_env(:new_relic_agent, :dimensional_metrics_harvest_cycle)
+
+    # Ensure the last harvester has shut down
+    assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000
+  end
+
+  test "Ignore late reports" do
+    TestHelper.restart_harvest_cycle(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+
+    harvester =
+      TelemetrySdk.DimensionalMetrics.HarvestCycle
+      |> Harvest.HarvestCycle.current_harvester()
+
+    assert :ok == GenServer.call(harvester, :send_harvest)
+
+    GenServer.cast(harvester, {:report, :late_msg})
+
+    assert :completed == GenServer.call(harvester, :send_harvest)
+
+    TestHelper.pause_harvest_cycle(TelemetrySdk.DimensionalMetrics.HarvestCycle)
+  end
+end


### PR DESCRIPTION
This is a stab to build off of this PR #376 

Looking at the original comments by Vince, I think one missing piece was aggregating the dimensional metrics during the 5 second reporting interval? I took a stab at it.@tpitale , if you have some time, love to hear your thoughts on this. I know @mattbaker  is interested in getting it over the finish line. 

Also, I think that [common block ](https://github.com/newrelic/elixir_agent/commit/95bef6962b1cc9b495ad2e468a28da3cfeaadfb2#diff-acdef3942c8febdf5fe3c3d38c0f8526935fa34e02a0bac66d39560fec274362R84-R85)is accurate for `count` and `summary` - https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api/#optional-map-attributes.

But for `gauge`, it appears the interval.ms value isn't required. It probably does no harm 😄 As an aside, the[ old NR Telemetry SDK specs](https://source.datanerd.us/agents/telemetry-sdk-specs/blob/master/capabilities.md#gauge) also show `gauge` without interval.ms
