### PR TITLE
Support ignoring web transaction paths via configuration

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,4 +5,5 @@ config :logger, level: :warning
 config :new_relic_agent,
   app_name: "ElixirAgentTest",
   automatic_attributes: [test_attribute: "test_value"],
-  log: "memory"
+  ignore_paths: ["/ignore/this", ~r(ignore/these/*.)],
+  log: "Logger"

--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -97,6 +97,27 @@ defmodule NewRelic.Config do
     do: get(:labels)
 
   @doc """
+  An optional list of paths that will be used to ignore Web Transactions.
+
+  Individual items can be Strings or Regexes.
+
+  Common use cases include:
+  * Ignore health checks: `"/health"`
+  * Ignore Phoenix longpoll http requests: `"/live/longpoll"`
+
+  Example:
+  ```
+  config :new_relic_agent,
+    ignore_paths: [
+      "/health",
+      ~r/longpoll/
+    ]
+  ```
+  """
+  def ignore_paths,
+    do: get(:ignore_paths)
+
+  @doc """
   Some Agent features can be toggled via configuration.
 
   ### Security

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -39,6 +39,7 @@ defmodule NewRelic.Init do
       region_prefix: region_prefix,
       automatic_attributes: determine_automatic_attributes(),
       labels: determine_config(:labels) |> parse_labels(),
+      ignore_paths: determine_config(:ignore_paths, []),
       telemetry_hosts: telemetry_hosts,
       trace_mode: determine_trace_mode()
     })

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -26,9 +26,15 @@ defmodule NewRelic.Transaction.Reporter do
     Transaction.Sidecar.add(custom_name: custom_name)
   end
 
-  def start_transaction(:web) do
-    Transaction.ErlangTrace.trace()
-    Transaction.Sidecar.track(:web)
+  def start_transaction(:web, path) do
+    if NewRelic.Util.path_match?(path, NewRelic.Config.ignore_paths()) do
+      ignore_transaction()
+      :ignore
+    else
+      Transaction.ErlangTrace.trace()
+      Transaction.Sidecar.track(:web)
+      :collect
+    end
   end
 
   def start_transaction(:other) do

--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -13,7 +13,7 @@ defmodule NewRelic.Transaction.Sidecar do
 
   def track(type) do
     # We use `GenServer.start` to avoid a bi-directional link
-    # and guarentee that we never crash the Transaction process
+    # and guarantee that we never crash the Transaction process
     # even in the case of an unexpected bug. Additionally, this
     # blocks the Transaction process the smallest amount possible
     {:ok, sidecar} = GenServer.start(__MODULE__, {self(), type})

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -179,6 +179,16 @@ defmodule NewRelic.Util do
     with {:ok, name} <- :inet.gethostname(), do: to_string(name)
   end
 
+  def path_match?(_path, []), do: false
+
+  def path_match?(path, path_set) do
+    Enum.any?(path_set, fn
+      string when is_binary(string) -> path == string
+      %Regex{} = regex -> path =~ regex
+      _ -> false
+    end)
+  end
+
   def uuid4() do
     "#{u(4)}-#{u(2)}-4a#{u(1)}-#{u(2)}-#{u(6)}"
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -169,6 +169,14 @@ defmodule TransactionTest do
       send_resp(conn, 200, "ignored")
     end
 
+    get "/ignore/this" do
+      send_resp(conn, 200, "ignore me!")
+    end
+
+    get "/ignore/these/too" do
+      send_resp(conn, 200, "ignore me!")
+    end
+
     get "/total_time" do
       Process.sleep(10)
 
@@ -408,6 +416,17 @@ defmodule TransactionTest do
 
     events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
 
+    assert events == []
+  end
+
+  test "Allow a transaction to be ignored via configuration" do
+    TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
+    Task.Supervisor.start_link(name: TestTaskSup)
+
+    assert %{status_code: 200} = TestHelper.request(TestPlugApp, conn(:get, "/ignore/this"))
+    assert %{status_code: 200} = TestHelper.request(TestPlugApp, conn(:get, "/ignore/these/too"))
+
+    events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
     assert events == []
   end
 


### PR DESCRIPTION
This PR enables Web Transactions to be ignored by path using configuration

Common use cases would be ignoring health checks, or ignoring Phoenix `longpoll` requests

Closes #386 