### PR TITLE
Set CI permissions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/elixir_agent/security/code-scanning/1](https://github.com/newrelic/elixir_agent/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required. Since the workflow primarily involves reading repository contents (e.g., checking out code, restoring caches), we will set `contents: read` as the permission. This ensures that the workflow has only the access it needs and no more.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow. This avoids redundancy and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
