### PR TITLE
Support native JSON library

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ defp deps do
 end
 ```
 
+If using an Elixir version before 1.18.x, please also add `:jason` to your dependency list.
+
+```elixir
+{:jason, "~> 1.0"}
+```
+
 ## Configuration
 
 You need to set a few required configuration keys so we can authenticate properly.

--- a/lib/new_relic/distributed_trace/new_relic_context.ex
+++ b/lib/new_relic/distributed_trace/new_relic_context.ex
@@ -15,7 +15,7 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
 
   def decode(raw_payload) when is_binary(raw_payload) do
     with {:ok, json} <- Base.decode64(raw_payload),
-         {:ok, map} <- Jason.decode(json),
+         {:ok, map} <- NewRelic.JSON.decode(json),
          %Context{} = context <- validate(map) do
       NewRelic.report_metric(:supportability, [:dt, :accept, :success])
       context
@@ -84,7 +84,7 @@ defmodule NewRelic.DistributedTrace.NewRelicContext do
         }
         |> maybe_put(:trust_key, "tk", context.account_id, context.trust_key)
     }
-    |> Jason.encode!()
+    |> NewRelic.JSON.encode!()
     |> Base.encode64()
   end
 

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -93,9 +93,10 @@ defmodule NewRelic.Harvest.Collector.Protocol do
 
   defp parse_http_response({:ok, %{status_code: 200, body: body}}, _params) do
     {:ok, NewRelic.JSON.decode!(body)}
-  rescue error ->
-    NewRelic.log(:error, "Bad collector JSON: #{Exception.message(error)}")
-    {:error, :bad_collector_response}
+  rescue
+    error ->
+      NewRelic.log(:error, "Bad collector JSON: #{Exception.message(error)}")
+      {:error, :bad_collector_response}
   end
 
   defp parse_http_response({:ok, %{status_code: 202}}, _params) do

--- a/lib/new_relic/harvest/collector/protocol.ex
+++ b/lib/new_relic/harvest/collector/protocol.ex
@@ -93,8 +93,8 @@ defmodule NewRelic.Harvest.Collector.Protocol do
 
   defp parse_http_response({:ok, %{status_code: 200, body: body}}, _params) do
     {:ok, NewRelic.JSON.decode!(body)}
-  rescue e ->
-    NewRelic.log(:error, "Bad collector JSON: #{Exception.format_banner(:error, e)}")
+  rescue error ->
+    NewRelic.log(:error, "Bad collector JSON: #{Exception.message(error)}")
     {:error, :bad_collector_response}
   end
 

--- a/lib/new_relic/json.ex
+++ b/lib/new_relic/json.ex
@@ -15,5 +15,4 @@ defmodule NewRelic.JSON do
     true ->
       raise "[:new_relic_agent] No JSON library found, please add :jason as a dependency"
   end
-
 end

--- a/lib/new_relic/json.ex
+++ b/lib/new_relic/json.ex
@@ -1,15 +1,19 @@
 defmodule NewRelic.JSON do
   @moduledoc false
 
-  if Code.ensure_loaded?(JSON) do
-    defdelegate decode(data), to: JSON
-    defdelegate decode!(data), to: JSON
-    defdelegate encode!(data), to: JSON
+  cond do
+    Code.ensure_loaded?(JSON) ->
+      def decode(data), do: apply(JSON, :decode, [data])
+      def decode!(data), do: apply(JSON, :decode!, [data])
+      def encode!(data), do: apply(JSON, :encode!, [data])
+
+    Code.ensure_loaded?(Jason) ->
+      def decode(data), do: apply(Jason, :decode, [data])
+      def decode!(data), do: apply(Jason, :decode!, [data])
+      def encode!(data), do: apply(Jason, :encode!, [data])
+
+    true ->
+      raise "[:new_relic_agent] No JSON library found, please add :jason as a dependency"
   end
 
-  if Code.ensure_loaded?(Jason) do
-    defdelegate decode(data), to: Jason
-    defdelegate decode!(data), to: Jason
-    defdelegate encode!(data), to: Jason
-  end
 end

--- a/lib/new_relic/json.ex
+++ b/lib/new_relic/json.ex
@@ -1,0 +1,15 @@
+defmodule NewRelic.JSON do
+  @moduledoc false
+
+  if Code.ensure_loaded?(JSON) do
+    defdelegate decode(data), to: JSON
+    defdelegate decode!(data), to: JSON
+    defdelegate encode!(data), to: JSON
+  end
+
+  if Code.ensure_loaded?(Jason) do
+    defdelegate decode(data), to: Jason
+    defdelegate decode!(data), to: Jason
+    defdelegate encode!(data), to: Jason
+  end
+end

--- a/lib/new_relic/logs_in_context.ex
+++ b/lib/new_relic/logs_in_context.ex
@@ -35,7 +35,7 @@ defmodule NewRelic.LogsInContext do
       log
       |> prepare_log()
       |> Map.merge(linking_metadata())
-      |> Jason.encode!()
+      |> NewRelic.JSON.encode!()
 
     %{log | msg: {:string, message}}
   end

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -14,14 +14,11 @@ defmodule NewRelic.Util.HTTP do
   end
 
   def post(url, body, headers) do
-    case Jason.encode(body) do
-      {:ok, body} ->
-        post(url, body, headers)
-
-      {:error, message} ->
-        NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
-        {:error, message}
-    end
+    body = NewRelic.JSON.encode!(body)
+    post(url, body, headers)
+  rescue e ->
+    NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
+    {:error, Exception.format_banner(:error, e, __STACKTRACE__)}
   end
 
   def get(url, headers \\ [], opts \\ []) do

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -16,9 +16,9 @@ defmodule NewRelic.Util.HTTP do
   def post(url, body, headers) do
     body = NewRelic.JSON.encode!(body)
     post(url, body, headers)
-  rescue e ->
+  rescue error ->
     NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
-    {:error, Exception.format_banner(:error, e, __STACKTRACE__)}
+    {:error, Exception.message(error)}
   end
 
   def get(url, headers \\ [], opts \\ []) do

--- a/lib/new_relic/util/http.ex
+++ b/lib/new_relic/util/http.ex
@@ -16,9 +16,10 @@ defmodule NewRelic.Util.HTTP do
   def post(url, body, headers) do
     body = NewRelic.JSON.encode!(body)
     post(url, body, headers)
-  rescue error ->
-    NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
-    {:error, Exception.message(error)}
+  rescue
+    error ->
+      NewRelic.log(:debug, "Unable to JSON encode: #{inspect(body)}")
+      {:error, Exception.message(error)}
   end
 
   def get(url, headers \\ [], opts \\ []) do

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -58,7 +58,7 @@ defmodule NewRelic.Util.Vendor do
   def aws_vendor_map(url) do
     case :httpc.request(:get, {~c(#{url}), []}, [{:timeout, 100}], []) do
       {:ok, {{_, 200, ~c"OK"}, _headers, body}} ->
-        case NewRelic.JSON.decode(body) do
+        case NewRelic.JSON.decode(to_string(body)) do
           {:ok, data} -> Map.take(data, @aws_vendor_data)
           _ -> nil
         end

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -58,7 +58,7 @@ defmodule NewRelic.Util.Vendor do
   def aws_vendor_map(url) do
     case :httpc.request(:get, {~c(#{url}), []}, [{:timeout, 100}], []) do
       {:ok, {{_, 200, ~c"OK"}, _headers, body}} ->
-        case Jason.decode(body) do
+        case NewRelic.JSON.decode(body) do
           {:ok, data} -> Map.take(data, @aws_vendor_data)
           _ -> nil
         end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule NewRelic.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:castore, ">= 0.1.0"},
-      {:jason, "~> 1.0"},
+      {:jason, "~> 1.0", optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       # Instrumentation:
       {:plug, ">= 1.10.4", optional: true},

--- a/test/collector_protocol_test.exs
+++ b/test/collector_protocol_test.exs
@@ -19,7 +19,7 @@ defmodule CollectorProtocolTest do
 
     assert Map.has_key?(payload, :display_host)
 
-    Jason.encode!(payload)
+    NewRelic.JSON.encode!(payload)
   end
 
   test "determine correct collector host" do

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -138,7 +138,7 @@ defmodule CustomEventTest do
     })
 
     events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
-    Jason.encode!(events)
+    NewRelic.JSON.encode!(events)
 
     [[_, attrs, _]] = events
     assert attrs[:bad_value] == "[BAD_VALUE]"

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -117,7 +117,7 @@ defmodule DistributedTraceTest do
     outbound_payload =
       response.body
       |> Base.decode64!()
-      |> Jason.decode!()
+      |> NewRelic.JSON.decode!()
 
     assert get_in(outbound_payload, ["d", "tr"]) == "d6b4ba0c3a712ca"
     assert get_in(outbound_payload, ["d", "ac"]) == "190"
@@ -164,7 +164,7 @@ defmodule DistributedTraceTest do
     outbound_payload =
       response.body
       |> Base.decode64!()
-      |> Jason.decode!()
+      |> NewRelic.JSON.decode!()
 
     data = outbound_payload["d"]
     assert "d6b4ba0c3a712ca" == data["tr"]
@@ -182,7 +182,7 @@ defmodule DistributedTraceTest do
     outbound_payload =
       response.body
       |> Base.decode64!()
-      |> Jason.decode!()
+      |> NewRelic.JSON.decode!()
 
     # Span GUID, Transaction ID, Trace ID initialized
     assert get_in(outbound_payload, ["d", "id"]) |> is_binary
@@ -208,7 +208,7 @@ defmodule DistributedTraceTest do
 
   describe "Context decoding" do
     test "ignore unknown version" do
-      payload = %{"v" => [666]} |> Jason.encode!() |> Base.encode64()
+      payload = %{"v" => [666]} |> NewRelic.JSON.encode!() |> Base.encode64()
 
       assert DistributedTrace.NewRelicContext.decode(payload) == :bad_dt_payload
     end

--- a/test/evil_collector_test.exs
+++ b/test/evil_collector_test.exs
@@ -115,7 +115,7 @@ defmodule EvilCollectorTest do
       }
     }
 
-    EvilCollector.start(code: 415, body: Jason.encode!(exception))
+    EvilCollector.start(code: 415, body: NewRelic.JSON.encode!(exception))
     previous_logger = GenServer.call(NewRelic.Logger, {:logger, :memory})
 
     Collector.Protocol.preconnect()

--- a/test/infinite_tracing_test.exs
+++ b/test/infinite_tracing_test.exs
@@ -258,8 +258,8 @@ defmodule InfiniteTracingTest do
     assert tx_span.attributes[:auto] == "attribute"
 
     # Ensure these will encode properly
-    Jason.encode!(tx_event)
-    Jason.encode!(spans)
+    NewRelic.JSON.encode!(tx_event)
+    NewRelic.JSON.encode!(spans)
 
     TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)

--- a/test/logs_in_context_test.exs
+++ b/test/logs_in_context_test.exs
@@ -21,7 +21,7 @@ defmodule LogsInContextTest do
 
     # Console logging is transformed into JSON structured log lines
     [_, json] = Regex.run(~r/.*({.*}).*/, log_line)
-    log = Jason.decode!(json)
+    log = NewRelic.JSON.decode!(json)
 
     assert log["timestamp"] |> is_integer
     assert log["message"] == "FOO"
@@ -49,7 +49,7 @@ defmodule LogsInContextTest do
 
     # Console logging is transformed into JSON structured log lines
     [_, json] = Regex.run(~r/.*({.*}).*/, log_line)
-    log = Jason.decode!(json)
+    log = NewRelic.JSON.decode!(json)
 
     assert log["message"] == "FOO BAR"
 

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -325,8 +325,8 @@ defmodule SpanEventTest do
     assert nested_function_event[:"tracer.reductions"] > 1
 
     # Ensure these will encode properly
-    Jason.encode!(tx_event)
-    Jason.encode!(span_events)
+    NewRelic.JSON.encode!(tx_event)
+    NewRelic.JSON.encode!(span_events)
 
     TestHelper.pause_harvest_cycle(Collector.SpanEvent.HarvestCycle)
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)

--- a/test/transaction_error_event_test.exs
+++ b/test/transaction_error_event_test.exs
@@ -159,18 +159,18 @@ defmodule TransactionErrorEventTest do
 
     traces = TestHelper.gather_harvest(Collector.ErrorTrace.Harvester)
     assert length(traces) == 1
-    assert Jason.encode!(traces)
+    assert NewRelic.JSON.encode!(traces)
 
     events = TestHelper.gather_harvest(Collector.TransactionErrorEvent.Harvester)
     assert length(events) == 1
-    assert Jason.encode!(events)
+    assert NewRelic.JSON.encode!(events)
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
     assert TestHelper.find_metric(metrics, "Errors/all")
 
     traces = TestHelper.gather_harvest(Collector.TransactionEvent.Harvester)
     assert length(traces) == 1
-    assert Jason.encode!(traces)
+    assert NewRelic.JSON.encode!(traces)
 
     Logger.add_backend(:console)
     TestHelper.pause_harvest_cycle(Collector.TransactionEvent.HarvestCycle)

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -257,7 +257,7 @@ defmodule TransactionTest do
     refute Map.has_key?(event, :nilValue)
 
     # Make sure it can serialize to JSON
-    Jason.encode!(events)
+    NewRelic.JSON.encode!(events)
   end
 
   test "Incrementing attribute counters" do

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -219,7 +219,7 @@ defmodule TransactionTraceTest do
 
     traces = TestHelper.gather_harvest(Collector.TransactionTrace.Harvester)
     assert length(traces) == 2
-    Jason.encode!(traces)
+    NewRelic.JSON.encode!(traces)
   end
 
   test "Transaction Trace when erlang trace disabled" do
@@ -233,7 +233,7 @@ defmodule TransactionTraceTest do
 
     # tbh, the TT struct we have to send is too complicated to assert on structurally
     # so i'm just gonna make sure the expected string fragments are in there :)
-    trace_str = Jason.encode!(traces)
+    trace_str = NewRelic.JSON.encode!(traces)
 
     assert trace_str =~ "TransactionTraceTest.ExternalService.query"
     assert trace_str =~ "TransactionTraceTest.ExternalService.secret_query"

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -20,7 +20,7 @@ defmodule UtilTest do
     assert NewRelic.Util.Event.process_event(%{key: self()})
 
     # Don't inspect the nodename, we don't want the atom char in the attribute
-    json = NewRelic.Util.Event.process_event(%{key: Node.self()}) |> Jason.encode!()
+    json = NewRelic.Util.Event.process_event(%{key: Node.self()}) |> NewRelic.JSON.encode!()
     refute json =~ ":node"
   end
 


### PR DESCRIPTION
Jason has been sunset for later versions of Elixir, and the new JSON library is available as of 1.18.

This could allow less dependencies for apps.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
