### PR TITLE
Only start telemetry handlers when agent is enabled

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,6 +4,8 @@ config :logger, level: :warning
 
 config :new_relic_agent,
   app_name: "ElixirAgentTest",
+  license_key: "license_key",
+  bypass_collector: true,
   automatic_attributes: [test_attribute: "test_value"],
   ignore_paths: ["/ignore/this", ~r(ignore/these/*.)],
   log: "Logger"

--- a/examples/config/config.exs
+++ b/examples/config/config.exs
@@ -4,7 +4,9 @@ config :logger, level: :debug
 
 config :new_relic_agent,
   app_name: "ExampleApps",
-  trusted_account_key: "trusted_account_key"
+  trusted_account_key: "trusted_account_key",
+  license_key: "license_key",
+  bypass_collector: true
 
 for config <- "../apps/*/config/config.exs" |> Path.expand(__DIR__) |> Path.wildcard() do
   import_config config

--- a/lib/new_relic/telemetry/supervisor.ex
+++ b/lib/new_relic/telemetry/supervisor.ex
@@ -8,14 +8,23 @@ defmodule NewRelic.Telemetry.Supervisor do
   end
 
   def init(_) do
-    children = [
+    Supervisor.init(
+      children(enabled: NewRelic.Config.enabled?()),
+      strategy: :one_for_one
+    )
+  end
+
+  defp children(enabled: true) do
+    [
       NewRelic.Telemetry.Ecto.Supervisor,
       NewRelic.Telemetry.Redix,
       NewRelic.Telemetry.Plug,
       NewRelic.Telemetry.Phoenix,
       NewRelic.Telemetry.Oban
     ]
+  end
 
-    Supervisor.init(children, strategy: :one_for_one)
+  defp children(enabled: false) do
+    []
   end
 end

--- a/test/evil_collector_test.exs
+++ b/test/evil_collector_test.exs
@@ -28,6 +28,7 @@ defmodule EvilCollectorTest do
 
   setup_all do
     Application.put_env(:new_relic_agent, :collector_instance_host, "localhost")
+    Application.put_env(:new_relic_agent, :bypass_collector, false)
 
     reset_config =
       TestHelper.update(:nr_config,
@@ -39,6 +40,7 @@ defmodule EvilCollectorTest do
 
     on_exit(fn ->
       Application.delete_env(:new_relic_agent, :collector_instance_host)
+      Application.put_env(:new_relic_agent, :bypass_collector, true)
       reset_config.()
     end)
 

--- a/test/integration/integration_test.exs
+++ b/test/integration/integration_test.exs
@@ -32,7 +32,7 @@ defmodule IntegrationTest do
   test "connects to proper collector host" do
     {:ok, %{"redirect_host" => redirect_host}} = Collector.Protocol.preconnect()
 
-    assert redirect_host =~ "collector-"
+    assert redirect_host =~ "collector"
   end
 
   test "Agent re-connect ability" do

--- a/test/tracer_test.exs
+++ b/test/tracer_test.exs
@@ -214,6 +214,6 @@ defmodule TracerTest do
     assert Traced.db_query() == :result
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
-    assert metrics == []
+    refute Enum.any?(metrics, fn [%{name: name}, _] -> name =~ "db_query" end)
   end
 end


### PR DESCRIPTION
* We only need to start telemetry handlers when the agent is enabled.  This avoids extra work in the application in situations where the agent is disabled (ex: tests)
* Also adds a config flag to bypass making collector http requests so we can test things w/o trying to actually connect to the collector