### PR TITLE
Additional elixir 1.15 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ config :new_relic_agent,
   httpc_request_options: [connect_timeout: 5000]
 ```
 
+#### For Elixir 1.15 and higher
+
+Due to changes in the Elixir 1.15 Logger, additional logger configuration is needed for NewRelic to capture all errors. Update your logger configuration by setting `handle_sasl_reports` to `true` and adding `NewRelic.ErrorLogger` to your logger backends.
+
+```elixir
+config :logger,
+  handle_sasl_reports: true,
+  backends: [:console, NewRelic.ErrorLogger]
+```
+
 ## Telemetry-based Instrumentation
 
 Some common Elixir packages are auto-instrumented via [`telemetry`](https://github.com/beam-telemetry/telemetry)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,8 @@
 import Config
 
-config :logger, handle_sasl_reports: true
+config :logger,
+  handle_sasl_reports: true,
+  backends: [NewRelic.ErrorLogger]
 
 if Mix.env() == :test, do: import_config("test.exs")
 if File.exists?("config/secret.exs"), do: import_config("secret.exs")

--- a/lib/new_relic/error/logger_handler.ex
+++ b/lib/new_relic/error/logger_handler.ex
@@ -16,7 +16,7 @@ defmodule NewRelic.Error.LoggerHandler do
       NewRelic.Error.Reporter.report_error(:process, report)
     end
 
-    :none
+    :skip
   end
 
   def translator(_level, :error, _timestamp, {_, %{args: _, function: _}} = metadata) do

--- a/lib/new_relic/error_logger.ex
+++ b/lib/new_relic/error_logger.ex
@@ -1,0 +1,42 @@
+defmodule NewRelic.ErrorLogger do
+  @moduledoc """
+  Handle error reporting in elixir >= 1.15
+  """
+  @behaviour :gen_event
+
+  import NewRelic.ConditionalCompile
+
+  def init(opts) do
+    after_elixir_version(
+      "1.15.0",
+      Logger.add_translator({__MODULE__, :translator})
+    )
+
+    {:ok, opts}
+  end
+
+  def handle_call(_opts, state), do: {:ok, :ok, state}
+
+  def handle_event(_opts, state), do: {:ok, state}
+
+  def handle_info(_opts, state), do: {:ok, state}
+
+  def code_change(_old_vsn, state, _extra), do: {:ok, state}
+
+  def terminate(_reason, _state) do
+    after_elixir_version(
+      "1.15.0",
+      Logger.remove_translator({__MODULE__, :translator})
+    )
+
+    :ok
+  end
+
+  # Don't log SASL progress reports
+  def translator(_level, _message, _timestamp, {{caller, :progress}, _})
+      when caller in [:supervisor, :application_controller] do
+    :skip
+  end
+
+  def translator(_level, _message, _timestamp, _metadata), do: :none
+end


### PR DESCRIPTION
This is a follow on to PR https://github.com/newrelic/elixir_agent/pull/421 and should completely address Issue https://github.com/newrelic/elixir_agent/issues/419

The purpose of the new `NewRelic.ErrorLogger` module is to prevent Logger from displaying the MANY status messages caused by enabling `handle_sasl_reports`.

I don't like requiring the user update their `:logger` config to allow the agent to capture errors, but can't think of another way to do it.

This PR also has the nice side effect of not showing the error messages in the console when running `mix test`, because it no longer logs errors to the console during the unit tests.

@tpitale FYI.  This PR plus https://github.com/newrelic/elixir_agent/pull/424, I think it would make a nice update for Elixir users.