### PR TITLE
Support connecting an Other Transaction to a Distributed Trace

### DIFF
--- a/lib/new_relic/other_transaction.ex
+++ b/lib/new_relic/other_transaction.ex
@@ -1,9 +1,9 @@
 defmodule NewRelic.OtherTransaction do
   @moduledoc false
 
-  def start_transaction(category, name) do
+  def start_transaction(category, name, headers \\ %{}) do
     NewRelic.Transaction.Reporter.start_transaction(:other)
-    NewRelic.DistributedTrace.start(:other)
+    NewRelic.DistributedTrace.start(:other, headers)
 
     NewRelic.add_attributes(
       pid: inspect(self()),

--- a/test/distributed_trace_test.exs
+++ b/test/distributed_trace_test.exs
@@ -206,6 +206,21 @@ defmodule DistributedTraceTest do
     |> Task.await()
   end
 
+  test "Start an Other transaction with inbound DT headers" do
+    headers = %{@dt_header => generate_inbound_payload(:browser)}
+
+    Task.async(fn ->
+      NewRelic.start_transaction("Category", "Name", headers)
+
+      headers = NewRelic.distributed_trace_headers(:other)
+
+      context = DistributedTrace.NewRelicContext.decode(Map.get(headers, @dt_header))
+
+      assert context.trace_id == "d6b4ba0c3a712ca"
+    end)
+    |> Task.await()
+  end
+
   describe "Context decoding" do
     test "ignore unknown version" do
       payload = %{"v" => [666]} |> NewRelic.JSON.encode!() |> Base.encode64()


### PR DESCRIPTION
This PR provides support for connecting an Other Transaction to an existing distributed trace. You can provide W3C `traceparent` and `tracestate` headers or another New Relic agent's `newrelic` header.

Closes #265 