### PR TITLE
Fixes: Transaction timing, bandit, span macro

### DIFF
--- a/examples/apps/oban_example/lib/oban_example/worker.ex
+++ b/examples/apps/oban_example/lib/oban_example/worker.ex
@@ -7,7 +7,7 @@ defmodule ObanExample.Worker do
   end
 
   def perform(%Oban.Job{args: _args}) do
-    Process.sleep(:rand.uniform(50))
+    Process.sleep(15 + :rand.uniform(50))
     :ok
   end
 end

--- a/examples/apps/oban_example/test/oban_example_test.exs
+++ b/examples/apps/oban_example/test/oban_example_test.exs
@@ -23,7 +23,11 @@ defmodule ObanExampleTest do
            )
 
     assert [
-             %{:name => "OtherTransaction/Oban/default/ObanExample.Worker/perform"},
+             %{
+               :name => "OtherTransaction/Oban/default/ObanExample.Worker/perform",
+               :timestamp => timestamp,
+               :duration => duration
+             },
              %{
                :"oban.worker" => "ObanExample.Worker",
                :"oban.queue" => "default",
@@ -31,6 +35,9 @@ defmodule ObanExampleTest do
                :"oban.job.tags" => "foo,bar"
              }
            ] = event
+
+    assert timestamp |> is_number
+    assert duration >= 0.015
   end
 
   test "instruments a failed job" do

--- a/examples/apps/redix_example/test/redix_example_test.exs
+++ b/examples/apps/redix_example/test/redix_example_test.exs
@@ -60,6 +60,8 @@ defmodule RedixExampleTest do
     assert get_event[:"db.statement"] == "GET mykey"
     assert get_event[:"redix.connection"] =~ "PID"
     assert get_event[:"redix.connection_name"] == ":redix"
+    assert get_event[:timestamp] |> is_number
+    assert get_event[:duration] > 0.0
 
     [pipeline_event, _, _] =
       Enum.find(span_events, fn [ev, _, _] ->

--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -258,7 +258,7 @@ defmodule NewRelic do
   defmacro span(name, attributes \\ [], do: block) do
     quote do
       id = make_ref()
-      NewRelic.Tracer.Direct.start_span(id, name: unquote(name), attributes: unquote(attributes))
+      NewRelic.Tracer.Direct.start_span(id, unquote(name), attributes: unquote(attributes))
       res = unquote(block)
       NewRelic.Tracer.Direct.stop_span(id)
       res

--- a/lib/new_relic/telemetry/oban.ex
+++ b/lib/new_relic/telemetry/oban.ex
@@ -61,14 +61,14 @@ defmodule NewRelic.Telemetry.Oban do
   @doc false
   def handle_event(
         @oban_start,
-        %{system_time: system_time},
+        %{system_time: start_time},
         meta,
         _config
       ) do
     Transaction.Reporter.start_transaction(:other)
     NewRelic.DistributedTrace.start(:other)
 
-    add_start_attrs(meta, system_time)
+    add_start_attrs(meta, start_time)
   end
 
   def handle_event(
@@ -99,10 +99,10 @@ defmodule NewRelic.Telemetry.Oban do
     :ignore
   end
 
-  defp add_start_attrs(meta, system_time) do
+  defp add_start_attrs(meta, start_time) do
     [
       pid: inspect(self()),
-      system_time: system_time,
+      start_time: start_time,
       other_transaction_name: "Oban/#{meta.queue}/#{meta.worker}/perform",
       "oban.worker": meta.worker,
       "oban.queue": meta.queue,

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -140,7 +140,7 @@ defmodule NewRelic.Telemetry.Plug do
   defp add_start_attrs(meta, meas, headers, :cowboy) do
     [
       pid: inspect(self()),
-      system_time: meas[:system_time],
+      start_time: meas[:system_time],
       host: meta.req.host,
       path: meta.req.path,
       remote_ip: meta.req.peer |> elem(0) |> :inet_parse.ntoa() |> to_string(),
@@ -155,7 +155,7 @@ defmodule NewRelic.Telemetry.Plug do
   defp add_start_attrs(meta, meas, headers, :bandit) do
     [
       pid: inspect(self()),
-      system_time: meas[:system_time],
+      start_time: meas[:system_time],
       host: meta.conn.host,
       path: meta.conn.request_path,
       remote_ip: meta.conn.remote_ip |> :inet_parse.ntoa() |> to_string(),

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -152,17 +152,25 @@ defmodule NewRelic.Telemetry.Plug do
     |> NewRelic.add_attributes()
   end
 
-  defp add_start_attrs(meta, meas, headers, :bandit) do
+  defp add_start_attrs(%{conn: conn}, meas, headers, :bandit) do
     [
       pid: inspect(self()),
       start_time: meas[:system_time],
-      host: meta.conn.host,
-      path: meta.conn.request_path,
-      remote_ip: meta.conn.remote_ip |> :inet_parse.ntoa() |> to_string(),
+      host: conn.host,
+      path: conn.request_path,
+      remote_ip: conn.remote_ip |> :inet_parse.ntoa() |> to_string(),
       referer: headers["referer"],
       user_agent: headers["user-agent"],
       content_type: headers["content-type"],
-      request_method: meta.conn.method
+      request_method: conn.method
+    ]
+    |> NewRelic.add_attributes()
+  end
+
+  defp add_start_attrs(_meta, meas, _headers, :bandit) do
+    [
+      pid: inspect(self()),
+      start_time: meas[:system_time]
     ]
     |> NewRelic.add_attributes()
   end
@@ -276,6 +284,8 @@ defmodule NewRelic.Telemetry.Plug do
   defp status_code(%{conn: %{status: status}}) do
     status
   end
+
+  defp status_code(_), do: nil
 
   defp plug_name(conn, match_path) do
     "/Plug/#{conn.method}/#{match_path}"

--- a/lib/new_relic/tracer/direct.ex
+++ b/lib/new_relic/tracer/direct.ex
@@ -66,7 +66,7 @@ defmodule NewRelic.Tracer.Direct do
           pid: self(),
           id: span,
           parent_id: previous_span || :root,
-          system_time: start_time,
+          start_time: start_time,
           duration: duration
         })
 

--- a/lib/new_relic/tracer/direct.ex
+++ b/lib/new_relic/tracer/direct.ex
@@ -3,7 +3,7 @@ defmodule NewRelic.Tracer.Direct do
 
   @max_open_span_count Application.compile_env(:new_relic, :max_open_span_count, 20)
 
-  def start_span(id, name, options) do
+  def start_span(id, name, options \\ []) do
     case Process.get(:nr_open_span_count, 0) do
       over when over >= @max_open_span_count ->
         Process.put(:nr_open_span_count, over + 1)
@@ -30,7 +30,7 @@ defmodule NewRelic.Tracer.Direct do
     :ok
   end
 
-  def stop_span(id, options) do
+  def stop_span(id, options \\ []) do
     case Process.get({:nr_span, id}) do
       nil ->
         :no_such_span

--- a/lib/new_relic/tracer/report.ex
+++ b/lib/new_relic/tracer/report.ex
@@ -37,7 +37,7 @@ defmodule NewRelic.Tracer.Report do
          name,
          pid,
          {id, parent_id},
-         {start_time, start_time_mono, end_time_mono, _child_duration_ms, reductions}
+         {system_time, start_time_mono, end_time_mono, _child_duration_ms, reductions}
        ) do
     duration_ms = duration_ms(start_time_mono, end_time_mono)
     duration_s = duration_ms / 1000
@@ -62,13 +62,13 @@ defmodule NewRelic.Tracer.Report do
           pid: pid,
           id: id,
           parent_id: parent_id,
-          start_time: start_time,
+          system_time: system_time,
           start_time_mono: start_time_mono,
           end_time_mono: end_time_mono
         })
 
         NewRelic.report_span(
-          timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
+          timestamp_ms: System.convert_time_unit(system_time, :native, :millisecond),
           duration_s: duration_s,
           name: metric_name,
           edge: [span: id, parent: parent_id],
@@ -105,13 +105,13 @@ defmodule NewRelic.Tracer.Report do
           pid: pid,
           id: id,
           parent_id: parent_id,
-          start_time: start_time,
+          system_time: system_time,
           start_time_mono: start_time_mono,
           end_time_mono: end_time_mono
         })
 
         NewRelic.report_span(
-          timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
+          timestamp_ms: System.convert_time_unit(system_time, :native, :millisecond),
           duration_s: duration_s,
           name: function_arity_name,
           edge: [span: id, parent: parent_id],
@@ -155,7 +155,7 @@ defmodule NewRelic.Tracer.Report do
          name,
          pid,
          {id, parent_id},
-         {start_time, start_time_mono, end_time_mono, child_duration_ms, reductions}
+         {system_time, start_time_mono, end_time_mono, child_duration_ms, reductions}
        ) do
     duration_ms = duration_ms(start_time_mono, end_time_mono)
     duration_s = duration_ms / 1000
