### PR TITLE
Fix TTs for bandit

### DIFF
--- a/lib/new_relic/transaction/trace.ex
+++ b/lib/new_relic/transaction/trace.ex
@@ -62,17 +62,9 @@ defmodule NewRelic.Transaction.Trace do
     [
       0,
       duration,
-      "ROOT",
+      metric_name,
       attributes,
-      [
-        [
-          0,
-          duration,
-          metric_name,
-          attributes,
-          Enum.map(segments, &format_child_segments/1)
-        ]
-      ]
+      Enum.map(segments, &format_child_segments/1)
     ]
   end
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -464,7 +464,7 @@ defmodule TransactionTest do
     assert event[:total_time_s] > event[:duration_s]
     assert event[:total_time_s] < event[:duration_s] * 2
 
-    assert event[:process_spawns] == 1
+    assert event[:process_spawns] == 2
   end
 
   describe "Request queuing" do


### PR DESCRIPTION
There was an assumption in the Transaction Trace processing that relied on the fact that the cowboy web server spawned a process during the transaction. Bandit doesn't have that behavior, which interfered with processing of the segments & how they are nested. This led to segments being duplicated in TTs.

* This PR fixes this situation by making sure the function processing function segments has access the segment representing the root process so it can correctly associate them where they need to go.
* Gets rid of a duplicate layer of nesting at the root of the TT which has always been there but probably shouldn't have been.
* Drops the cowboy specific modification of process spawn count attribute