### PR TITLE
Fix Finch attributes

### DIFF
--- a/lib/new_relic/telemetry/finch.ex
+++ b/lib/new_relic/telemetry/finch.ex
@@ -130,9 +130,9 @@ defmodule NewRelic.Telemetry.Finch do
           category: "http",
           attributes:
             %{
-              "request.url": url,
-              "request.method": request.method,
-              "request.client": "Finch",
+              url: url,
+              method: request.method,
+              component: "Finch",
               "finch.pool": finch_pool
             }
             |> Map.merge(result_attrs)
@@ -193,12 +193,12 @@ defmodule NewRelic.Telemetry.Finch do
           edge: [span: id, parent: parent_id],
           category: "http",
           attributes: %{
+            url: url,
+            method: request.method,
+            component: "Finch",
+            "finch.pool": finch_pool,
             error: true,
-            "error.message": error_message,
-            "request.url": url,
-            "request.method": request.method,
-            "request.client": "Finch",
-            "finch.pool": finch_pool
+            "error.message": error_message
           }
         )
 

--- a/test/telemetry/finch_test.exs
+++ b/test/telemetry/finch_test.exs
@@ -36,7 +36,9 @@ defmodule NewRelic.Telemetry.FinchTest do
 
     external_span = TestHelper.find_span(span_events, "External/httpstat.us/Finch/GET")
 
-    assert external_span[:"request.url"] == "https://httpstat.us/200"
+    assert external_span[:"http.url"] == "https://httpstat.us/200"
+    assert external_span[:"http.method"] == "GET"
+    assert external_span[:component] == "Finch"
     assert external_span[:"response.status"] == 200
   end
 
@@ -51,7 +53,7 @@ defmodule NewRelic.Telemetry.FinchTest do
 
     external_span = TestHelper.find_span(span_events, "External/httpstat.us/Finch/GET")
 
-    assert external_span[:"request.url"] == "https://httpstat.us/500"
+    assert external_span[:"http.url"] == "https://httpstat.us/500"
     assert external_span[:"response.status"] == 500
   end
 
@@ -66,7 +68,7 @@ defmodule NewRelic.Telemetry.FinchTest do
 
     external_span = TestHelper.find_span(span_events, "External/nxdomain/Finch/GET")
 
-    assert external_span[:"request.url"] == "https://nxdomain/"
+    assert external_span[:"http.url"] == "https://nxdomain/"
     assert external_span[:error] == true
     assert external_span[:"error.message"] |> is_binary()
   end
@@ -86,7 +88,7 @@ defmodule NewRelic.Telemetry.FinchTest do
 
     external_span = TestHelper.find_span(span_events, "External/httpstat.us/Finch/GET")
 
-    assert external_span[:"request.url"] == "https://httpstat.us/200"
+    assert external_span[:"http.url"] == "https://httpstat.us/200"
     assert external_span[:error] == true
     assert external_span[:"error.message"] =~ "Oops"
   end


### PR DESCRIPTION
This PR fixes Finch instrumentation `http` attributes so they are the correct ones to light up parts of the Distributed Tracing UI