### PR TITLE
Tracer - Create a proper list when tail of list is ignored

### DIFF
--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -281,6 +281,11 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
+  # Replace :__ignored__ with [] when it's the tail of a list so we don't create an improper list
+  def rewrite_call_term({:|, line, [left, :__ignored__]}) do
+    {:|, line, [left, []]}
+  end
+
   def rewrite_call_term(term), do: term
 
   def is_variable?({name, _, context}) when is_variable(name, context), do: true

--- a/test/tracer_macro_test.exs
+++ b/test/tracer_macro_test.exs
@@ -29,6 +29,20 @@ defmodule NewRelic.Tracer.MacroTest do
       assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
     end
 
+    test "create a proper list when ignoring tail of a list" do
+      ast =
+        quote do
+          [a | _ignored]
+        end
+
+      expected =
+        quote do
+          [a | []]
+        end
+
+      assert expected == NewRelic.Tracer.Macro.build_call_args(ast)
+    end
+
     test "strip default values" do
       ast =
         quote do


### PR DESCRIPTION
When rewriting function call arguments as part of a `@trace`... If there's an `_ignored` variable as the tail of a list, prevent creation of an improper list by replacing `:__ignored__` with an empty list `[]`

Closes #366 