### PR TITLE
Handle when Bandit was unable to create a conn

### DIFF
--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -268,8 +268,12 @@ defmodule NewRelic.Telemetry.Plug do
     end
   end
 
-  defp get_headers(meta, :bandit) do
-    Map.new(meta.conn.req_headers)
+  defp get_headers(%{conn: conn}, :bandit) do
+    Map.new(conn.req_headers)
+  end
+
+  defp get_headers(_, :bandit) do
+    %{}
   end
 
   defp get_headers(meta, :cowboy) do


### PR DESCRIPTION
Sometimes Bandit can't create a conn because of various error states, so we need to handle that condition.

Fixes #447 