### PR TITLE
Fix Oban queue_time unit

### DIFF
--- a/examples/apps/oban_example/test/oban_example_test.exs
+++ b/examples/apps/oban_example/test/oban_example_test.exs
@@ -40,6 +40,7 @@ defmodule ObanExampleTest do
 
     assert timestamp |> is_number
     assert duration >= 0.015
+    assert duration <= 0.065
   end
 
   test "instruments a failed job" do

--- a/lib/new_relic/telemetry/oban.ex
+++ b/lib/new_relic/telemetry/oban.ex
@@ -125,7 +125,7 @@ defmodule NewRelic.Telemetry.Oban do
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],
       "oban.job.result": meta.state,
-      "oban.job.queue_time": meas.queue_time
+      "oban.job.queue_time": System.convert_time_unit(meas.queue_time, :native, :millisecond)
     ]
     |> NewRelic.add_attributes()
   end


### PR DESCRIPTION
Oban `queue_time` is reported in `native` units, so we need to convert it to a known unit.