### PR TITLE
Add notice_error function for rescued exceptions

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -289,6 +289,25 @@ defmodule NewRelic do
   defdelegate increment_custom_metric(name, count \\ 1),
     to: NewRelic.Harvest.Collector.Metric.Harvester
 
+  @doc """
+  Report an Exception inside a Transaction.
+
+  This should only be used when you `rescue` an exception inside a Transaction,
+  but still want to report it. All un-rescued exceptions are already reported as errors.
+
+  ## Example
+
+  ```elixir
+  try do
+    raise RuntimeError
+  rescue
+    exception -> NewRelic.notice_error(exception, __STACKTRACE__)
+  end
+  ```
+  """
+  @spec notice_error(Exception.t(), Exception.stacktrace()) :: :ok
+  defdelegate notice_error(exception, stacktrace), to: NewRelic.Transaction.Reporter
+
   @doc false
   defdelegate enable_erlang_trace, to: NewRelic.Transaction.ErlangTraceManager
 

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -84,6 +84,14 @@ defmodule NewRelic.Transaction.Reporter do
     :ok
   end
 
+  def notice_error(exception, stacktrace) do
+    if NewRelic.Config.feature?(:error_collector) do
+      error(%{kind: :error, reason: exception, stack: stacktrace})
+    end
+
+    :ok
+  end
+
   def error(error) do
     Transaction.Sidecar.add(transaction_error: {:error, error})
   end


### PR DESCRIPTION
Provides a new function `NewRelic.notice_error/2` to report a rescued exception inside a Transaction. Requires passing in the exception and the `__STACKTRACE__`

Closes https://github.com/newrelic/elixir_agent/issues/388
Closes https://github.com/newrelic/elixir_agent/issues/347