@@ -174,13 +174,13 @@ defmodule NewRelic.Tracer.Report do
       pid: pid,
       id: id,
       parent_id: parent_id,
-      start_time: start_time,
+      system_time: system_time,
       start_time_mono: start_time_mono,
       end_time_mono: end_time_mono
     })
 
     NewRelic.report_span(
-      timestamp_ms: System.convert_time_unit(start_time, :native, :millisecond),
+      timestamp_ms: System.convert_time_unit(system_time, :native, :millisecond),
       duration_s: duration_s,
       name: function_name,
       edge: [span: id, parent: parent_id],

--- a/test/telemetry/finch_test.exs
+++ b/test/telemetry/finch_test.exs
@@ -5,7 +5,7 @@ defmodule NewRelic.Telemetry.FinchTest do
   setup do
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
     TestHelper.restart_harvest_cycle(Collector.SpanEvent.HarvestCycle)
-    send(NewRelic.DistributedTrace.BackoffSampler, :reset)
+    NewRelic.DistributedTrace.BackoffSampler.reset()
 
     start_supervised({Finch, name: __MODULE__})
 


### PR DESCRIPTION
This PR contains fixes for a few issues with the `1.31.0` release

* A fix for another instance where the bandit start telemetry doesn't include the `conn` in an error case
* A fix for the `NewRelic.span` macro that was just introduced, but not exercised in tests (oops)
* Wires up Transaction reporting so that we will always have a full set of timing attributes, even if we don't get timing attributes from the instrumentation due to some kind of error. There was a bug revealed when an `Oban` job process exited w/o emitting telemetry, so when we went to "complete" it, it didn't have a needed attribute. This PR fixes this by ensuring the agent automatically put timing attributes on all Transactions. If instrumentation provides more accurate timing attributes, we prefer those over the ones captured by the agent. 

Timing attribute precedence:
* `start_time :: native, duration :: native` (passed by `telemetry` instrumentation)
* `system_time :: native, start_time_mono :: native, end_time_mono :: native` (passed by `Transaction.Reporter`)



Fixes #482 