### PR TITLE
Fix: phoenix nil attribute

### DIFF
--- a/lib/new_relic/telemetry/phoenix.ex
+++ b/lib/new_relic/telemetry/phoenix.ex
@@ -61,7 +61,7 @@ defmodule NewRelic.Telemetry.Phoenix do
         end,
       "phoenix.format": conn.private[:phoenix_format],
       "phoenix.template": conn.private[:phoenix_template],
-      "phoenix.view": conn.private[:phoenix_view] |> inspect()
+      "phoenix.view": conn.private[:phoenix_view] && inspect(conn.private[:phoenix_view])
     ]
     |> NewRelic.add_attributes()
   end


### PR DESCRIPTION
Don't inspect the `phoenix.view` attribute unless it's present (so we don't send up `"nil"` as the value)