### PR TITLE
Optionally disable stacktrace args

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -159,6 +159,10 @@ defmodule NewRelic.Config do
     get(:features, :function_argument_collection)
   end
 
+  def feature?(:stacktrace_argument_collection) do
+    get(:features, :stacktrace_argument_collection)
+  end
+
   def feature?(:request_queuing_metrics) do
     get(:features, :request_queuing_metrics)
   end

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -96,6 +96,11 @@ defmodule NewRelic.Init do
           "NEW_RELIC_FUNCTION_ARGUMENT_COLLECTION_ENABLED",
           :function_argument_collection_enabled
         ),
+      stacktrace_argument_collection:
+        determine_feature(
+          "NEW_RELIC_STACKTRACE_ARGUMENT_COLLECTION_ENABLED",
+          :stacktrace_argument_collection_enabled
+        ),
       request_queuing_metrics:
         determine_feature(
           "NEW_RELIC_REQUEST_QUEUING_METRICS_ENABLED",

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -12,6 +12,7 @@ defmodule ErrorTest do
     def handle_call(:secretfun, _from, _state), do: Not.secretfun("secretvalue", "other_secret")
     def handle_call(:sleep, _from, _state), do: :timer.sleep(:infinity)
     def handle_call(:raise, _from, _state), do: raise("ERROR")
+    def handle_call(:erlang_error, _from, _state), do: raise(:erlang.error(:badarg))
   end
 
   test "Catch and harvest errors" do
@@ -114,6 +115,27 @@ defmodule ErrorTest do
     assert Enum.find(events, fn [intrinsic, _, _] ->
              intrinsic[:"error.class"] == "ArgumentError"
            end)
+  end
+
+  test "Handle Erlang exception when stacktrace arg colleection is turned off" do
+    Process.flag(:trap_exit, true)
+    TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
+    TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
+    ErrorDummy.start_link()
+
+    reset_features = TestHelper.update(:nr_features, stacktrace_argument_collection: false)
+
+    capture_log(fn ->
+      catch_exit do
+        GenServer.call(ErrorDummy, :erlang_error)
+      end
+    end)
+
+    [[_, event_error, _]] = TestHelper.gather_harvest(Collector.TransactionErrorEvent.Harvester)
+
+    assert String.contains?(event_error.stacktrace, "init(\"DISABLED (arity: 1)\")")
+
+    reset_features.()
   end
 
   test "Catch a simple raise" do

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -55,7 +55,11 @@ defmodule ErrorTest do
 
     refute String.contains?(List.first(trace_error.stack_trace), "secretvalue")
     refute String.contains?(List.first(trace_error.stack_trace), "other_secret")
-    assert String.contains?(List.first(trace_error.stack_trace), "Not.secretfun(\"DISABLED (arity: 2)\")")
+
+    assert String.contains?(
+             List.first(trace_error.stack_trace),
+             "Not.secretfun(\"DISABLED (arity: 2)\")"
+           )
 
     reset_features.()
   end


### PR DESCRIPTION
Stacktrace arguments may contain sensitive information. This work adds a configurable option to globally redact arguments from stacktraces that are reported. Original WIP: https://github.com/newrelic/elixir_agent/pull/416
@mattbaker