### PR TITLE
Use Map functionality for into and reduce

### DIFF
--- a/lib/new_relic/aggregate/aggregate.ex
+++ b/lib/new_relic/aggregate/aggregate.ex
@@ -20,9 +20,7 @@ defmodule NewRelic.Aggregate do
   defp averages(%{call_count: call_count} = values) do
     values
     |> Stream.reject(fn {key, _value} -> key == :call_count end)
-    |> Enum.reduce(%{}, fn {key, value}, acc ->
-      Map.put(acc, :"avg_#{key}", value / call_count)
-    end)
+    |> Map.new(fn {key, value} -> {:"avg_#{key}", value / call_count} end)
   end
 
   defp averages(_values), do: %{}

--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -207,9 +207,7 @@ defmodule NewRelic.DistributedTrace do
   end
 
   def set_span(:generic, attrs) do
-    attrs
-    |> Map.new()
-    |> add_span_attributes()
+    add_span_attributes(Map.new(attrs))
   end
 
   def set_span(:http, url: url, method: method, component: component) do

--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -207,7 +207,9 @@ defmodule NewRelic.DistributedTrace do
   end
 
   def set_span(:generic, attrs) do
-    add_span_attributes(Enum.into(attrs, %{}))
+    attrs
+    |> Map.new()
+    |> add_span_attributes()
   end
 
   def set_span(:http, url: url, method: method, component: component) do
@@ -237,10 +239,7 @@ defmodule NewRelic.DistributedTrace do
   def add_span_attributes(attrs) do
     Process.put(
       :nr_current_span_attrs,
-      Map.merge(
-        get_span_attrs(),
-        Enum.into(attrs, %{})
-      )
+      Map.merge(get_span_attrs(), Map.new(attrs))
     )
 
     :ok

--- a/lib/new_relic/error/trace.ex
+++ b/lib/new_relic/error/trace.ex
@@ -49,7 +49,7 @@ defmodule NewRelic.Error.Trace do
   defp format_user_attributes(user_attributes) do
     user_attributes
     |> Map.drop(@intrinsics)
