### PR TITLE
Handle errors in `Harvest.HarvestCycle.send_harvest/2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 tmp
 config/secret.exs
 .DS_Store
+.tool-versions

--- a/lib/new_relic/harvest/harvest_cycle.ex
+++ b/lib/new_relic/harvest/harvest_cycle.ex
@@ -131,11 +131,20 @@ defmodule NewRelic.Harvest.HarvestCycle do
           :exit, _exit ->
             NewRelic.log(:error, "Failed to send harvest from #{inspect(supervisor)}")
         after
-          DynamicSupervisor.terminate_child(supervisor, harvester)
+          terminate_child(supervisor, harvester)
         end
       end,
       shutdown: @harvest_timeout
     )
+  end
+
+  defp terminate_child(supervisor, harvester) do
+    try do
+      DynamicSupervisor.terminate_child(supervisor, harvester)
+    catch
+      :exit, _exit ->
+        :ok
+    end
   end
 
   defp stop_harvest_cycle(timer), do: timer && Process.cancel_timer(timer)


### PR DESCRIPTION
This is an attempt to silent the error from `Harvest.HarvestCycle.send_harvest/2` when the given `supervisor` is not started.

I wasn't able to reproduce this issue consistently.

Fixes #511 

## Example

```
exited in: GenServer.call(NewRelic.Harvest.Collector.CustomEvent.HarvesterSupervisor, {:terminate_child, #PID<0.1987228.0>}, :infinity)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
```

## Stacktrace

```
  File "lib/gen_server.ex", line 1121, in GenServer.call/3
  File "lib/new_relic/harvest/harvest_cycle.ex", line 134, in anonymous fn/2 in NewRelic.Harvest.HarvestCycle.send_harvest/2
  File "lib/task/supervised.ex", line 101, in Task.Supervised.invoke_mfa/2
```