### PR TITLE
Enable adding span attrs inside span macro

### DIFF
--- a/lib/new_relic/tracer/direct.ex
+++ b/lib/new_relic/tracer/direct.ex
@@ -50,9 +50,13 @@ defmodule NewRelic.Tracer.Direct do
           end
 
         name = Keyword.get(options, :name, name)
-        stop_attributes = Keyword.get(options, :attributes, []) |> Map.new()
-        attributes = Map.merge(start_attributes, stop_attributes)
         timestamp_ms = System.convert_time_unit(system_time, :native, :millisecond)
+        stop_attributes = Keyword.get(options, :attributes, []) |> Map.new()
+
+        attributes =
+          start_attributes
+          |> Map.merge(NewRelic.DistributedTrace.get_span_attrs())
+          |> Map.merge(stop_attributes)
 
         {primary_name, secondary_name} =
           case name do

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -117,6 +117,7 @@ defmodule SpanEventTest do
       end
 
       NewRelic.span "another.span", with: "an attribute" do
+        NewRelic.add_span_attributes(inside: "attribute!")
         Process.sleep(5)
       end
 
@@ -205,6 +206,7 @@ defmodule SpanEventTest do
 
     assert another_span[:category] == "generic"
     assert another_span[:with] == "an attribute"
+    assert another_span[:inside] == "attribute!"
 
     [single_span, _, _] =
       Enum.find(span_events, fn [ev, _, _] ->


### PR DESCRIPTION
This PR enables using `add_span_attributes` inside a span created with `NewRelic.span` macro