-    |> Enum.into(%{}, fn {k, v} ->
+    |> Map.new(fn {k, v} ->
       (String.Chars.impl_for(v) && {k, v}) || {k, inspect(v)}
     end)
   end

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -161,8 +161,7 @@ defmodule NewRelic.Init do
   end
 
   def determine_automatic_attributes() do
-    :new_relic_agent
-    |> Application.get_env(:automatic_attributes, [])
+    Application.get_env(:new_relic_agent, :automatic_attributes, [])
     |> Map.new(fn
       {name, {:system, env_var}} -> {name, System.get_env(env_var)}
       {name, {m, f, a}} -> {name, apply(m, f, a)}

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -161,8 +161,9 @@ defmodule NewRelic.Init do
   end
 
   def determine_automatic_attributes() do
-    Application.get_env(:new_relic_agent, :automatic_attributes, [])
-    |> Enum.into(%{}, fn
+    :new_relic_agent
+    |> Application.get_env(:automatic_attributes, [])
+    |> Map.new(fn
       {name, {:system, env_var}} -> {name, System.get_env(env_var)}
       {name, {m, f, a}} -> {name, apply(m, f, a)}
       {name, value} -> {name, value}

--- a/lib/new_relic/sampler/process.ex
+++ b/lib/new_relic/sampler/process.ex
@@ -47,10 +47,10 @@ defmodule NewRelic.Sampler.Process do
   end
 
   defp record_samples(state) do
-    Enum.reduce(state.pids, %{}, fn {pid, true}, acc ->
+    Map.new(state.pids, fn {pid, true} ->
       {current_sample, stats} = collect(pid, state.previous[pid])
       NewRelic.report_sample(:ProcessSample, stats)
-      Map.put(acc, pid, current_sample)
+      {pid, current_sample}
     end)
   end
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -113,7 +113,7 @@ defmodule NewRelic.Transaction.Complete do
       |> Enum.map(&transform_trace_name_attrs/1)
       |> Enum.map(&struct(Transaction.Trace.Segment, &1))
       |> Enum.group_by(& &1.pid)
-      |> Enum.into(%{}, &generate_segment_tree(&1))
+      |> Map.new(&generate_segment_tree(&1))
 
     root_process_segment =
       tx_attrs

--- a/lib/new_relic/util.ex
+++ b/lib/new_relic/util.ex
@@ -119,7 +119,7 @@ defmodule NewRelic.Util do
   def metadata() do
     System.get_env()
     |> Enum.filter(fn {key, _} -> String.starts_with?(key, @nr_metadata_prefix) end)
-    |> Enum.into(%{})
+    |> Map.new()
   end
 
   def utilization() do

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -84,7 +84,8 @@ defmodule TransactionTraceTest do
     end
 
     get "/huge_args" do
-      Enum.into(1..10000, %{}, &{&1, &1})
+      1..10000
+      |> Map.new(&{&1, &1})
       |> HelperModule.do_work()
 
       HelperModule.work_hard(%{on: :something})

--- a/test/transaction_trace_test.exs
+++ b/test/transaction_trace_test.exs
@@ -84,8 +84,7 @@ defmodule TransactionTraceTest do
     end
 
     get "/huge_args" do
-      1..10000
-      |> Map.new(&{&1, &1})
+      Map.new(1..10000, &{&1, &1})
       |> HelperModule.do_work()
 
       HelperModule.work_hard(%{on: :something})

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -32,7 +32,7 @@ defmodule UtilTest do
         nested: %{foo: %{bar: %{baz: "qux"}}},
         nested_list: [%{one: %{two: "three"}}, %{four: "five"}, %{}, "string", ["nested string"]],
         super_long_list: Enum.map(0..99, & &1),
-        big_map: String.graphemes("abcdefghijklmnopqrstuvwxyz") |> Enum.into(%{}, &{&1, &1})
+        big_map: String.graphemes("abcdefghijklmnopqrstuvwxyz") |> Map.new(&{&1, &1})
       )
 
     assert {"nested.foo.bar.baz", "qux"} in flattened


### PR DESCRIPTION
There are two cases where Enum functionality is used over Map functionality.

1. Enum.reduce, when the acc is only used for Map.put(acc, ...) -- in this case, Map.new is equivalent, and skips `:lists.foldl` in favor of `Enum.map |> :maps.from_list`, which is faster based on benchmarks by almost 1.5x.

2. Enum.into(enum, %{}) -- in this case, Map.new is equivalent, but is more readable.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->

```
Mix.install([{:benchee, "~> 1.0"}])

enum = Enum.to_list(1..10000)

Benchee.run(
  %{
    "map_new" => fn -> Map.new(enum, &{&1, &1}) end,
    "enum_into" => fn -> Enum.into(enum, %{}, &{&1, &1}) end,
    "enum_reduce" => fn -> Enum.reduce(enum, %{}, &Map.put(&2, &1, &1)) end
  },
  time: 10,
  memory_time: 2
)

```

```
Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 42 s

Benchmarking enum_into ...
Benchmarking enum_reduce ...
Benchmarking map_new ...
Calculating statistics...
Formatting results...

Name                  ips        average  deviation         median         99th %
map_new            538.35        1.86 ms    ±14.97%        1.75 ms        3.09 ms
enum_into          522.59        1.91 ms    ±30.75%        1.77 ms        3.24 ms
enum_reduce        365.72        2.73 ms    ±36.09%        2.51 ms        4.64 ms

Comparison: 
map_new            538.35
enum_into          522.59 - 1.03x slower +0.0560 ms
enum_reduce        365.72 - 1.47x slower +0.88 ms

Memory usage statistics:

Name           Memory usage
map_new           430.39 KB
enum_into         430.39 KB - 1.00x memory usage +0 KB
enum_reduce      1709.70 KB - 3.97x memory usage +1279.30 KB

**All measurements for memory usage were the same**
```
