### PR TITLE
Improve deep flatten

### DIFF
--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -251,7 +251,7 @@ defmodule TransactionTest do
     # Bad values
     assert event[:tuple] == "[BAD_VALUE]"
     assert event[:function] == "[BAD_VALUE]"
-    assert event[:struct] == "[BAD_VALUE]"
+    assert event["struct.__struct__"] == "NewRelic.Metric"
 
     # Don't report nil values
     refute Map.has_key?(event, :nilValue)


### PR DESCRIPTION
Improves the way we flatten data structures passed in as attributes.

* Only add the `*.size` attribute when we have dropped some items from Map or List attributes
* Make passing a `Struct` work nicely