### PR TITLE
Fix bandit duration with exception

### DIFF
--- a/examples/apps/phx_example/test/phx_example_test.exs
+++ b/examples/apps/phx_example/test/phx_example_test.exs
@@ -154,6 +154,7 @@ defmodule PhxExampleTest do
         assert event[:"phoenix.router"] == "PhxExampleWeb.Router"
         assert event[:"phoenix.controller"] == "PhxExampleWeb.PageController"
         assert event[:"phoenix.action"] == "error"
+        assert event[:duration] > 0.099
       end
 
       @tag :capture_log

--- a/lib/new_relic/telemetry/plug.ex
+++ b/lib/new_relic/telemetry/plug.ex
@@ -205,7 +205,7 @@ defmodule NewRelic.Telemetry.Plug do
     resp_duration_ms = meas[:resp_start_time] && to_ms(meas[:resp_end_time]) - to_ms(meas[:resp_start_time])
 
     [
-      duration: meas[:duration] || 0,
+      duration: meas[:duration],
       error: meta[:error],
       status: status_code(meta) || 500,
       memory_kb: info[:memory] / @kb,


### PR DESCRIPTION
Bandit exception telemetry events don't have a `duration`. This fixes our handling of this, instead of inserting `0` as a fallback, we can allow this attribute to be `nil`, and the built in time tracking done by the `Sidecar` will get us an accurate value for duration