### PR TITLE
Handle report messages in logs_in_context

### DIFF
--- a/test/support/test_helper.ex
+++ b/test/support/test_helper.ex
@@ -97,6 +97,15 @@ defmodule TestHelper do
     end)
   end
 
+  def run_with(:logs_in_context, mode) do
+    :logger.remove_primary_filter(:nr_logs_in_context)
+    NewRelic.LogsInContext.configure(mode)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      :logger.remove_primary_filter(:nr_logs_in_context)
+    end)
+  end
+
   # :nr_config
   #  - user facing agent configuration, ex: NewRelic.Config.app_name
   #  - determined and set in NewRelic.Init


### PR DESCRIPTION
This PR extends the Logs in Context feature to handle log messages that are "reports", ie: they don't have a string message, just a keyword list / map. For example:

```elixir
Logger.error(user: 123, error: "something went wrong")
```