### PR TITLE
Fix test config

### DIFF
--- a/test/backoff_sampler_test.exs
+++ b/test/backoff_sampler_test.exs
@@ -98,7 +98,12 @@ defmodule BackoffSamplerTest do
   end
 
   test "cycles trigger" do
-    Application.put_env(:new_relic_agent, :sampling_target_period, 100)
+    original_env = Application.get_env(:new_relic_agent, :sampling_target_period)
+    sampling_target = 100
+
+    Application.put_env(:new_relic_agent, :sampling_target_period, sampling_target)
+
+    on_exit(fn -> TestHelper.reset_env(:sampling_target_period, original_env) end)
 
     BackoffSampler.reset()
     BackoffSampler.trigger_next_cycle()
@@ -122,7 +127,7 @@ defmodule BackoffSamplerTest do
     refute BackoffSampler.sample?()
 
     # Wait until the next cycle
-    Process.sleep(110)
+    Process.sleep(sampling_target + 10)
 
     # Next cycle it will adjust and take some, but not all
     decisions = [

--- a/test/erlang_trace_overload_test.exs
+++ b/test/erlang_trace_overload_test.exs
@@ -4,11 +4,22 @@ defmodule ErlangTraceOverloadTest do
   @test_queue_len 1
   @test_backoff 100
 
+  @tag :capture_log
   test "Handle process spawn overload in ErlangTrace" do
+    original_queue_len = Application.get_env(:new_relic_agent, :overload_queue_len)
+    original_backoff = Application.get_env(:new_relic_agent, :overload_backoff)
+
     Application.put_env(:new_relic_agent, :overload_queue_len, @test_queue_len)
     Application.put_env(:new_relic_agent, :overload_backoff, @test_backoff)
     NewRelic.disable_erlang_trace()
     NewRelic.enable_erlang_trace()
+
+    on_exit(fn ->
+      TestHelper.reset_env(:overload_queue_len, original_queue_len)
+      TestHelper.reset_env(:overload_backoff, original_backoff)
+      NewRelic.disable_erlang_trace()
+      NewRelic.enable_erlang_trace()
+    end)
 
     first_pid = Process.whereis(NewRelic.Transaction.ErlangTrace)
     Process.monitor(first_pid)
@@ -41,10 +52,5 @@ defmodule ErlangTraceOverloadTest do
     assert is_pid(second_pid)
 
     assert first_pid != second_pid
-
-    Application.delete_env(:new_relic_agent, :overload_queue_len)
-    Application.delete_env(:new_relic_agent, :overload_backoff)
-    NewRelic.disable_erlang_trace()
-    NewRelic.enable_erlang_trace()
   end
 end

--- a/test/erlang_trace_test.exs
+++ b/test/erlang_trace_test.exs
@@ -8,6 +8,10 @@ defmodule ErlangTraceTest do
 
     NewRelic.disable_erlang_trace()
 
+    on_exit(fn ->
+      NewRelic.enable_erlang_trace()
+    end)
+
     assert_receive {:DOWN, _ref, _, ^first_pid, _}
 
     NewRelic.enable_erlang_trace()
@@ -18,8 +22,14 @@ defmodule ErlangTraceTest do
   end
 
   test "config option to disable at boot" do
+    original_env = Application.get_env(:new_relic_agent, :disable_erlang_trace)
+
     # Pretend the app is starting up with the config option
     Application.put_env(:new_relic_agent, :disable_erlang_trace, true)
+
+    on_exit(fn ->
+      TestHelper.reset_env(:disable_erlang_trace, original_env)
+    end)
 
     supervisor = Process.whereis(NewRelic.Transaction.ErlangTraceSupervisor)
     Process.monitor(supervisor)

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -12,7 +12,7 @@ defmodule ErrorTest do
     def handle_call(:secretfun, _from, _state), do: Not.secretfun("secretvalue", "other_secret")
     def handle_call(:sleep, _from, _state), do: :timer.sleep(:infinity)
     def handle_call(:raise, _from, _state), do: raise("ERROR")
-    def handle_call(:erlang_error, _from, _state), do: raise(:erlang.error(:badarg))
+    def handle_call(:erlang_error, _from, _state), do: :erlang.error(:badarg)
   end
 
   test "Catch and harvest errors" do

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -12,6 +12,14 @@ defmodule InitTest do
   end
 
   test "handle config default properly" do
+    original_env = Application.get_env(:new_relic_agent, :harvest_enabled)
+
+    on_exit(fn ->
+      TestHelper.reset_env(:harvest_enabled, original_env)
+      System.delete_env("NEW_RELIC_HARVEST_ENABLED")
+      NewRelic.Init.init_config()
+    end)
+
     Application.put_env(:new_relic_agent, :harvest_enabled, true)
     NewRelic.Init.init_config()
     assert NewRelic.Config.get(:harvest_enabled)
@@ -27,8 +35,5 @@ defmodule InitTest do
     System.put_env("NEW_RELIC_HARVEST_ENABLED", "false")
     NewRelic.Init.init_config()
     refute NewRelic.Config.get(:harvest_enabled)
-
-    System.delete_env("NEW_RELIC_HARVEST_ENABLED")
-    NewRelic.Init.init_config()
   end
 end

--- a/test/metric_harvester_test.exs
+++ b/test/metric_harvester_test.exs
@@ -30,7 +30,12 @@ defmodule MetricHarvesterTest do
   end
 
   test "harvest cycle" do
+    original_env = Application.get_env(:new_relic_agent, :data_report_period)
+
     Application.put_env(:new_relic_agent, :data_report_period, 300)
+
+    on_exit(fn -> TestHelper.reset_env(:data_report_period, original_env) end)
+
     TestHelper.restart_harvest_cycle(Collector.Metric.HarvestCycle)
 
     first = Harvest.HarvestCycle.current_harvester(Collector.Metric.HarvestCycle)
@@ -46,7 +51,6 @@ defmodule MetricHarvesterTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.Metric.HarvestCycle)
-    Application.delete_env(:new_relic_agent, :data_report_period)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -94,4 +94,12 @@ defmodule TestHelper do
 
     fn -> :persistent_term.put(key, original) end
   end
