### PR TITLE
Fix incomplete bandit response time metrics

### DIFF
--- a/examples/apps/phx_example/lib/phx_example_web/controllers/page_controller.ex
+++ b/examples/apps/phx_example/lib/phx_example_web/controllers/page_controller.ex
@@ -2,6 +2,7 @@ defmodule PhxExampleWeb.PageController do
   use PhxExampleWeb, :controller
 
   def index(conn, _params) do
+    Process.sleep(300)
     render(conn, :index)
   end
 

--- a/examples/apps/phx_example/test/phx_example_test.exs
+++ b/examples/apps/phx_example/test/phx_example_test.exs
@@ -34,6 +34,17 @@ defmodule PhxExampleTest do
         assert event[:"phoenix.controller"] == "PhxExampleWeb.PageController"
         assert event[:"phoenix.action"] == "index"
         assert event[:status] == 200
+
+        [
+          %{name: "WebTransactionTotalTime", scope: ""},
+          [1, value, _, _, _, _]
+        ] =
+          TestHelper.find_metric(
+            metrics,
+            "WebTransactionTotalTime"
+          )
+
+        assert_in_delta value, 0.3, 0.1
       end
 
       test "Phoenix metrics generated for LiveView" do

--- a/lib/new_relic/metric/metric_data.ex
+++ b/lib/new_relic/metric/metric_data.ex
@@ -60,11 +60,13 @@ defmodule NewRelic.Metric.MetricData do
           min_call_time: total_time_s,
           max_call_time: total_time_s
         },
-        # Transaction breakdown doesn't handle Elixir's level of concurrency,
-        # sending just call count improves things
         %Metric{
           name: join(["WebTransactionTotalTime", name]),
-          call_count: 1
+          call_count: 1,
+          total_call_time: total_time_s,
+          total_exclusive_time: total_time_s,
+          min_call_time: total_time_s,
+          max_call_time: total_time_s
         }
       ]
 
@@ -98,11 +100,13 @@ defmodule NewRelic.Metric.MetricData do
           min_call_time: total_time_s,
           max_call_time: total_time_s
         },
-        # Transaction breakdown doesn't handle Elixir's level of concurrency,
-        # sending just call count improves things
         %Metric{
           name: join(["OtherTransactionTotalTime", name]),
-          call_count: 1
+          call_count: 1,
+          total_call_time: total_time_s,
+          total_exclusive_time: total_time_s,
+          min_call_time: total_time_s,
+          max_call_time: total_time_s
         }
       ]
 

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -140,6 +140,7 @@ defmodule NewRelic.Telemetry.Plug do
   defp add_start_attrs(meta, meas, headers, :cowboy) do
     [
       pid: inspect(self()),
+      "http.server": "cowboy",
       start_time: meas[:system_time],
       host: meta.req.host,
       path: meta.req.path,
@@ -155,6 +156,7 @@ defmodule NewRelic.Telemetry.Plug do
   defp add_start_attrs(%{conn: conn}, meas, headers, :bandit) do
     [
       pid: inspect(self()),
+      "http.server": "bandit",
       start_time: meas[:system_time],
       host: conn.host,
       path: conn.request_path,

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -170,12 +170,12 @@ defmodule NewRelic.Transaction.Complete do
     {[segment_tree], tx_attrs, tx_error, span_events, apdex, tx_metrics}
   end
 
-  defp total_time_s(%{transactionType: :Web}, concurrent_process_time_ms) do
-    # Cowboy request process is already included in concurrent time
+  defp total_time_s(%{transactionType: :Web, "http.server": "cowboy"}, concurrent_process_time_ms) do
+    # Cowboy request process duration is already included in concurrent time
     concurrent_process_time_ms / 1000
   end
 
-  defp total_time_s(%{transactionType: :Other} = tx_attrs, concurrent_process_time_ms) do
+  defp total_time_s(tx_attrs, concurrent_process_time_ms) do
     (tx_attrs.duration_ms + concurrent_process_time_ms) / 1000
   end
 


### PR DESCRIPTION
This PR fixes a display bug reported in https://github.com/newrelic/elixir_agent/issues/489

The bug exists because there were assumptions in the Transaction processing logic that relied on behavior in cowboy that isn't present in bandit, specifically that cowboy would spawn a process to handle the request _after_ the start telemetry was executed, so that process spawn had to be considered when processing total time.

The fix is to only apply that extra processing when the transaction is marked as coming from cowboy.

Also included is a modification to the Transaction breakdown metrics that will give those charts the total time to take into account.

Closes #489