### PR TITLE
Fix bug with missing bandit conn

### DIFF
--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -170,7 +170,9 @@ defmodule NewRelic.Telemetry.Plug do
   defp add_start_attrs(_meta, meas, _headers, :bandit) do
     [
       pid: inspect(self()),
-      start_time: meas[:system_time]
+      start_time: meas[:system_time],
+      host: "unknown",
+      path: "unknown"
     ]
     |> NewRelic.add_attributes()
   end
@@ -199,6 +201,7 @@ defmodule NewRelic.Telemetry.Plug do
 
     [
       duration: meas[:duration] || 0,
+      error: meta[:error],
       status: status_code(meta) || 500,
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],


### PR DESCRIPTION
This PR fixes a bug that happens sometimes when a bandit request fails early at the socket level. When this happens, bandit can execute telemetry events without the expected `conn` struct. This was partially addressed in https://github.com/newrelic/elixir_agent/pull/483 but there are a few attributes required for a Web Transaction that we need to make sure are always provided.

I was able to reproduce this locally but not consistent enough to write a test for it

```
(Bandit.HTTPError) Header read socket error: :closed
```