### PR TITLE
Fix: bandit attributes

### DIFF
--- a/examples/apps/phx_example/test/phx_example_test.exs
+++ b/examples/apps/phx_example/test/phx_example_test.exs
@@ -23,6 +23,10 @@ defmodule PhxExampleTest do
 
         [[_, event]] = TestSupport.gather_harvest(Collector.TransactionEvent.Harvester)
 
+        if event[:"bandit.resp_duration_ms"] do
+          assert event[:"bandit.resp_duration_ms"] > 0
+        end
+
         assert event[:"phoenix.endpoint"] =~ "PhxExampleWeb"
         assert event[:"phoenix.router"] == "PhxExampleWeb.Router"
         assert event[:"phoenix.controller"] == "PhxExampleWeb.PageController"

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -209,14 +209,10 @@ defmodule NewRelic.Telemetry.Plug do
 
   defp add_stop_attrs(meas, meta, :bandit) do
     info = Process.info(self(), [:memory, :reductions])
-    duration = meas[:duration] || System.monotonic_time() - meas[:monotonic_time]
-
-    resp_duration_ms =
-      meas[:resp_start_time] &&
-        (meas[:resp_start_time] |> to_ms) - (meas[:resp_end_time] |> to_ms)
+    resp_duration_ms = meas[:resp_start_time] && to_ms(meas[:resp_end_time]) - to_ms(meas[:resp_start_time])
 
     [
-      duration: duration,
+      duration: meas[:duration] || 0,
       status: status_code(meta) || 500,
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],


### PR DESCRIPTION
* bandit attribute `resp_duration_ms` was calculated incorrectly
* bandit `duration` can't be calculated from `monotonic_time` because that is the timestamp of the `exception` event, so use 0 duration when we can't know the actual duration