+
+  def reset_env(key, nil) do
+    Application.delete_env(:new_relic_agent, key)
+  end
+
+  def reset_env(key, original) do
+    Application.put_env(:new_relic_agent, key, original)
+  end
 end

--- a/test/telemetry_sdk/logs_harvester_test.exs
+++ b/test/telemetry_sdk/logs_harvester_test.exs
@@ -19,6 +19,10 @@ defmodule TelemetrySdk.LogsHarvesterTest do
   end
 
   test "harvest cycle" do
+    original_env = Application.get_env(:new_relic_agent, :logs_harvest_cycle)
+
+    on_exit(fn -> TestHelper.reset_env(:logs_harvest_cycle, original_env) end)
+
     Application.put_env(:new_relic_agent, :logs_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(TelemetrySdk.Logs.HarvestCycle)
 
@@ -35,7 +39,6 @@ defmodule TelemetrySdk.LogsHarvesterTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(TelemetrySdk.Logs.HarvestCycle)
-    Application.delete_env(:new_relic_agent, :logs_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/telemetry_sdk/span_harvester_test.exs
+++ b/test/telemetry_sdk/span_harvester_test.exs
@@ -19,7 +19,11 @@ defmodule TelemetrySdk.SpanHarvesterTest do
   end
 
   test "harvest cycle" do
+    original_env = Application.get_env(:new_relic_agent, :spans_harvest_cycle)
+    on_exit(fn -> TestHelper.reset_env(:spans_harvest_cycle, original_env) end)
+
     Application.put_env(:new_relic_agent, :spans_harvest_cycle, 300)
+
     TestHelper.restart_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
 
     first = Harvest.HarvestCycle.current_harvester(TelemetrySdk.Spans.HarvestCycle)
@@ -35,7 +39,6 @@ defmodule TelemetrySdk.SpanHarvesterTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(TelemetrySdk.Spans.HarvestCycle)
-    Application.delete_env(:new_relic_agent, :spans_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -125,6 +125,12 @@ defmodule TransactionErrorEventTest do
   end
 
   test "harvest cycle" do
+    original_env = Application.get_env(:new_relic_agent, :error_event_harvest_cycle)
+
+    on_exit(fn ->
+      TestHelper.reset_env(:error_event_harvest_cycle, original_env)
+    end)
+
     Application.put_env(:new_relic_agent, :error_event_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
 
@@ -142,7 +148,6 @@ defmodule TransactionErrorEventTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
-    Application.delete_env(:new_relic_agent, :error_event_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000

--- a/test/transaction_event_test.exs
+++ b/test/transaction_event_test.exs
@@ -44,6 +44,10 @@ defmodule TransactionEventTest do
   end
 
   test "collect and store top priority events" do
+    original_env = Application.get_env(:new_relic_agent, :transaction_event_reservoir_size)
+
+    on_exit(fn -> TestHelper.reset_env(:transaction_event_reservoir_size, original_env) end)
+
     Application.put_env(:new_relic_agent, :transaction_event_reservoir_size, 2)
 
     {:ok, harvester} =
@@ -71,8 +75,6 @@ defmodule TransactionEventTest do
     Process.monitor(harvester)
     Harvest.HarvestCycle.send_harvest(Collector.TransactionEvent.HarvesterSupervisor, harvester)
     assert_receive {:DOWN, _ref, _, ^harvester, :shutdown}, 1000
-
-    Application.delete_env(:new_relic_agent, :transaction_event_reservoir_size)
   end
 
   test "user attributes can be truncated" do
@@ -92,6 +94,10 @@ defmodule TransactionEventTest do
   end
 
   test "harvest cycle" do
+    original_env = Application.get_env(:new_relic_agent, :transaction_event_harvest_cycle)
+
+    on_exit(fn -> TestHelper.reset_env(:transaction_event_harvest_cycle, original_env) end)
+
     Application.put_env(:new_relic_agent, :transaction_event_harvest_cycle, 300)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
@@ -108,7 +114,6 @@ defmodule TransactionEventTest do
     assert Process.alive?(second)
 
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
-    Application.delete_env(:new_relic_agent, :transaction_event_harvest_cycle)
 
     # Ensure the last harvester has shut down
     assert_receive {:DOWN, _ref, _, ^second, :shutdown}, 1000
@@ -145,6 +150,10 @@ defmodule TransactionEventTest do
   end
 
   test "Respect the reservoir_size" do
+    original_env = Application.get_env(:new_relic_agent, :transaction_event_reservoir_size)
+
+    on_exit(fn -> TestHelper.reset_env(:transaction_event_reservoir_size, original_env) end)
+
     Application.put_env(:new_relic_agent, :transaction_event_reservoir_size, 3)
     TestHelper.restart_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
 
@@ -157,7 +166,6 @@ defmodule TransactionEventTest do
     events = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
     assert length(events) == 3
 
-    Application.delete_env(:new_relic_agent, :transaction_event_reservoir_size)
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)
   end
 end


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

This only changes tests--

I noticed that there are many cases where tests effect Application config, and do no reset them. This can cause test flakiness, especially with `automatic_attributes` being set to `[]` after some tests, when other tests rely on the values set in `test.exs`.

These changes add a helper that resets Application config `on_exit`. The helper removes the config if it didn't previously exist, and will set it to it's original value if it did exist.

This shouldn't have any negative effects at all, unless other tests were relying on broken state to begin with.

I also fixed a type system warning emitted in Elixir 1.18.