### PR TITLE
Adds Bandit HTTP server support

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -139,7 +139,7 @@ jobs:
 
     - name: Start integration test dependencies
       run: |
-        docker-compose up -d
+        docker compose up -d
         until pg_isready -h localhost; do sleep 1; done;
         until mysqladmin --protocol tcp ping; do sleep 1; done;
 

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -174,6 +174,7 @@ defmodule NewRelic.Telemetry.Plug do
 
   defp add_start_attrs(meta, system_time, :bandit) do
     headers = Map.new(meta.conn.req_headers)
+
     [
       pid: inspect(self()),
       system_time: system_time,
@@ -214,7 +215,8 @@ defmodule NewRelic.Telemetry.Plug do
       status: status_code(meta),
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],
-      "bandit.resp_duration_ms": (meas[:resp_start_time] |> to_ms) - (meas[:resp_end_time] |> to_ms),
+      "bandit.resp_duration_ms":
+        (meas[:resp_start_time] |> to_ms) - (meas[:resp_end_time] |> to_ms),
       "bandit.resp_body_bytes": meas[:resp_body_bytes]
     ]
     |> NewRelic.add_attributes()

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -214,7 +214,6 @@ defmodule NewRelic.Telemetry.Plug do
       status: status_code(meta),
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],
-      "bandit.monotonic_time": meas[:monotonic_time] |> to_ms,
       "bandit.resp_duration_ms": (meas[:resp_start_time] |> to_ms) - (meas[:resp_end_time] |> to_ms),
       "bandit.resp_body_bytes": meas[:resp_body_bytes]
     ]


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

### Description
This PR aims to add Bandit HTTP server support to New Relic's Elixir agent.

### Suggested changes
- Inclusion of `@bandit_start`, `@bandit_stop`, and `@bandit_exception` Plug events in `plug.ex`, each of them corresponding to [Bandit's telemetry spans](https://hexdocs.pm/bandit/Bandit.Telemetry.html) emitted by Bandit.

### Motivation
Currently New Relic's Elixir agent supports [plug_cowboy](https://github.com/elixir-plug/plug_cowboy) adapter only, and by applying the suggested changes to this lib I was able to collect and send web transactions to New Relic normally.

### Related issues
- https://github.com/newrelic/elixir_agent/issues/415

### Questions
I didn't find any test directly related to `NewRelic.Telemetry.Plug` module, so I couldn't find a way to check if the suggested changes would break any feature. Also I didn't find any indicator on the debug logs that could tell me if something was wrong during my tests, so any advise on how to create a test to check this is more than welcome!
