### PR TITLE
Fix elixir_logger/2

### DIFF
--- a/lib/new_relic/logger.ex
+++ b/lib/new_relic/logger.ex
@@ -82,7 +82,7 @@ defmodule NewRelic.Logger do
 
   defp elixir_logger(:debug, message), do: Logger.debug(message)
   defp elixir_logger(:info, message), do: Logger.info(message)
-  defp elixir_logger(:warn, message), do: Logger.warning(message)
+  defp elixir_logger(:warning, message), do: Logger.warning(message)
   defp elixir_logger(:error, message), do: Logger.error(message)
 
   @sep " - "

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -36,6 +36,8 @@ defmodule LoggerTest do
     previous_logger = GenServer.call(NewRelic.Logger, {:logger, :logger})
     NewRelic.log(:info, "HELLO")
     NewRelic.log(:error, "DANG")
+    NewRelic.log(:warning, "OOPS")
+    NewRelic.log(:debug, "SHHH")
     GenServer.call(NewRelic.Logger, {:replace, previous_logger})
   end
 end


### PR DESCRIPTION
There isn't a pattern matching for the `:warning` atom. It's called by `log/2` which has a guard clause to make sure the level is one of `[:debug, :info, :warning, :error]`, so `:warn` is not a valid option. I also checked who calls `NewRelic.log/2` which delegates to this function, and there isn't occurrences of `:warn`, only `:warning`.