### PR TITLE
Use Elixir Logger as the default agent logger

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -40,11 +40,12 @@ defmodule NewRelic.Config do
   This controls how the Agent logs it's own behavior, and doesn't impact your
   applications own logging at all.
 
-  Defaults to the File `"tmp/new_relic.log"`.
+  Defaults to using `Logger`.
 
   Options:
+  - `"Logger"` Send Agent logs to Elixir's `Logger`
+  - `"tmp"` Write to `tmp/new_relic.log`
   - `"stdout"` Write directly to Standard Out
-  - `"Logger"` Send Agent logs to Elixir's Logger
   - `"file_name.log"` Write to a chosen file
 
   Agent logging can be configured in two ways:

--- a/lib/new_relic/logger.ex
+++ b/lib/new_relic/logger.ex
@@ -61,7 +61,8 @@ defmodule NewRelic.Logger do
 
   def initial_logger do
     case NewRelic.Config.logger() do
-      nil -> {:file, "tmp/new_relic.log"}
+      nil -> :logger
+      "file" -> {:file, "tmp/new_relic.log"}
       "stdout" -> :stdio
       "memory" -> :memory
       "Logger" -> :logger


### PR DESCRIPTION
This PR sets the default Agent logging behavior to use the Elixir `Logger`, instead of the current behavior of writing directly to `tmp/new_relic.log`

This could be considered a breaking change. It doesn't change the agent's behavior, but obviously changes where logs go, which is something folks probably care about.

Closes #377 