### PR TITLE
track and update longest external request

### DIFF
--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -93,6 +93,8 @@ defmodule NewRelic.Tracer.Report do
 
         NewRelic.report_metric({:external, url, component, method}, duration_s: duration_s)
 
+        Transaction.Reporter.track_longest_external(duration_ms)
+
         Transaction.Reporter.track_metric({
           {:external, url, component, method},
           duration_s: duration_s
@@ -132,6 +134,8 @@ defmodule NewRelic.Tracer.Report do
         )
 
         NewRelic.report_metric({:external, function_name}, duration_s: duration_s)
+
+        Transaction.Reporter.track_longest_external(duration_ms)
 
         Transaction.Reporter.track_metric({
           {:external, function_name},

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -106,4 +106,8 @@ defmodule NewRelic.Transaction.Reporter do
   def track_spawn(parent, child, timestamp) do
     Transaction.Sidecar.track_spawn(parent, child, timestamp)
   end
+
+  def track_longest_external(duration_ms) do
+    Transaction.Sidecar.update_longest_external(duration_ms)
+  end
 end

--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -82,6 +82,10 @@ defmodule NewRelic.Transaction.Sidecar do
     cast({:append_attributes, attrs})
   end
 
+  def update_longest_external (duration_ms) do
+    cast({:update_longest_external, duration_ms})
+  end
+
   def trace_context(context) do
     :ets.insert(__MODULE__.ContextStore, {{:context, get_sidecar()}, context})
   end
@@ -140,6 +144,11 @@ defmodule NewRelic.Transaction.Sidecar do
         Map.update(acc, key, [val], &[val | &1])
       end)
 
+    {:noreply, %{state | attributes: attributes}}
+  end
+
+  def handle_cast({:update_longest_external, duration_ms}, state) do
+    attributes = Map.update(state[:attributes], "external.longest_call", duration_ms, fn existing_duration -> if existing_duration > duration_ms, do: existing_duration, else: duration_ms  end)
     {:noreply, %{state | attributes: attributes}}
   end
 

--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -82,7 +82,7 @@ defmodule NewRelic.Transaction.Sidecar do
     cast({:append_attributes, attrs})
   end
 
-  def update_longest_external (duration_ms) do
+  def update_longest_external(duration_ms) do
     cast({:update_longest_external, duration_ms})
   end
 
@@ -148,7 +148,11 @@ defmodule NewRelic.Transaction.Sidecar do
   end
 
   def handle_cast({:update_longest_external, duration_ms}, state) do
-    attributes = Map.update(state[:attributes], "external.longest_call", duration_ms, fn existing_duration -> if existing_duration > duration_ms, do: existing_duration, else: duration_ms  end)
+    attributes =
+      Map.update(state[:attributes], "external.longest_call", duration_ms, fn existing_duration ->
+        if existing_duration > duration_ms, do: existing_duration, else: duration_ms
+      end)
+
     {:noreply, %{state | attributes: attributes}}
   end
 


### PR DESCRIPTION
This tracks the longest external request as a transaction attribute, per transaction. Another possibility is it can be tracked as a metric - probably should be a single metric per harvest for longest external, not a metric per transaction. 

Here are some testing results - https://staging.onenr.io/0a2wdYVZERE
