### PR TITLE
Add extended attrs for functions, make extended attrs configurable

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -153,8 +153,10 @@ defmodule NewRelic.Config do
     * Controls all Redix instrumentation
   * `:oban_instrumentation_enabled` (default `true`)
     * Controls all Oban instrumentation
-  * `:request_queuing_metrics_enabled`
+  * `:request_queuing_metrics_enabled` (default `true`)
     * Controls collection of request queuing metrics
+  * `:extended_attributes` (default `true`)
+    * Controls reporting extended per-source attributes for datastore, external and function traces
 
 
   ### Configuration
@@ -207,6 +209,10 @@ defmodule NewRelic.Config do
 
   def feature?(:request_queuing_metrics) do
     get(:features, :request_queuing_metrics)
+  end
+
+  def feature?(:extended_attributes) do
+    get(:features, :extended_attributes)
   end
 
   @doc """

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -117,6 +117,11 @@ defmodule NewRelic.Init do
         determine_feature(
           "NEW_RELIC_REQUEST_QUEUING_METRICS_ENABLED",
           :request_queuing_metrics_enabled
+        ),
+      extended_attributes:
+        determine_feature(
+          "NEW_RELIC_EXTENDED_ATTRIBUTES_ENABLED",
+          :extended_attributes_enabled
         )
     })
   end

--- a/lib/new_relic/telemetry/ecto/handler.ex
+++ b/lib/new_relic/telemetry/ecto/handler.ex
@@ -88,10 +88,15 @@ defmodule NewRelic.Telemetry.Ecto.Handler do
         databaseCallCount: 1,
         databaseDuration: duration_s,
         datastore_call_count: 1,
-        datastore_duration_ms: duration_ms,
-        "datastore.#{table}.call_count": 1,
-        "datastore.#{table}.duration_ms": duration_ms
+        datastore_duration_ms: duration_ms
       )
+
+      if NewRelic.Config.feature?(:extended_attributes) do
+        NewRelic.incr_attributes(
+          "datastore.#{table}.call_count": 1,
+          "datastore.#{table}.duration_ms": duration_ms
+        )
+      end
     end
   end
 

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -86,10 +86,12 @@ defmodule NewRelic.Tracer.Report do
             })
         )
 
-        NewRelic.incr_attributes(
-          "external.#{host}.call_count": 1,
-          "external.#{host}.duration_ms": duration_ms
-        )
+        if NewRelic.Config.feature?(:extended_attributes) do
+          NewRelic.incr_attributes(
+            "external.#{host}.call_count": 1,
+            "external.#{host}.duration_ms": duration_ms
+          )
+        end
 
         NewRelic.report_metric({:external, url, component, method}, duration_s: duration_s)
 
@@ -126,10 +128,12 @@ defmodule NewRelic.Tracer.Report do
             })
         )
 
-        NewRelic.incr_attributes(
-          "external.#{function_name}.call_count": 1,
-          "external.#{function_name}.duration_ms": duration_ms
-        )
+        if NewRelic.Config.feature?(:extended_attributes) do
+          NewRelic.incr_attributes(
+            "external.#{function_name}.call_count": 1,
+            "external.#{function_name}.duration_ms": duration_ms
+          )
+        end
 
         NewRelic.report_metric({:external, function_name}, duration_s: duration_s)
 
@@ -192,6 +196,13 @@ defmodule NewRelic.Tracer.Report do
           "tracer.reductions": reductions
         })
     )
+
+    if NewRelic.Config.feature?(:extended_attributes) do
+      NewRelic.incr_attributes(
+        "function.#{function_name}.call_count": 1,
+        "function.#{function_name}.duration_ms": duration_ms
+      )
+    end
 
     NewRelic.report_metric(
       {:function, function_name},


### PR DESCRIPTION
* Adds "extended" attributes for function tracers (ie: `function.function_name/1.call_count`)
* Makes all "extended" attributes configurable