### PR TITLE
Make unused public function private

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Change public functions to be private.
+4b24a127a02d8d641c0f72f0f8538a5daca0d125

--- a/lib/new_relic/aggregate/aggregate.ex
+++ b/lib/new_relic/aggregate/aggregate.ex
@@ -17,7 +17,7 @@ defmodule NewRelic.Aggregate do
     |> Map.put(:category, :Metric)
   end
 
-  def averages(%{call_count: call_count} = values) do
+  defp averages(%{call_count: call_count} = values) do
     values
     |> Stream.reject(fn {key, _value} -> key == :call_count end)
     |> Enum.reduce(%{}, fn {key, value}, acc ->
@@ -25,5 +25,5 @@ defmodule NewRelic.Aggregate do
     end)
   end
 
-  def averages(_values), do: %{}
+  defp averages(_values), do: %{}
 end

--- a/lib/new_relic/aggregate/reporter.ex
+++ b/lib/new_relic/aggregate/reporter.ex
@@ -39,12 +39,12 @@ defmodule NewRelic.Aggregate.Reporter do
     {:reply, :ok, %{}}
   end
 
-  def record_aggregates(state) do
-    Enum.map(state, fn {_meta, metric} ->
+  defp record_aggregates(state) do
+    Enum.each(state, fn {_meta, metric} ->
       NewRelic.report_custom_event(aggregate_event_type(), Aggregate.annotate(metric))
     end)
   end
 
-  def aggregate_event_type,
+  defp aggregate_event_type,
     do: Application.get_env(:new_relic_agent, :aggregate_event_type, "ElixirAggregate")
 end

--- a/lib/new_relic/custom/event.ex
+++ b/lib/new_relic/custom/event.ex
@@ -11,7 +11,7 @@ defmodule NewRelic.Custom.Event do
     Enum.map(events, &format_event/1)
   end
 
-  def format_event(%__MODULE__{} = event) do
+  defp format_event(%__MODULE__{} = event) do
     [
       %{
         type: event.type,

--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -32,7 +32,7 @@ defmodule NewRelic.DistributedTrace do
     end
   end
 
-  def accept_distributed_trace_headers(:http, headers) do
+  defp accept_distributed_trace_headers(:http, headers) do
     w3c_headers(headers) || newrelic_header(headers) || :no_payload
   end
 
@@ -77,7 +77,7 @@ defmodule NewRelic.DistributedTrace do
     end
   end
 
-  def generate_new_context() do
+  defp generate_new_context() do
     {priority, sampled} = generate_sampling()
 
     %Context{
@@ -90,7 +90,7 @@ defmodule NewRelic.DistributedTrace do
     }
   end
 
-  def track_transaction(context, transport_type: type) do
+  defp track_transaction(context, transport_type: type) do
     context
     |> assign_transaction_guid()
     |> maybe_generate_sampling()
@@ -101,25 +101,25 @@ defmodule NewRelic.DistributedTrace do
     |> set_tracing_context()
   end
 
-  def maybe_generate_sampling(%Context{sampled: nil, priority: nil} = context) do
+  defp maybe_generate_sampling(%Context{sampled: nil, priority: nil} = context) do
     {priority, sampled} = generate_sampling()
     %{context | sampled: sampled, priority: priority}
   end
 
-  def maybe_generate_sampling(context), do: context
+  defp maybe_generate_sampling(context), do: context
 
-  def maybe_generate_trace_id(%Context{trace_id: nil} = context) do
+  defp maybe_generate_trace_id(%Context{trace_id: nil} = context) do
     %{context | trace_id: generate_guid(16)}
   end
 
-  def maybe_generate_trace_id(context) do
+  defp maybe_generate_trace_id(context) do
     context
   end
 
-  def report_attributes(
-        %{source: {:w3c, %{tracestate: :non_new_relic}}} = context,
-        transport_type: type
-      ) do
+  defp report_attributes(
+         %{source: {:w3c, %{tracestate: :non_new_relic}}} = context,
+         transport_type: type
+       ) do
     [
       "parent.transportType": type,
       guid: context.trace_id,
@@ -134,13 +134,13 @@ defmodule NewRelic.DistributedTrace do
     context
   end
 
-  def report_attributes(
-        %Context{
-          parent_id: nil,
-          span_guid: nil
-        } = context,
-        transport_type: _type
-      ) do
+  defp report_attributes(
+         %Context{
+           parent_id: nil,
+           span_guid: nil
+         } = context,
+         transport_type: _type
+       ) do
     [
       guid: context.guid,
       traceId: context.trace_id,
@@ -152,7 +152,7 @@ defmodule NewRelic.DistributedTrace do
     context
   end
 
-  def report_attributes(context, transport_type: type) do
+  defp report_attributes(context, transport_type: type) do
     [
       "parent.type": context.type,
       "parent.app": context.app_id,
@@ -171,7 +171,7 @@ defmodule NewRelic.DistributedTrace do
     context
   end
 
-  def report_attributes(%{source: {:w3c, w3c}} = context, :w3c) do
+  defp report_attributes(%{source: {:w3c, w3c}} = context, :w3c) do
     NewRelic.add_attributes(tracingVendors: Enum.join(w3c.tracing_vendors, ","))
 
     w3c.tracestate == :new_relic &&
@@ -180,11 +180,11 @@ defmodule NewRelic.DistributedTrace do
     context
   end
 
-  def report_attributes(context, :w3c) do
+  defp report_attributes(context, :w3c) do
     context
   end
 
-  def convert_to_outbound(%Context{} = context) do
+  defp convert_to_outbound(%Context{} = context) do
     %Context{
       source: context.source,
       account_id: AgentRun.account_id(),
@@ -198,7 +198,7 @@ defmodule NewRelic.DistributedTrace do
     }
   end
 
-  def set_tracing_context(context) do
+  defp set_tracing_context(context) do
     Transaction.Sidecar.trace_context(context)
   end
 
@@ -258,7 +258,7 @@ defmodule NewRelic.DistributedTrace do
     {current, previous_span, previous_span_attrs}
   end
 
-  def get_current_span_guid() do
+  defp get_current_span_guid() do
     case Process.get(:nr_current_span) do
       nil -> generate_guid(pid: self())
       {label, ref} -> generate_guid(pid: self(), label: label, ref: ref)
@@ -289,7 +289,7 @@ defmodule NewRelic.DistributedTrace do
     :rand.uniform() |> Float.round(6)
   end
 
-  def assign_transaction_guid(context) do
+  defp assign_transaction_guid(context) do
     Map.put(context, :guid, generate_guid())
   end
 

--- a/lib/new_relic/distributed_trace/backoff_sampler.ex
+++ b/lib/new_relic/distributed_trace/backoff_sampler.ex
@@ -60,7 +60,7 @@ defmodule NewRelic.DistributedTrace.BackoffSampler do
     put(@sampled_true_count, 0)
   end
 
-  def calculate(state) do
+  defp calculate(state) do
     sampled = do_sample?(state)
     update_state(sampled)
     sampled
@@ -98,22 +98,22 @@ defmodule NewRelic.DistributedTrace.BackoffSampler do
     Process.send_after(__MODULE__, :cycle, cycle_period)
   end
 
-  def update_state(false = _sampled?) do
+  defp update_state(false = _sampled?) do
     incr(@decided_count)
   end
 
-  def update_state(true = _sampled?) do
+  defp update_state(true = _sampled?) do
     incr(@decided_count)
     incr(@sampled_true_count)
   end
 
-  def random(0), do: 0
-  def random(n), do: :rand.uniform(n)
+  defp random(0), do: 0
+  defp random(n), do: :rand.uniform(n)
 
   @compile {:inline, new: 2, incr: 1, put: 2, get: 1, pt: 0}
   defp new(size, opts), do: :counters.new(size, opts)
   defp incr(index), do: :counters.add(pt(), index, 1)
   defp put(index, value), do: :counters.put(pt(), index, value)
   defp get(index), do: :counters.get(pt(), index)
-  def pt(), do: :persistent_term.get({__MODULE__, :counter})
+  defp pt(), do: :persistent_term.get({__MODULE__, :counter})
 end

--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -88,10 +88,7 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
     |> Base.encode64()
   end
 
-  def maybe_put(data, :trust_key, _key, account_id, account_id), do: data
-  def maybe_put(data, :trust_key, _key, _account_id, nil), do: data
-  def maybe_put(data, :trust_key, key, _account_id, trust_key), do: Map.put(data, key, trust_key)
-
-  def parse_int(nil), do: :error
-  def parse_int(field), do: Integer.parse(field)
+  defp maybe_put(data, :trust_key, _key, account_id, account_id), do: data
+  defp maybe_put(data, :trust_key, _key, _account_id, nil), do: data
+  defp maybe_put(data, :trust_key, key, _account_id, trust_key), do: Map.put(data, key, trust_key)
 end

--- a/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
+++ b/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
@@ -73,7 +73,7 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
     end
   end
 
-  def matching_new_relic_state?(context) do
+  defp matching_new_relic_state?(context) do
     context.key == :new_relic &&
       context.value.trusted_account_key == AgentRun.trusted_account_key()
   end

--- a/lib/new_relic/error/event.ex
+++ b/lib/new_relic/error/event.ex
@@ -16,7 +16,7 @@ defmodule NewRelic.Error.Event do
     Enum.map(errors, &format_event/1)
   end
 
-  def format_event(%__MODULE__{} = error) do
+  defp format_event(%__MODULE__{} = error) do
     [
       _intrinsic_attributes = %{
         type: error.type,
@@ -33,17 +33,17 @@ defmodule NewRelic.Error.Event do
     ]
   end
 
-  def format_agent_attributes(%{
-        http_response_code: http_response_code,
-        request_method: request_method
-      }) do
+  defp format_agent_attributes(%{
+         http_response_code: http_response_code,
+         request_method: request_method
+       }) do
     %{
       httpResponseCode: http_response_code,
       "request.headers.method": request_method
     }
   end
 
-  def format_agent_attributes(_agent_attributes) do
+  defp format_agent_attributes(_agent_attributes) do
     %{}
   end
 end

--- a/lib/new_relic/error/trace.ex
+++ b/lib/new_relic/error/trace.ex
@@ -15,7 +15,7 @@ defmodule NewRelic.Error.Trace do
     Enum.map(errors, &format_error/1)
   end
 
-  def format_error(%__MODULE__{} = error) do
+  defp format_error(%__MODULE__{} = error) do
     [
       error.timestamp,
       error.transaction_name,

--- a/lib/new_relic/harvest/collector/agent_run.ex
+++ b/lib/new_relic/harvest/collector/agent_run.ex
@@ -77,7 +77,7 @@ defmodule NewRelic.Harvest.Collector.AgentRun do
     |> store_agent_run()
   end
 
-  def get(key),
+  defp get(key),
     do: :persistent_term.get(:nr_agent_run, %{})[key]
 
   defp store_agent_run({:ok, %{"agent_run_id" => _} = connect_response}) do

--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -74,28 +74,28 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
 
   # Helpers
 
-  def process(event) do
+  defp process(event) do
     event
     |> NewRelic.Util.coerce_attributes()
     |> Map.merge(NewRelic.Config.automatic_attributes())
   end
 
-  def store_event(%{sampling: %{events_seen: seen, reservoir_size: size}} = state, event)
-      when seen < size,
-      do: %{state | custom_events: [event | state.custom_events]}
+  defp store_event(%{sampling: %{events_seen: seen, reservoir_size: size}} = state, event)
+       when seen < size,
+       do: %{state | custom_events: [event | state.custom_events]}
 
-  def store_event(state, _event), do: state
+  defp store_event(state, _event), do: state
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :events_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     events = build_payload(state)
     Collector.Protocol.custom_event([Collector.AgentRun.agent_run_id(), state.sampling, events])
     log_harvest(length(events), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size, events_seen, reservoir_size) do
+  defp log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "CustomEventData"}, harvest_size: harvest_size)
 
     NewRelic.report_metric({:supportability, "CustomEventData"},
@@ -110,5 +110,5 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
     )
   end
 
-  def build_payload(state), do: Event.format_events(state.custom_events)
+  defp build_payload(state), do: Event.format_events(state.custom_events)
 end

--- a/lib/new_relic/harvest/collector/error_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/error_trace/harvester.ex
@@ -63,15 +63,15 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
 
   @reservoir_size 20
 
-  def store_error(%{error_traces_seen: seen} = state, _trace)
-      when seen >= @reservoir_size do
+  defp store_error(%{error_traces_seen: seen} = state, _trace)
+       when seen >= @reservoir_size do
     %{
       state
       | error_traces_seen: state.error_traces_seen + 1
     }
   end
 
-  def store_error(state, trace) do
+  defp store_error(state, trace) do
     %{
       state
       | error_traces_seen: state.error_traces_seen + 1,
@@ -79,13 +79,13 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
     }
   end
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     errors = build_payload(state)
     Collector.Protocol.error([Collector.AgentRun.agent_run_id(), errors])
     log_harvest(length(errors), state.error_traces_seen)
   end
 
-  def log_harvest(harvest_size, events_seen) do
+  defp log_harvest(harvest_size, events_seen) do
     NewRelic.report_metric({:supportability, "ErrorData"}, harvest_size: harvest_size)
 
     NewRelic.report_metric({:supportability, "ErrorData"},
@@ -100,5 +100,5 @@ defmodule NewRelic.Harvest.Collector.ErrorTrace.Harvester do
     )
   end
 
-  def build_payload(state), do: state.error_traces |> Enum.uniq() |> Trace.format_errors()
+  defp build_payload(state), do: state.error_traces |> Enum.uniq() |> Trace.format_errors()
 end

--- a/lib/new_relic/harvest/collector/metric/harvester.ex
+++ b/lib/new_relic/harvest/collector/metric/harvester.ex
@@ -60,13 +60,13 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
     {:reply, build_metric_data(state.metrics), state}
   end
 
-  def merge(metrics, state) do
+  defp merge(metrics, state) do
     metrics
     |> List.wrap()
     |> Enum.reduce(state.metrics, &merge_metric/2)
   end
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     metric_data = build_metric_data(state.metrics)
 
     Collector.Protocol.metric_data([
@@ -83,7 +83,7 @@ defmodule NewRelic.Harvest.Collector.Metric.Harvester do
     log_harvest(length(metric_data))
   end
 
-  def log_harvest(harvest_size) do
+  defp log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, "MetricData"}, harvest_size: harvest_size)
     NewRelic.log(:debug, "Completed Metric harvest - size: #{harvest_size}")
   end

--- a/lib/new_relic/harvest/collector/span_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/span_event/harvester.ex
@@ -121,13 +121,13 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
 
   # Helpers
 
-  def store_event(%{sampling: %{reservoir_size: size}} = state, %{priority: key} = event),
+  defp store_event(%{sampling: %{reservoir_size: size}} = state, %{priority: key} = event),
     do: %{state | events: Util.PriorityQueue.insert(state.events, size, key, event)}
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :events_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     spans = build_payload(state)
 
     Collector.Protocol.span_event([
@@ -139,12 +139,12 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
     log_harvest(length(spans), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def generate_guid(:root), do: DistributedTrace.generate_guid(pid: self())
+  defp generate_guid(:root), do: DistributedTrace.generate_guid(pid: self())
 
-  def generate_guid({label, ref}),
+  defp generate_guid({label, ref}),
     do: DistributedTrace.generate_guid(pid: self(), label: label, ref: ref)
 
-  def log_harvest(harvest_size, events_seen, reservoir_size) do
+  defp log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "SpanEventData"}, harvest_size: harvest_size)
 
     NewRelic.report_metric({:supportability, "SpanEventData"},
@@ -159,7 +159,7 @@ defmodule NewRelic.Harvest.Collector.SpanEvent.Harvester do
     )
   end
 
-  def build_payload(state) do
+  defp build_payload(state) do
     state.events
     |> Util.PriorityQueue.values()
     |> Event.format_events()

--- a/lib/new_relic/harvest/collector/supervisor.ex
+++ b/lib/new_relic/harvest/collector/supervisor.ex
@@ -24,7 +24,7 @@ defmodule NewRelic.Harvest.Collector.Supervisor do
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  def data_supervisor(namespace, key) do
+  defp data_supervisor(namespace, key) do
     Supervisor.child_spec(
       {Harvest.DataSupervisor, [namespace: namespace, key: key, lookup_module: Collector.AgentRun]},
       id: make_ref()

--- a/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_error_event/harvester.ex
@@ -65,22 +65,22 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
 
   # Helpers
 
-  def store_event(%{sampling: %{events_seen: seen, reservoir_size: size}} = state, event)
-      when seen < size,
-      do: %{state | error_events: [event | state.error_events]}
+  defp store_event(%{sampling: %{events_seen: seen, reservoir_size: size}} = state, event)
+       when seen < size,
+       do: %{state | error_events: [event | state.error_events]}
 
-  def store_event(state, _event), do: state
+  defp store_event(state, _event), do: state
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :events_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     events = build_payload(state)
     Collector.Protocol.error_event([Collector.AgentRun.agent_run_id(), state.sampling, events])
     log_harvest(length(events), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size, events_seen, reservoir_size) do
+  defp log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "ErrorEventData"}, harvest_size: harvest_size)
 
     NewRelic.log(
@@ -90,5 +90,5 @@ defmodule NewRelic.Harvest.Collector.TransactionErrorEvent.Harvester do
     )
   end
 
-  def build_payload(state), do: Event.format_events(state.error_events)
+  defp build_payload(state), do: Event.format_events(state.error_events)
 end

--- a/lib/new_relic/harvest/collector/transaction_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_event/harvester.ex
@@ -66,15 +66,15 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
 
   # Helpers
 
-  def store_event(%{sampling: %{reservoir_size: size}} = state, event) do
+  defp store_event(%{sampling: %{reservoir_size: size}} = state, event) do
     key = event.user_attributes[:priority] || :rand.uniform() |> Float.round(6)
     %{state | events: PriorityQueue.insert(state.events, size, key, event)}
   end
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :events_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     events = build_payload(state)
 
     Collector.Protocol.transaction_event([
@@ -86,7 +86,7 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
     log_harvest(length(events), state.sampling.events_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size, events_seen, reservoir_size) do
+  defp log_harvest(harvest_size, events_seen, reservoir_size) do
     NewRelic.report_metric({:supportability, "AnalyticEventData"}, harvest_size: harvest_size)
 
     NewRelic.report_metric({:supportability, "AnalyticEventData"},
@@ -101,7 +101,7 @@ defmodule NewRelic.Harvest.Collector.TransactionEvent.Harvester do
     )
   end
 
-  def build_payload(state) do
+  defp build_payload(state) do
     state.events
     |> PriorityQueue.values()
     |> Event.format_events()

--- a/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
+++ b/lib/new_relic/harvest/collector/transaction_trace/harvester.ex
@@ -98,20 +98,20 @@ defmodule NewRelic.Harvest.Collector.TransactionTrace.Harvester do
 
   def store_slow_trace(state, _trace, _max_slow_traces), do: state
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     traces = build_trace_payload(state)
     Collector.Protocol.transaction_trace([Collector.AgentRun.agent_run_id(), traces])
     log_harvest(length(traces))
   end
 
-  def log_harvest(harvest_size) do
+  defp log_harvest(harvest_size) do
     NewRelic.report_metric({:supportability, "TransactionTraceData"}, harvest_size: harvest_size)
     NewRelic.log(:debug, "Completed Transaction Trace harvest - size: #{harvest_size}")
   end
 
-  def build_trace_payload(state), do: state |> collect_traces |> Trace.format_traces()
+  defp build_trace_payload(state), do: state |> collect_traces |> Trace.format_traces()
 
-  def collect_traces(%{slowest_traces: slowest_traces, traces_by_name: traces_by_name}),
+  defp collect_traces(%{slowest_traces: slowest_traces, traces_by_name: traces_by_name}),
     do: (slowest_traces ++ Map.values(traces_by_name)) |> List.flatten() |> Enum.uniq()
 
   defp min_duration,

--- a/lib/new_relic/harvest/telemetry_sdk/api.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/api.ex
@@ -5,7 +5,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.API do
     url = url(:log)
     payload = {:logs, logs, generate_request_id()}
 
-    request(url, payload)
+    post(url, payload)
     |> maybe_retry(url, payload)
   end
 
@@ -13,7 +13,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.API do
     url = url(:trace)
     payload = {:spans, spans, generate_request_id()}
 
-    request(url, payload)
+    post(url, payload)
     |> maybe_retry(url, payload)
   end
 
@@ -21,30 +21,26 @@ defmodule NewRelic.Harvest.TelemetrySdk.API do
     url = url(:metric)
     payload = {:metrics, metrics, generate_request_id()}
 
-    request(url, payload)
-    |> maybe_retry(url, payload)
-  end
-
-  def request(url, payload) do
     post(url, payload)
+    |> maybe_retry(url, payload)
   end
 
   @success 200..299
   @drop [400, 401, 403, 405, 409, 410, 411]
-  def maybe_retry({:ok, %{status_code: status_code}} = result, _, _)
-      when status_code in @success
-      when status_code in @drop do
+  defp maybe_retry({:ok, %{status_code: status_code}} = result, _, _)
+       when status_code in @success
+       when status_code in @drop do
     result
   end
 
   # 413 split
 
   # 408, 500+
-  def maybe_retry(_result, url, payload) do
+  defp maybe_retry(_result, url, payload) do
     post(url, payload)
   end
 
-  def post(url, {_, payload, request_id}) do
+  defp post(url, {_, payload, request_id}) do
     NewRelic.Util.HTTP.post(url, payload, headers(request_id))
   end
 

--- a/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/logs/harvester.ex
@@ -62,22 +62,22 @@ defmodule NewRelic.Harvest.TelemetrySdk.Logs.Harvester do
 
   # Helpers
 
-  def store_log(%{sampling: %{logs_seen: seen, reservoir_size: size}} = state, log)
-      when seen < size,
-      do: %{state | logs: [log | state.logs]}
+  defp store_log(%{sampling: %{logs_seen: seen, reservoir_size: size}} = state, log)
+       when seen < size,
+       do: %{state | logs: [log | state.logs]}
 
-  def store_log(state, _log),
+  defp store_log(state, _log),
     do: state
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :logs_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     TelemetrySdk.API.log(build_log_data(state.logs))
     log_harvest(length(state.logs), state.sampling.logs_seen, state.sampling.reservoir_size)
   end
 
-  def log_harvest(harvest_size, logs_seen, reservoir_size) do
+  defp log_harvest(harvest_size, logs_seen, reservoir_size) do
     NewRelic.log(
       :debug,
       "Completed TelemetrySdk.Logs harvest - " <>

--- a/lib/new_relic/harvest/telemetry_sdk/spans/harvester.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/spans/harvester.ex
@@ -119,31 +119,31 @@ defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
 
   # Helpers
 
-  def store_span(
-        %{trace_mode: :infinite, sampling: %{spans_seen: seen, reservoir_size: size}} = state,
-        span
-      )
-      when seen == size do
+  defp store_span(
+         %{trace_mode: :infinite, sampling: %{spans_seen: seen, reservoir_size: size}} = state,
+         span
+       )
+       when seen == size do
     Harvest.HarvestCycle.cycle(TelemetrySdk.Spans.HarvestCycle)
     %{state | spans: [span | state.spans]}
   end
 
-  def store_span(%{trace_mode: :infinite} = state, span) do
+  defp store_span(%{trace_mode: :infinite} = state, span) do
     %{state | spans: [span | state.spans]}
   end
 
-  def store_span(%{sampling: %{spans_seen: seen, reservoir_size: size}} = state, span)
-      when seen < size do
+  defp store_span(%{sampling: %{spans_seen: seen, reservoir_size: size}} = state, span)
+       when seen < size do
     %{state | spans: [span | state.spans]}
   end
 
-  def store_span(state, _span),
+  defp store_span(state, _span),
     do: state
 
-  def store_sampling(%{sampling: sampling} = state),
+  defp store_sampling(%{sampling: sampling} = state),
     do: %{state | sampling: Map.update!(sampling, :spans_seen, &(&1 + 1))}
 
-  def send_harvest(state) do
+  defp send_harvest(state) do
     TelemetrySdk.API.span(build_span_data(state.spans))
 
     log_harvest(
@@ -154,7 +154,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Spans.Harvester do
     )
   end
 
-  def log_harvest(harvest_size, spans_seen, reservoir_size, trace_mode) do
+  defp log_harvest(harvest_size, spans_seen, reservoir_size, trace_mode) do
     with :infinite <- trace_mode do
       NewRelic.report_metric({:supportability, :infinite_tracing}, harvest_size: harvest_size)
     end

--- a/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/supervisor.ex
@@ -20,7 +20,7 @@ defmodule NewRelic.Harvest.TelemetrySdk.Supervisor do
     Supervisor.init(children, strategy: :one_for_all)
   end
 
-  def data_supervisor(namespace, key) do
+  defp data_supervisor(namespace, key) do
     Supervisor.child_spec(
       {Harvest.DataSupervisor, [namespace: namespace, key: key, lookup_module: TelemetrySdk.Config]},
       id: make_ref()

--- a/lib/new_relic/logger.ex
+++ b/lib/new_relic/logger.ex
@@ -70,11 +70,11 @@ defmodule NewRelic.Logger do
     end
   end
 
-  def device(:stdio), do: {:ok, :stdio}
-  def device(:memory), do: StringIO.open("")
-  def device(:logger), do: {:ok, Logger}
+  defp device(:stdio), do: {:ok, :stdio}
+  defp device(:memory), do: StringIO.open("")
+  defp device(:logger), do: {:ok, Logger}
 
-  def device({:file, logfile}) do
+  defp device({:file, logfile}) do
     log(:info, "Log File: #{Path.absname(logfile)}")
     logfile |> Path.dirname() |> File.mkdir_p!()
     {:ok, _file} = File.open(logfile, [:append, :utf8])
@@ -86,13 +86,13 @@ defmodule NewRelic.Logger do
   defp elixir_logger(:error, message), do: Logger.error(message)
 
   @sep " - "
-  def formatted(level, message), do: [formatted(level), @sep, timestamp(), @sep, message, "\n"]
-  def formatted(:debug), do: "[DEBUG]"
-  def formatted(:info), do: "[INFO]"
-  def formatted(:warning), do: "[WARN]"
-  def formatted(:error), do: "[ERROR]"
+  defp formatted(level, message), do: [formatted(level), @sep, timestamp(), @sep, message, "\n"]
+  defp formatted(:debug), do: "[DEBUG]"
+  defp formatted(:info), do: "[INFO]"
+  defp formatted(:warning), do: "[WARN]"
+  defp formatted(:error), do: "[ERROR]"
 
-  def timestamp do
+  defp timestamp do
     :calendar.local_time()
     |> NaiveDateTime.from_erl!()
     |> NaiveDateTime.to_string()

--- a/lib/new_relic/logs_in_context.ex
+++ b/lib/new_relic/logs_in_context.ex
@@ -22,7 +22,7 @@ defmodule NewRelic.LogsInContext do
     :skip
   end
 
-  def primary_filter(%{msg: {:string, _msg}} = log, %{mode: :direct}) do
+  defp primary_filter(%{msg: {:string, _msg}} = log, %{mode: :direct}) do
     log
     |> prepare_log()
     |> TelemetrySdk.Logs.Harvester.report_log()
@@ -30,7 +30,7 @@ defmodule NewRelic.LogsInContext do
     log
   end
 
-  def primary_filter(%{msg: {:string, _msg}} = log, %{mode: :forwarder}) do
+  defp primary_filter(%{msg: {:string, _msg}} = log, %{mode: :forwarder}) do
     message =
       log
       |> prepare_log()
@@ -40,7 +40,7 @@ defmodule NewRelic.LogsInContext do
     %{log | msg: {:string, message}}
   end
 
-  def primary_filter(_log, _config) do
+  defp primary_filter(_log, _config) do
     :ignore
   end
 
@@ -90,7 +90,7 @@ defmodule NewRelic.LogsInContext do
     AgentRun.entity_metadata()
   end
 
-  def tracing_metadata() do
+  defp tracing_metadata() do
     context = NewRelic.DistributedTrace.get_tracing_context() || %{}
 
     %{

--- a/lib/new_relic/sampler/agent.ex
+++ b/lib/new_relic/sampler/agent.ex
@@ -27,7 +27,7 @@ defmodule NewRelic.Sampler.Agent do
     {:reply, :ok, state}
   end
 
-  def record_sample do
+  defp record_sample do
     NewRelic.report_metric(
       {:supportability, :agent, "Sidecar/Process/ActiveCount"},
       value: NewRelic.Transaction.Sidecar.counter()

--- a/lib/new_relic/sampler/beam.ex
+++ b/lib/new_relic/sampler/beam.ex
@@ -37,7 +37,7 @@ defmodule NewRelic.Sampler.Beam do
     {:reply, :ok, %{state | previous: current_sample}}
   end
 
-  def record_sample(state) do
+  defp record_sample(state) do
     {current_sample, stats} = collect(state.previous)
     NewRelic.report_sample(:BeamStat, stats)
     NewRelic.report_metric(:memory, mb: stats[:memory_total_mb])

--- a/lib/new_relic/sampler/ets.ex
+++ b/lib/new_relic/sampler/ets.ex
@@ -31,7 +31,7 @@ defmodule NewRelic.Sampler.Ets do
     {:reply, :ok, state}
   end
 
-  def record_sample, do: Enum.map(named_tables(), &record_sample/1)
+  defp record_sample, do: Enum.map(named_tables(), &record_sample/1)
 
   @size_threshold 500
   def record_sample(table) do
@@ -42,7 +42,7 @@ defmodule NewRelic.Sampler.Ets do
     end
   end
 
-  def named_tables, do: Enum.reject(:ets.all(), &is_reference/1)
+  defp named_tables, do: Enum.reject(:ets.all(), &is_reference/1)
 
   defp take_sample(table) do
     with words when is_number(words) <- :ets.info(table, :memory),

--- a/lib/new_relic/sampler/process.ex
+++ b/lib/new_relic/sampler/process.ex
@@ -46,7 +46,7 @@ defmodule NewRelic.Sampler.Process do
     {:reply, :ok, %{state | previous: previous}}
   end
 
-  def record_samples(state) do
+  defp record_samples(state) do
     Enum.reduce(state.pids, %{}, fn {pid, true}, acc ->
       {current_sample, stats} = collect(pid, state.previous[pid])
       NewRelic.report_sample(:ProcessSample, stats)
@@ -54,22 +54,22 @@ defmodule NewRelic.Sampler.Process do
     end)
   end
 
-  def store_pid(true, state, _existing_pid), do: state
+  defp store_pid(true, state, _existing_pid), do: state
 
-  def store_pid(nil, state, pid) do
+  defp store_pid(nil, state, pid) do
     Process.monitor(pid)
     pids = Map.put(state.pids, pid, true)
     previous = Map.put(state.previous, pid, take_sample(pid))
     %{state | pids: pids, previous: previous}
   end
 
-  def collect(pid, previous) do
+  defp collect(pid, previous) do
     current_sample = take_sample(pid)
     stats = Map.merge(current_sample, delta(previous, current_sample))
     {current_sample, stats}
   end
 
-  def take_sample(pid) do
+  defp take_sample(pid) do
     # http://erlang.org/doc/man/erlang.html#process_info-2
     info = Process.info(pid, [:message_queue_len, :memory, :reductions, :registered_name])
 

--- a/lib/new_relic/sampler/reporter.ex
+++ b/lib/new_relic/sampler/reporter.ex
@@ -4,7 +4,7 @@ defmodule NewRelic.Sampler.Reporter do
   def report_sample(category, sample) when is_map(sample),
     do: NewRelic.report_custom_event(sampler_event_type(), Map.put(sample, :category, category))
 
-  def sampler_event_type,
+  defp sampler_event_type,
     do: Application.get_env(:new_relic_agent, :sample_event_type, "ElixirSample")
 
   def sample_cycle, do: Application.get_env(:new_relic_agent, :sample_cycle, 15_000)

--- a/lib/new_relic/sampler/top_process.ex
+++ b/lib/new_relic/sampler/top_process.ex
@@ -45,7 +45,7 @@ defmodule NewRelic.Sampler.TopProcess do
   end
 
   @size 5
-  def measure_and_insert(pid, {mem_pq, msg_pq}) do
+  defp measure_and_insert(pid, {mem_pq, msg_pq}) do
     case Process.info(pid, [:memory, :message_queue_len, :registered_name, :reductions]) do
       [memory: mem, message_queue_len: msg, registered_name: _, reductions: _] = info ->
         mem_pq = PQ.insert(mem_pq, @size, mem, {pid, info})
@@ -57,7 +57,7 @@ defmodule NewRelic.Sampler.TopProcess do
     end
   end
 
-  def report_sample({pid, info}) do
+  defp report_sample({pid, info}) do
     case Process.info(pid, :reductions) do
       {:reductions, current_reductions} ->
         NewRelic.report_sample(:ProcessSample, %{

--- a/lib/new_relic/span/event.ex
+++ b/lib/new_relic/span/event.ex
@@ -32,7 +32,7 @@ defmodule NewRelic.Span.Event do
     Enum.map(spans, &format_event/1)
   end
 
-  def format_event(%__MODULE__{} = span) do
+  defp format_event(%__MODULE__{} = span) do
     intrinsics =
       %{
         type: span.type,

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -66,21 +66,21 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def trace_function?(module, name, arity),
+  defp trace_function?(module, name, arity),
     do:
       trace_function?(:via_annotation, module) ||
         trace_function?(:via_multiple_heads, module, name, arity)
 
-  def trace_function?(:via_annotation, module), do: Module.get_attribute(module, :trace)
+  defp trace_function?(:via_annotation, module), do: Module.get_attribute(module, :trace)
 
-  def trace_function?(:via_multiple_heads, module, name, arity) do
+  defp trace_function?(:via_multiple_heads, module, name, arity) do
     case Module.get_attribute(module, :nr_last_tracer) do
       {^name, ^arity, trace_info} -> trace_info
       _ -> false
     end
   end
 
-  def trace_deprecated?({_, category: :datastore}, module, name) do
+  defp trace_deprecated?({_, category: :datastore}, module, name) do
     Logger.warning(
       "[New Relic] Trace `:datastore` deprecated in favor of automatic Ecto instrumentation. " <>
         "Please remove @trace from #{inspect(module)}.#{name}"
@@ -89,35 +89,35 @@ defmodule NewRelic.Tracer.Macro do
     false
   end
 
-  def trace_deprecated?(trace_info, _, _) do
+  defp trace_deprecated?(trace_info, _, _) do
     trace_info
   end
 
-  def function_specs(module),
+  defp function_specs(module),
     do:
       module
       |> Module.get_attribute(:nr_tracers)
       |> Enum.map(&traced_function_spec/1)
       |> Enum.uniq()
 
-  def function_definitions(module),
+  defp function_definitions(module),
     do:
       module
       |> Module.get_attribute(:nr_tracers)
       |> Enum.map(&traced_function_definition/1)
       |> Enum.reverse()
 
-  def traced_function_spec(%{function: function, args: args}), do: {function, length(args)}
+  defp traced_function_spec(%{function: function, args: args}), do: {function, length(args)}
 
-  def traced_function_definition(%{
-        module: module,
-        access: :def,
-        function: function,
-        args: args,
-        body: body,
-        guards: [],
-        trace_info: trace_info
-      }) do
+  defp traced_function_definition(%{
+         module: module,
+         access: :def,
+         function: function,
+         args: args,
+         body: body,
+         guards: [],
+         trace_info: trace_info
+       }) do
     quote do
       def unquote(function)(unquote_splicing(build_function_args(args))) do
         unquote(traced_function_body(body, module, function, args, trace_info))
@@ -125,15 +125,15 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def traced_function_definition(%{
-        module: module,
-        access: :def,
-        function: function,
-        args: args,
-        body: body,
-        guards: guards,
-        trace_info: trace_info
-      }) do
+  defp traced_function_definition(%{
+         module: module,
+         access: :def,
+         function: function,
+         args: args,
+         body: body,
+         guards: guards,
+         trace_info: trace_info
+       }) do
     quote do
       def unquote(function)(unquote_splicing(build_function_args(args)))
           when unquote_splicing(guards) do
@@ -142,15 +142,15 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def traced_function_definition(%{
-        module: module,
-        access: :defp,
-        function: function,
-        args: args,
-        body: body,
-        guards: [],
-        trace_info: trace_info
-      }) do
+  defp traced_function_definition(%{
+         module: module,
+         access: :defp,
+         function: function,
+         args: args,
+         body: body,
+         guards: [],
+         trace_info: trace_info
+       }) do
     quote do
       defp unquote(function)(unquote_splicing(build_function_args(args))) do
         unquote(traced_function_body(body, module, function, args, trace_info))
@@ -158,15 +158,15 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def traced_function_definition(%{
-        module: module,
-        access: :defp,
-        function: function,
-        args: args,
-        body: body,
-        guards: guards,
-        trace_info: trace_info
-      }) do
+  defp traced_function_definition(%{
+         module: module,
+         access: :defp,
+         function: function,
+         args: args,
+         body: body,
+         guards: guards,
+         trace_info: trace_info
+       }) do
     quote do
       defp unquote(function)(unquote_splicing(build_function_args(args)))
            when unquote_splicing(guards) do
@@ -175,7 +175,7 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def traced_function_body(body, module, function, args, trace_info) do
+  defp traced_function_body(body, module, function, args, trace_info) do
     trace_annotation =
       case trace_info do
         {name, options} -> {name, options}
@@ -224,8 +224,7 @@ defmodule NewRelic.Tracer.Macro do
             nil -> :root
           end
 
-        duration_ms =
-          System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1000
+        duration_ms = System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1000
 
         duration_acc = Process.get({:nr_duration_acc, parent_ref}, 0)
         Process.put({:nr_duration_acc, parent_ref}, duration_acc + duration_ms)
@@ -253,13 +252,13 @@ defmodule NewRelic.Tracer.Macro do
     end
   end
 
-  def build_function_args(args) when is_list(args), do: Enum.map(args, &build_function_args/1)
+  defp build_function_args(args) when is_list(args), do: Enum.map(args, &build_function_args/1)
 
   # Don't try to re-declare the default argument
-  def build_function_args({:\\, _, [arg, _default]}),
+  defp build_function_args({:\\, _, [arg, _default]}),
     do: arg
 
-  def build_function_args(arg), do: arg
+  defp build_function_args(arg), do: arg
 
   def build_call_args(args) do
     Macro.postwalk(args, &rewrite_call_term/1)
@@ -267,16 +266,16 @@ defmodule NewRelic.Tracer.Macro do
 
   # Unwrap Struct literals into a Map, they can't be re-referenced directly due to enforced_keys
   @struct_keys [:__aliases__, :__MODULE__]
-  def rewrite_call_term({:%, line, [{key, _, _} = struct, {:%{}, _, members}]})
-      when key in @struct_keys do
+  defp rewrite_call_term({:%, line, [{key, _, _} = struct, {:%{}, _, members}]})
+       when key in @struct_keys do
     {:%{}, line, [{:__struct__, struct}] ++ members}
   end
 
   # Strip default arguments
-  def rewrite_call_term({:\\, _, [arg, _default]}), do: arg
+  defp rewrite_call_term({:\\, _, [arg, _default]}), do: arg
 
   # Drop the de-structuring side of a pattern match
-  def rewrite_call_term({:=, _, [left, right]}) do
+  defp rewrite_call_term({:=, _, [left, right]}) do
     cond do
       :__ignored__ == left -> right
       :__ignored__ == right -> left
@@ -286,7 +285,7 @@ defmodule NewRelic.Tracer.Macro do
   end
 
   # Replace ignored variables with an atom
-  def rewrite_call_term({name, _, context} = term) when is_variable(name, context) do
+  defp rewrite_call_term({name, _, context} = term) when is_variable(name, context) do
     case Atom.to_string(name) do
       "__" <> _special_form -> term
       "_" <> _ignored_var -> :__ignored__
@@ -295,12 +294,12 @@ defmodule NewRelic.Tracer.Macro do
   end
 
   # Replace :__ignored__ with [] when it's the tail of a list so we don't create an improper list
-  def rewrite_call_term({:|, line, [left, :__ignored__]}) do
+  defp rewrite_call_term({:|, line, [left, :__ignored__]}) do
     {:|, line, [left, []]}
   end
 
-  def rewrite_call_term(term), do: term
+  defp rewrite_call_term(term), do: term
 
-  def is_variable?({name, _, context}) when is_variable(name, context), do: true
-  def is_variable?(_term), do: false
+  defp is_variable?({name, _, context}) when is_variable(name, context), do: true
+  defp is_variable?(_term), do: false
 end

--- a/lib/new_relic/transaction/erlang_trace.ex
+++ b/lib/new_relic/transaction/erlang_trace.ex
@@ -83,7 +83,7 @@ defmodule NewRelic.Transaction.ErlangTrace do
     ArgumentError -> :process_gone
   end
 
-  def enable_trace_patterns do
+  defp enable_trace_patterns do
     # Use function tracers to notice when linked work has been kicked off
     #   http://erlang.org/doc/man/erlang.html#trace_3_trace_messages_return_from
     #   http://erlang.org/doc/apps/erts/match_spec.html

--- a/lib/new_relic/transaction/event.ex
+++ b/lib/new_relic/transaction/event.ex
@@ -14,7 +14,7 @@ defmodule NewRelic.Transaction.Event do
     Enum.map(transactions, &format_event/1)
   end
 
-  def format_event(%__MODULE__{} = transaction) do
+  defp format_event(%__MODULE__{} = transaction) do
     [
       %{
         webDuration: transaction.web_duration,

--- a/lib/new_relic/transaction/trace.ex
+++ b/lib/new_relic/transaction/trace.ex
@@ -34,7 +34,7 @@ defmodule NewRelic.Transaction.Trace do
     Enum.map(traces, &format_trace/1)
   end
 
-  def format_trace(%__MODULE__{} = trace) do
+  defp format_trace(%__MODULE__{} = trace) do
     trace_segments = format_segments(trace)
     trace_details = [trace.start_time, @unused_map, @unused_map, trace_segments, trace.attributes]
 
@@ -52,11 +52,11 @@ defmodule NewRelic.Transaction.Trace do
     ]
   end
 
-  def format_segments(%{
-        segments: [first_segment | _] = segments,
-        duration: duration,
-        metric_name: metric_name
-      }) do
+  defp format_segments(%{
+         segments: [first_segment | _] = segments,
+         duration: duration,
+         metric_name: metric_name
+       }) do
     attributes = first_segment.attributes |> NewRelic.Util.coerce_attributes()
 
     [
@@ -76,7 +76,7 @@ defmodule NewRelic.Transaction.Trace do
     ]
   end
 
-  def format_child_segments(%Segment{} = segment) do
+  defp format_child_segments(%Segment{} = segment) do
     [
       segment.relative_start_time,
       segment.relative_end_time,

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -135,7 +135,7 @@ defmodule NewRelic.Util do
     |> Vendor.maybe_add_vendors()
   end
 
-  def maybe_heroku_dyno_hostname do
+  defp maybe_heroku_dyno_hostname do
     System.get_env("DYNO")
     |> case do
       nil -> nil
@@ -145,14 +145,14 @@ defmodule NewRelic.Util do
     end
   end
 
-  def maybe_add_linux_boot_id(util) do
+  defp maybe_add_linux_boot_id(util) do
     case File.read("/proc/sys/kernel/random/boot_id") do
       {:ok, boot_id} -> Map.put(util, "boot_id", boot_id)
       _ -> util
     end
   end
 
-  def maybe_add_ip_addresses(util) do
+  defp maybe_add_ip_addresses(util) do
     case :inet.getif() do
       {:ok, addrs} ->
         ip_address = Enum.map(addrs, fn {ip, _, _} -> to_string(:inet.ntoa(ip)) end)
@@ -163,7 +163,7 @@ defmodule NewRelic.Util do
     end
   end
 
-  def maybe_add_fqdn(util) do
+  defp maybe_add_fqdn(util) do
     case :net_adm.dns_hostname(:net_adm.localhost()) do
       {:ok, fqdn} -> Map.put(util, :full_hostname, to_string(fqdn))
       _ -> util

--- a/lib/new_relic/util/error.ex
+++ b/lib/new_relic/util/error.ex
@@ -15,11 +15,11 @@ defmodule NewRelic.Util.Error do
     {exception_type, exception_reason, exception_stacktrace}
   end
 
-  def format_type(:error, %ErlangError{original: {_reason, {module, function, args}}}),
+  defp format_type(:error, %ErlangError{original: {_reason, {module, function, args}}}),
     do: Exception.format_mfa(module, function, length(args))
 
-  def format_type(:error, %{__struct__: struct}), do: inspect(struct)
-  def format_type(:exit, _reason), do: "EXIT"
+  defp format_type(:error, %{__struct__: struct}), do: inspect(struct)
+  defp format_type(:exit, _reason), do: "EXIT"
 
   def format_reason(:error, %ErlangError{original: {reason, {module, function, args}}}),
     do: "(" <> Exception.format_mfa(module, function, length(args)) <> ") " <> inspect(reason)

--- a/lib/new_relic/util/event.ex
+++ b/lib/new_relic/util/event.ex
@@ -1,9 +1,7 @@
 defmodule NewRelic.Util.Event do
   @moduledoc false
 
-  def process(events), do: Enum.map(events, &process_event/1)
-
-  def process_event(event), do: Enum.into(event, %{}, &process_attr/1)
+  def process_event(event), do: Map.new(event, &process_attr/1)
 
   defp process_attr({key, val}) when is_binary(val), do: {key, val |> limit_size}
   defp process_attr({key, val}) when is_bitstring(val), do: {key, val |> inspect |> limit_size}

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -34,14 +34,12 @@ defmodule NewRelic.Util.HTTP do
     end
   end
 
-  @doc """
-  Certs are from `CAStore`.
-  https://github.com/elixir-mint/castore
+  # Certs are from `CAStore`.
+  # https://github.com/elixir-mint/castore
 
-  SSL configured according to EEF Security guide:
-  https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
-  """
-  def http_options(opts \\ []) do
+  # SSL configured according to EEF Security guide:
+  # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/ssl
+  defp http_options(opts \\ []) do
     env_opts = Application.get_env(:new_relic_agent, :httpc_request_options, [])
 
     [

--- a/lib/new_relic/util/priority_queue.ex
+++ b/lib/new_relic/util/priority_queue.ex
@@ -30,10 +30,6 @@ defmodule NewRelic.Util.PriorityQueue do
     :gb_trees.values(tree)
   end
 
-  def list(tree) do
-    :gb_trees.to_list(tree)
-  end
-
   defp differentiator() do
     :erlang.unique_integer()
   end

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -13,7 +13,7 @@ defmodule NewRelic.Util.Vendor do
   end
 
   @aws_url "http://169.254.169.254/2016-09-02/dynamic/instance-identity/document"
-  def maybe_add_aws(vendors, options \\ []) do
+  defp maybe_add_aws(vendors, options) do
     Keyword.get(options, :aws_url, @aws_url)
     |> aws_vendor_map()
     |> case do
@@ -22,7 +22,7 @@ defmodule NewRelic.Util.Vendor do
     end
   end
 
-  def maybe_add_kubernetes(vendors, _options) do
+  defp maybe_add_kubernetes(vendors, _options) do
     System.get_env("KUBERNETES_SERVICE_HOST")
     |> case do
       nil -> vendors
@@ -31,7 +31,7 @@ defmodule NewRelic.Util.Vendor do
   end
 
   @cgroup_filename "/proc/self/cgroup"
-  def maybe_add_docker(vendors, options) do
+  defp maybe_add_docker(vendors, options) do
     Keyword.get(options, :cgroup_filename, @cgroup_filename)
     |> docker_vendor_map()
     |> case do
@@ -41,7 +41,7 @@ defmodule NewRelic.Util.Vendor do
   end
 
   @cgroup_matcher ~r/\d+:.*cpu[,:].*(?<id>[0-9a-f]{64}).*/
-  def docker_vendor_map(cgroup_filename) do
+  defp docker_vendor_map(cgroup_filename) do
     File.read(cgroup_filename)
     |> case do
       {:ok, cgroup_file} ->
@@ -55,7 +55,7 @@ defmodule NewRelic.Util.Vendor do
   end
 
   @aws_vendor_data ["availabilityZone", "instanceId", "instanceType"]
-  def aws_vendor_map(url) do
+  defp aws_vendor_map(url) do
     case :httpc.request(:get, {~c(#{url}), []}, [{:timeout, 100}], []) do
       {:ok, {{_, 200, ~c"OK"}, _headers, body}} ->
         case Jason.decode(body) do

--- a/test/backoff_sampler_test.exs
+++ b/test/backoff_sampler_test.exs
@@ -89,12 +89,12 @@ defmodule BackoffSamplerTest do
   end
 
   test "handle when we need rand(0)" do
-    BackoffSampler.do_sample?(%{
-      cycle_number: 1,
-      sampled_true_count: 0,
-      sampling_target: 10,
-      decided_count_last: 0
-    })
+    assert BackoffSampler.do_sample?(%{
+             cycle_number: 1,
+             sampled_true_count: 0,
+             sampling_target: 10,
+             decided_count_last: 0
+           })
   end
 
   test "cycles trigger" do


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

This makes many functions that were previously public, private. Making the functions private help the compiler to give better indications of dead codepaths, and is also a better dev experience.

Most of these use cases seem to be unintentionally public.

I know this is _technically_ a potentially breaking change, so if it is undesired feel free to close. Alternatively, if some of these should actually be public, I can help document them.
