### PR TITLE
Move `:os_mon` from included app to extra app

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,7 @@ defmodule NewRelic.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger, :inets, :ssl],
-      included_applications: [:os_mon],
+      extra_applications: [:logger, :inets, :ssl, :os_mon],
       mod: {NewRelic.Application, []}
     ]
   end


### PR DESCRIPTION
## Resolves #528 

Reverts part of a previous commit https://github.com/newrelic/elixir_agent/commit/2156a34da3838e1f8e0b33103211af1144c44746 which causes Elixir/Phoenix apps to fail `mix release` with error
`** (Mix) :os_mon is listed both as a regular application and as an included application`