### PR TITLE
Increase resolution of finch request duration

### DIFF
--- a/lib/new_relic/telemetry/finch.ex
+++ b/lib/new_relic/telemetry/finch.ex
@@ -95,7 +95,7 @@ defmodule NewRelic.Telemetry.Finch do
         metric_name = "External/#{request.host}/Finch/#{request.method}"
         secondary_name = "#{request.host} - Finch/#{request.method}"
 
-        duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+        duration_ms = System.convert_time_unit(duration, :native, :microsecond) / 1000
         duration_s = duration_ms / 1000
 
         id = span
@@ -176,7 +176,7 @@ defmodule NewRelic.Telemetry.Finch do
            } <- Process.delete(config.handler_id) do
         metric_name = "External/#{request.host}/Finch/#{request.method}"
 
-        duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+        duration_ms = System.convert_time_unit(duration, :native, :microsecond) / 1000
         duration_s = duration_ms / 1000
 
         id = span

--- a/lib/new_relic/telemetry/oban.ex
+++ b/lib/new_relic/telemetry/oban.ex
@@ -125,7 +125,7 @@ defmodule NewRelic.Telemetry.Oban do
       memory_kb: info[:memory] / @kb,
       reductions: info[:reductions],
       "oban.job.result": meta.state,
-      "oban.job.queue_time": System.convert_time_unit(meas.queue_time, :native, :millisecond)
+      "oban.job.queue_time": System.convert_time_unit(meas.queue_time, :native, :microsecond) / 1000
     ]
     |> NewRelic.add_attributes()
   end


### PR DESCRIPTION
This PR increases the resolution of timestamps that we collect for Finch request durations (so they aren't rounded to whole number milliseconds). Also do the same for Oban queue time.