### PR TITLE
Add option to redact args in stacktraces

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -159,6 +159,10 @@ defmodule NewRelic.Config do
     get(:features, :function_argument_collection)
   end
 
+  def feature?(:stacktrace_argument_collection) do
+    get(:features, :stacktrace_argument_collection)
+  end
+
   def feature?(:request_queuing_metrics) do
     get(:features, :request_queuing_metrics)
   end

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -96,6 +96,11 @@ defmodule NewRelic.Init do
           "NEW_RELIC_FUNCTION_ARGUMENT_COLLECTION_ENABLED",
           :function_argument_collection_enabled
         ),
+      stacktrace_argument_collection:
+        determine_feature(
+          "NEW_RELIC_STACKTRACE_ARGUMENT_COLLECTION_ENABLED",
+          :stacktrace_argument_collection_enabled
+        ),
       request_queuing_metrics:
         determine_feature(
           "NEW_RELIC_REQUEST_QUEUING_METRICS_ENABLED",

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -55,7 +55,11 @@ defmodule ErrorTest do
 
     refute String.contains?(List.first(trace_error.stack_trace), "secretvalue")
     refute String.contains?(List.first(trace_error.stack_trace), "other_secret")
-    assert String.contains?(List.first(trace_error.stack_trace), "Not.secretfun(\"DISABLED (arity: 2)\")")
+
+    assert String.contains?(
+             List.first(trace_error.stack_trace),
+             "Not.secretfun(\"DISABLED (arity: 2)\")"
+           )
 
     reset_features.()
   end


### PR DESCRIPTION
We'd like an option to redact arguments in stacktraces before the stacktraces are sent to New Relic.

This draft currently adds a configuration value that will replace arguments in a stacktrace with the string `"DISABLED arity: ($X")`

It's a work in progress.

TODO:

- [ ] Tests to verify args are redacted in all the ways stacktraces can leave the agent for New Relic