### PR TITLE
Add Sum of Squares calculation

### DIFF
--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -110,13 +110,21 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
         add(counter, @total_exclusive_time, encode(metric.total_exclusive_time))
         add(counter, @min_call_time, encode(metric.min_call_time))
         add(counter, @max_call_time, encode(metric.max_call_time))
-        add(counter, @sum_of_squares, encode(metric.sum_of_squares))
 
         Map.put(metrics_acc, {metric.name, metric.scope}, counter)
 
       counter ->
+        total_call_time = metric.total_call_time
+        acc_mean = decode(get(counter, @total_call_time)) / get(counter, @call_count)
+
         add(counter, @call_count, round(metric.call_count))
-        add(counter, @total_call_time, encode(metric.total_call_time))
+        add(counter, @total_call_time, encode(total_call_time))
+
+        mean = decode(get(counter, @total_call_time)) / get(counter, @call_count)
+
+        delta = total_call_time - acc_mean
+        delta2 = total_call_time - mean
+
         add(counter, @total_exclusive_time, encode(metric.total_exclusive_time))
 
         if metric.min_call_time < decode(get(counter, @min_call_time)),
@@ -125,7 +133,7 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
         if metric.max_call_time > decode(get(counter, @max_call_time)),
           do: put(counter, @max_call_time, encode(metric.max_call_time))
 
-        add(counter, @sum_of_squares, encode(metric.sum_of_squares))
+        add(counter, @sum_of_squares, encode(delta * delta2))
 
         metrics_acc
     end

--- a/lib/new_relic/metric/metric.ex
+++ b/lib/new_relic/metric/metric.ex
@@ -7,6 +7,5 @@ defmodule NewRelic.Metric do
             total_call_time: 0,
             total_exclusive_time: 0,
             min_call_time: 0,
-            max_call_time: 0,
-            sum_of_squares: 0
+            max_call_time: 0
 end

--- a/test/metric_harvester_test.exs
+++ b/test/metric_harvester_test.exs
@@ -21,7 +21,41 @@ defmodule MetricHarvesterTest do
     [metric] = metrics
     [metric_ident, metric_values] = metric
     assert metric_ident == %{name: "TestMetric", scope: ""}
-    assert metric_values == [2, 150, 0, 0, 0, 0]
+    assert metric_values == [2, 150, 0, 0, 0, 1_250]
+
+    # Verify that the Harvester shuts down w/o error
+    Process.monitor(harvester)
+    Harvest.HarvestCycle.send_harvest(Collector.Metric.HarvesterSupervisor, harvester)
+    assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
+  end
+
+  test "Harvester - ensure correct sum of squares calculation" do
+    {:ok, harvester} =
+      DynamicSupervisor.start_child(
+        Collector.Metric.HarvesterSupervisor,
+        Collector.Metric.Harvester
+      )
+
+    values = Enum.map(1..100, &:rand.uniform/1)
+
+    Enum.each(values, fn value ->
+      metric = %NewRelic.Metric{name: "TestMetric", call_count: 1, total_call_time: value}
+      GenServer.cast(harvester, {:report, metric})
+    end)
+
+    # Calculate the actual SST value
+    count = Enum.count(values)
+    sum = Enum.sum(values)
+    mean = sum / count
+    sst = Enum.reduce(values, 0, fn val, acc -> :math.pow(val - mean, 2) + acc end)
+
+    # Gather the metric values
+    metrics = GenServer.call(harvester, :gather_harvest)
+    [metric] = metrics
+    [_, [100, _, _, _, _, harvested_sst]] = metric
+
+    # Verify online calculation is within reasonable limits
+    assert abs(sst - harvested_sst) < 0.1
 
     # Verify that the Harvester shuts down w/o error
     Process.monitor(harvester)


### PR DESCRIPTION
Calculate "Total Sum of Squares" value for Metrics.

This uses Welford's online algorithm. It is relatively accurate when using 64-bit floating point values, only losing accuracy on float rounding. Here, there is a bit more lost since the floating points are limited in size and held as integers. (Still better than 0 imho 😄)

This also remove the `sum_of_squares` field from the `NewRelic.Metric` struct since it isn't needed for calculation and doesn't need to have an extra `Access` call on it. Also, counters default to 0, so removed the initial add of 0 to 0.

Adding this value to the reported metrics allows the `stddev` function to be used on the reported metrics. This can be helpful when looking at performance regressions, for example.

Note: This could add a bit of overhead in the extremely hot function it's in! Understandably, this _could_ have negative effects on the overall performance of the agent and reporting metrics on time.

I also noticed that most of the agents don't have this value set, or only set to 0 or 1 or something, so I imagined it's due to the calculation overhead.

My feelings won't be hurt if this doesn't end up in the default branch 💟, but wanted to put this out there for consideration and discussion.

