### PR TITLE
Rescue bandit too many headers error

### DIFF
--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -270,6 +270,8 @@ defmodule NewRelic.Telemetry.Plug do
 
   defp get_headers(meta, :bandit) do
     Map.new(meta.conn.req_headers)
+  rescue
+    Bandit.HTTPError -> %{}
   end
 
   defp get_headers(meta, :cowboy) do


### PR DESCRIPTION
Bandit can raise when reading headers if there are more than a configurable maximum. Make sure the agent doesn't blow up if this max has been reached by rescuing this exception.

https://github.com/mtrudel/bandit/blob/84e0d5d85c122724056607e60fc37164ba9e4347/lib/bandit/http1/socket.ex#L139-L143

Fixes #447 