### PR TITLE
Increase resolution of span duration

### DIFF
--- a/lib/new_relic/tracer/direct.ex
+++ b/lib/new_relic/tracer/direct.ex
@@ -43,10 +43,10 @@ defmodule NewRelic.Tracer.Direct do
           case Keyword.get(options, :duration) do
             nil ->
               duration = System.monotonic_time() - monotonic_start_time
-              {duration, System.convert_time_unit(duration, :native, :millisecond) / 1_000}
+              {duration, System.convert_time_unit(duration, :native, :microsecond) / 1_000_000}
 
             duration ->
-              {duration, System.convert_time_unit(duration, :native, :millisecond) / 1_000}
+              {duration, System.convert_time_unit(duration, :native, :microsecond) / 1_000_000}
           end
 
         name = Keyword.get(options, :name, name)

--- a/lib/new_relic/tracer/macro.ex
+++ b/lib/new_relic/tracer/macro.ex
@@ -224,7 +224,7 @@ defmodule NewRelic.Tracer.Macro do
             nil -> :root
           end
 
-        duration_ms = System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1000
+        duration_ms = System.convert_time_unit(end_time_mono - start_time_mono, :native, :microsecond) / 1_000
 
         duration_acc = Process.get({:nr_duration_acc, parent_ref}, 0)
         Process.put({:nr_duration_acc, parent_ref}, duration_acc + duration_ms)


### PR DESCRIPTION
This PR increases the resolution of `NewRelic.span` `duration`. Converting directly to `millisecond` can cause very short times to round down to `0`, so we convert to `microsecond` and divide by an extra `1000`