### PR TITLE
Add internal DT prioritizing function

### DIFF
--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -85,8 +85,9 @@ defmodule NewRelic.DistributedTrace do
     end
   end
 
-  # Danger: This can skew sampling heavily if used on high throughput transactions.
-  # Will only impact outgoing distributed traces instrumented after this function has been called.
+  # Danger:
+  # This function can heavily skew sampling if used on high throughput
+  # transactions, and can also lead to over sampling / rejected data
   def prioritize_tracing do
     case get_tracing_context() do
       nil ->

--- a/lib/new_relic/distributed_trace/backoff_sampler.ex
+++ b/lib/new_relic/distributed_trace/backoff_sampler.ex
@@ -107,6 +107,11 @@ defmodule NewRelic.DistributedTrace.BackoffSampler do
     incr(@sampled_true_count)
   end
 
+  def track_manual_sampling() do
+    incr(@decided_count)
+    incr(@sampled_true_count)
+  end
+
   defp random(0), do: 0
   defp random(n), do: :rand.uniform(n)
 

--- a/test/backoff_sampler_test.exs
+++ b/test/backoff_sampler_test.exs
@@ -1,5 +1,5 @@
 defmodule BackoffSamplerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias NewRelic.DistributedTrace.BackoffSampler
 
   test "Backoff behavior as best as we can" do
@@ -33,7 +33,7 @@ defmodule BackoffSamplerTest do
 
     BackoffSampler.cycle()
 
-    # Next cycle it will adjust and take some, but not all
+    # Next cycle it will adjust and take some of the first 10 it sees, but not all
     decisions = [
       BackoffSampler.sample?(),
       BackoffSampler.sample?(),
@@ -49,7 +49,7 @@ defmodule BackoffSamplerTest do
     assert true in decisions
     assert false in decisions
 
-    # Next cycle it will adjust and take some, but not all
+    # Next cycle it will adjust and take some of the first 10 it sees, but not all
     decisions = [
       BackoffSampler.sample?(),
       BackoffSampler.sample?(),

--- a/test/priority_queue_test.exs
+++ b/test/priority_queue_test.exs
@@ -1,5 +1,5 @@
 defmodule PriorityQueueTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias NewRelic.Util.PriorityQueue
 

--- a/test/ssl_test.exs
+++ b/test/ssl_test.exs
@@ -1,5 +1,5 @@
 defmodule SSLTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   describe "Verify SSL setup" do
     test "reject bad domains" do

--- a/test/telemetry_sdk/config_test.exs
+++ b/test/telemetry_sdk/config_test.exs
@@ -1,5 +1,5 @@
 defmodule TelemetrySdk.ConfigTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias NewRelic.Harvest.TelemetrySdk
 
   test "determine correct Telemetry API hosts" do

--- a/test/tracer_macro_test.exs
+++ b/test/tracer_macro_test.exs
@@ -1,5 +1,5 @@
 defmodule NewRelic.Tracer.MacroTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   @doc """
   We re-inject the function args into the call to the Tracer reporter


### PR DESCRIPTION
This PR adds an internal function for prioritizing the current Distributed Trace.

I'm not exposing it as a Public API because it is dangerous:
1) It can cause traces to be heavily skewed if it were to be called during a high volume transaction.
2) It changes the sampling decision during a Trace, which means that the sampling decision forwarded to other services in the Trace may be different than before this is called.
3) It tracks these sampling decisions with the BackoffSampler, but it doesn't check that we're under the sampling target, which means this could cause over sampling (and thus risk higher data usage / rejected data)

All that said, it's nice to have when you have a high-value low-volume transaction you want to trace more often.