### PR TITLE
Only start os_mon when agent enabled

### DIFF
--- a/lib/new_relic/enabled_supervisor.ex
+++ b/lib/new_relic/enabled_supervisor.ex
@@ -19,6 +19,8 @@ defmodule NewRelic.EnabledSupervisor do
       NewRelic.Aggregate.Supervisor
     ]
 
+    NewRelic.OsMon.start()
+
     Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/new_relic/os_mon.ex
+++ b/lib/new_relic/os_mon.ex
@@ -1,0 +1,29 @@
+defmodule NewRelic.OsMon do
+  def start() do
+    Application.ensure_all_started(:os_mon)
+    :persistent_term.put(__MODULE__, true)
+  end
+
+  @mb 1024 * 1024
+  def get_system_memory() do
+    when_enabled(fn ->
+      case :memsup.get_system_memory_data()[:system_total_memory] do
+        nil -> nil
+        bytes -> trunc(bytes / @mb)
+      end
+    end)
+  end
+
+  def util() do
+    when_enabled(fn ->
+      :cpu_sup.util()
+    end)
+  end
+
+  defp when_enabled(fun, default \\ nil) do
+    case :persistent_term.get(__MODULE__, false) do
+      true -> fun.()
+      false -> default
+    end
+  end
+end

--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -15,7 +15,7 @@ defmodule NewRelic.Sampler.Beam do
     :erlang.system_flag(:scheduler_wall_time, true)
 
     # throw away first value
-    :cpu_sup.util()
+    NewRelic.OsMon.util()
     :erlang.statistics(:scheduler_wall_time)
 
     NewRelic.sample_process()
@@ -80,7 +80,7 @@ defmodule NewRelic.Sampler.Beam do
       schedulers: :erlang.system_info(:schedulers),
       scheduler_utilization: :erlang.statistics(:scheduler_wall_time) |> Enum.sort(),
       cpu_count: :erlang.system_info(:logical_processors),
-      cpu_utilization: :cpu_sup.util()
+      cpu_utilization: NewRelic.OsMon.util()
     }
   end
 

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -123,7 +123,7 @@ defmodule NewRelic.Util do
     %{
       metadata_version: 5,
       logical_processors: :erlang.system_info(:logical_processors),
-      total_ram_mib: get_system_memory(),
+      total_ram_mib: NewRelic.OsMon.get_system_memory(),
       hostname: hostname()
     }
     |> maybe_add_ip_addresses
@@ -164,14 +164,6 @@ defmodule NewRelic.Util do
     case :net_adm.dns_hostname(:net_adm.localhost()) do
       {:ok, fqdn} -> Map.put(util, :full_hostname, to_string(fqdn))
       _ -> util
-    end
-  end
-
-  @mb 1024 * 1024
-  defp get_system_memory() do
-    case :memsup.get_system_memory_data()[:system_total_memory] do
-      nil -> nil
-      bytes -> trunc(bytes / @mb)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule NewRelic.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger, :inets, :ssl, :os_mon],
+      extra_applications: [:logger, :inets, :ssl],
+      included_applications: [:os_mon],
       mod: {NewRelic.Application, []}
     ]
   end


### PR DESCRIPTION
We don't need to start `os_mon` when the agent is not enabled (ex: tests), so this starts it only when the agent is enabled, and safely wraps calls into `os_mon` applications.