### PR TITLE
fix compile time regex for otp 28

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.18'
-            otp: '27'
-          - elixir: '1.17'
-            otp: '27'
-          - elixir: '1.16'
-            otp: '26'
-          - elixir: '1.15'
-            otp: '26'
+          - elixir: "1.19"
+            otp: "28"
+          - elixir: "1.18"
+            otp: "27"
+          - elixir: "1.17"
+            otp: "26"
+          - elixir: "1.16"
+            otp: "26"
 
     steps:
     - name: Checkout

--- a/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
+++ b/lib/new_relic/distributed_trace/w3c_trace_context/trace_state.ex
@@ -91,12 +91,13 @@ defmodule NewRelic.DistributedTrace.W3CTraceContext.TraceState do
       length(members) <= 32
   end
 
-  @key_wo_vendor ~r/^[0-9a-z][_0-9a-z\-\*\/]{0,255}$/
-  @key_with_vendor ~r/^[0-9a-z][_0-9a-z\-\*\/]{0,240}@[0-9a-z][_0-9a-z\-\*\/]{0,13}$/
-  @value ~r/^([\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e])$/
+  defp key_wo_vendor, do: ~r/^[0-9a-z][_0-9a-z\-\*\/]{0,255}$/
+  defp key_with_vendor, do: ~r/^[0-9a-z][_0-9a-z\-\*\/]{0,240}@[0-9a-z][_0-9a-z\-\*\/]{0,13}$/
+  defp valid_value, do: ~r/^([\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e])$/
+
   defp valid_member?([key, value]) do
-    valid_key? = Regex.match?(@key_wo_vendor, key) || Regex.match?(@key_with_vendor, key)
-    valid_value? = Regex.match?(@value, value)
+    valid_key? = Regex.match?(key_wo_vendor(), key) || Regex.match?(key_with_vendor(), key)
+    valid_value? = Regex.match?(valid_value(), value)
 
     valid_key? && valid_value?
   end

--- a/lib/new_relic/harvest/telemetry_sdk/config.ex
+++ b/lib/new_relic/harvest/telemetry_sdk/config.ex
@@ -10,12 +10,13 @@ defmodule NewRelic.Harvest.TelemetrySdk.Config do
     Application.get_env(:new_relic_agent, key, @default[key])
   end
 
-  @region_matcher ~r/^(?<region>\D+)/
-  @env_matcher ~r/^(?<env>.+)-collector/
+  defp region_matcher, do: ~r/^(?<region>\D+)/
+  defp env_matcher, do: ~r/^(?<env>.+)-collector/
+
   def determine_hosts(host, region) do
-    env = host && Regex.named_captures(@env_matcher, host)["env"]
+    env = host && Regex.named_captures(env_matcher(), host)["env"]
     env = env && env <> "-"
-    region = region && Regex.named_captures(@region_matcher, region)["region"] <> "."
+    region = region && Regex.named_captures(region_matcher(), region)["region"] <> "."
 
     %{
       log: "https://#{env}log-api.#{region}newrelic.com/log/v1",

--- a/lib/new_relic/init.ex
+++ b/lib/new_relic/init.ex
@@ -46,11 +46,12 @@ defmodule NewRelic.Init do
     })
   end
 
-  @region_matcher ~r/^(?<prefix>.+?)x/
+  defp region_matcher, do: ~r/^(?<prefix>.+?)x/
+
   def determine_region(nil), do: nil
 
   def determine_region(license_key) do
-    case Regex.named_captures(@region_matcher, license_key) do
+    case Regex.named_captures(region_matcher(), license_key) do
       %{"prefix" => prefix} -> String.trim_trailing(prefix, "x")
       _ -> nil
     end
@@ -191,11 +192,12 @@ defmodule NewRelic.Init do
 
   def parse_labels(nil), do: []
 
-  @label_splitter ~r/;|:/
   def parse_labels(label_string) do
     label_string
-    |> String.split(@label_splitter, trim: true)
+    |> String.split(label_splitter(), trim: true)
     |> Enum.map(&String.trim/1)
     |> Enum.chunk_every(2, 2, :discard)
   end
+
+  defp label_splitter, do: ~r/;|:/
 end

--- a/lib/new_relic/telemetry/ecto/metadata.ex
+++ b/lib/new_relic/telemetry/ecto/metadata.ex
@@ -43,17 +43,16 @@ defmodule NewRelic.Telemetry.Ecto.Metadata do
   #   Exqlite: table
   @esc ~w(" ` [ ])
 
-  @capture %{
-    select: ~r/FROM (?<table>\S+)/,
-    insert: ~r/INSERT INTO (?<table>\S+)/,
-    update: ~r/UPDATE (?<table>\S+)/,
-    delete: ~r/FROM (?<table>\S+)/,
-    create: ~r/CREATE TABLE( IF NOT EXISTS)? (?<table>\S+)/
-  }
   def parse_query(operation, query) do
-    case Regex.named_captures(@capture[operation], query) do
+    case Regex.named_captures(capture(operation), query) do
       %{"table" => table} -> {operation, String.replace(table, @esc, "")}
       _ -> {operation, :other}
     end
   end
+
+  defp capture(:select), do: ~r/FROM (?<table>\S+)/
+  defp capture(:insert), do: ~r/INSERT INTO (?<table>\S+)/
+  defp capture(:update), do: ~r/UPDATE (?<table>\S+)/
+  defp capture(:delete), do: ~r/FROM (?<table>\S+)/
+  defp capture(:create), do: ~r/CREATE TABLE( IF NOT EXISTS)? (?<table>\S+)/
 end

--- a/lib/new_relic/util/vendor.ex
+++ b/lib/new_relic/util/vendor.ex
@@ -40,14 +40,15 @@ defmodule NewRelic.Util.Vendor do
     end
   end
 
-  @cgroup_matcher ~r/\d+:.*cpu[,:].*(?<id>[0-9a-f]{64}).*/
+  defp cgroup_matcher, do: ~r/\d+:.*cpu[,:].*(?<id>[0-9a-f]{64}).*/
+
   defp docker_vendor_map(cgroup_filename) do
     File.read(cgroup_filename)
     |> case do
       {:ok, cgroup_file} ->
         cgroup_file
         |> String.split("\n", trim: true)
-        |> Enum.find_value(&Regex.named_captures(@cgroup_matcher, &1))
+        |> Enum.find_value(&Regex.named_captures(cgroup_matcher(), &1))
 
       _ ->
         nil


### PR DESCRIPTION
In OTP 28 you can no longer have compile time regex, ie in a module attr. Their recommendation is to move them to functions.

<!--
Thank you for submitting a Pull Request

A quick note: This software lives inside of other software. It is relied upon to monitor critical services.

Because of these unique conditions, our standards for code quality must be high!

* Tests are required!
* Performance really matters!
* Features that are specific to just your app are unlikely to make it in
* Instrumentation particular to a library or framework are probably a better fit for their own package which depends on this Agent.

-->
