### PR TITLE
adjust metadata_reporter :transaction report_error

### DIFF
--- a/lib/new_relic/error/metadata_reporter.ex
+++ b/lib/new_relic/error/metadata_reporter.ex
@@ -11,14 +11,14 @@ defmodule NewRelic.Error.MetadataReporter do
 
   def report_error(:transaction, {_cause, metadata}) do
     kind = :error
-    {reason, stacktrace} = metadata.reason
+    {exception, stacktrace} = metadata.reason
     process_name = parse_process_name(metadata[:registered_name], stacktrace)
 
     NewRelic.add_attributes(process: process_name)
 
     NewRelic.Transaction.Reporter.error(%{
       kind: kind,
-      reason: reason,
+      reason: exception,
       stack: stacktrace
     })
   end

--- a/lib/new_relic/error/metadata_reporter.ex
+++ b/lib/new_relic/error/metadata_reporter.ex
@@ -9,9 +9,10 @@ defmodule NewRelic.Error.MetadataReporter do
   # Before elixir 1.15, ignore terminating errors so they don't get reported twice
   before_elixir_version("1.15.0", def(report_error(_, {{_, :terminating}, _}), do: nil))
 
+
   def report_error(:transaction, {_cause, metadata}) do
     kind = :error
-    {_exception_type, reason, stacktrace, _expected} = parse_reason(metadata.reason)
+    {reason, stacktrace} = metadata.reason
     process_name = parse_process_name(metadata[:registered_name], stacktrace)
 
     NewRelic.add_attributes(process: process_name)
@@ -81,6 +82,7 @@ defmodule NewRelic.Error.MetadataReporter do
 
   defp parse_process_name([], [{module, _f, _a, _} | _]), do: inspect(module)
   defp parse_process_name([], _stacktrace), do: "UnknownProcess"
+  defp parse_process_name(nil, _stacktrace), do: "UnknownProcess"
   defp parse_process_name(registered_name, _stacktrace), do: inspect(registered_name)
 
   defp parse_error_expected(%{expected: true}), do: true

--- a/lib/new_relic/error/metadata_reporter.ex
+++ b/lib/new_relic/error/metadata_reporter.ex
@@ -9,7 +9,6 @@ defmodule NewRelic.Error.MetadataReporter do
   # Before elixir 1.15, ignore terminating errors so they don't get reported twice
   before_elixir_version("1.15.0", def(report_error(_, {{_, :terminating}, _}), do: nil))
 
-
   def report_error(:transaction, {_cause, metadata}) do
     kind = :error
     {reason, stacktrace} = metadata.reason


### PR DESCRIPTION
This PR fixes a bug within `lib/new_relic/error/metadata_reporter.ex` which can emerge when upgrading from Elixir 1.14 to 1.15 which could manifest as reported errors which were formerly on the Elixir level could report as being wrapped on the Erlang level.

Compare to the use of the `NewRelic.Transaction.Reporter.error` in this PR to here: https://github.com/newrelic/elixir_agent/blob/56525d921f1910430ce84e8e8f0e7d884e67e61a/lib/new_relic/error/reporter.ex#L38  -- can see the `reason` should be an exception struct (which I believe is further parsed as part of the collection cycle), not the "reason" string explanation

```elixir
NewRelic.Transaction.Reporter.error(%{
      kind: kind,
      reason: exception,
      stack: stacktrace
    })
```

this reason exception and stacktrace can be extracted directly from the metadata.reason tuple:
`{_exception_type, reason, stacktrace, _expected} = parse_reason(metadata.reason)`
can instead simply be `{exception, stacktrace} = metadata.reason`.

When a direct 'reason' string was being passed instead of the expected exception struct, this can manifest as an 'erlang wrapped' error in reporting -- what was `(ErrorType) <message>` becomes `(ErlangError) Erlang Error: (ErrorType) <msesage>` and further metadata is misreported, including for example expected errors being flipped to false (as a result of landing here https://github.com/newrelic/elixir_agent/blob/56525d921f1910430ce84e8e8f0e7d884e67e61a/lib/new_relic/error/metadata_reporter.ex#L73)

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
