### PR TITLE
Handle shutdown cleaner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 tmp
 config/secret.exs
 .DS_Store
+.tool-versions

--- a/lib/new_relic/harvest/harvest_cycle.ex
+++ b/lib/new_relic/harvest/harvest_cycle.ex
@@ -131,11 +131,20 @@ defmodule NewRelic.Harvest.HarvestCycle do
           :exit, _exit ->
             NewRelic.log(:error, "Failed to send harvest from #{inspect(supervisor)}")
         after
-          DynamicSupervisor.terminate_child(supervisor, harvester)
+          terminate_child(supervisor, harvester)
         end
       end,
       shutdown: @harvest_timeout
     )
+  end
+
+  defp terminate_child(supervisor, harvester) do
+    try do
+      DynamicSupervisor.terminate_child(supervisor, harvester)
+    catch
+      :exit, _exit ->
+        :ok
+    end
   end
 
   defp stop_harvest_cycle(timer), do: timer && Process.cancel_timer(timer)

--- a/lib/new_relic/harvest/harvest_cycle.ex
+++ b/lib/new_relic/harvest/harvest_cycle.ex
@@ -130,21 +130,16 @@ defmodule NewRelic.Harvest.HarvestCycle do
         catch
           :exit, _exit ->
             NewRelic.log(:error, "Failed to send harvest from #{inspect(supervisor)}")
-        after
-          terminate_child(supervisor, harvester)
+        end
+
+        try do
+          DynamicSupervisor.terminate_child(supervisor, harvester)
+        catch
+          :exit, _exit -> :ok
         end
       end,
       shutdown: @harvest_timeout
     )
-  end
-
-  defp terminate_child(supervisor, harvester) do
-    try do
-      DynamicSupervisor.terminate_child(supervisor, harvester)
-    catch
-      :exit, _exit ->
-        :ok
-    end
   end
 
   defp stop_harvest_cycle(timer), do: timer && Process.cancel_timer(timer)

--- a/test/telemetry/finch_test.exs
+++ b/test/telemetry/finch_test.exs
@@ -11,27 +11,27 @@ defmodule NewRelic.Telemetry.FinchTest do
   end
 
   test "finch external metrics" do
-    request("https://httpstat.us/200")
+    request("https://httpbin.org/200")
 
     metrics = TestHelper.gather_harvest(Collector.Metric.Harvester)
 
-    assert TestHelper.find_metric(metrics, "External/httpstat.us/Finch/GET", 1)
-    assert TestHelper.find_metric(metrics, "External/httpstat.us/all", 1)
+    assert TestHelper.find_metric(metrics, "External/httpbin.org/Finch/GET", 1)
+    assert TestHelper.find_metric(metrics, "External/httpbin.org/all", 1)
     assert TestHelper.find_metric(metrics, "External/all", 1)
   end
 
   test "[:finch, :request, :stop] - 200" do
     Task.async(fn ->
       NewRelic.start_transaction("FinchTest", "200")
-      request("https://httpstat.us/200")
+      request("https://httpbin.org/status/200")
     end)
     |> Task.await()
 
     span_events = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
 
-    external_span = TestHelper.find_event(span_events, "External/httpstat.us/Finch/GET")
+    external_span = TestHelper.find_event(span_events, "External/httpbin.org/Finch/GET")
 
-    assert external_span[:"http.url"] == "https://httpstat.us/200"
+    assert external_span[:"http.url"] == "https://httpbin.org/status/200"
     assert external_span[:"http.method"] == "GET"
     assert external_span[:component] == "Finch"
     assert external_span[:"response.status"] == 200
@@ -40,15 +40,15 @@ defmodule NewRelic.Telemetry.FinchTest do
   test "[:finch, :request, :stop] - 500" do
     Task.async(fn ->
       NewRelic.start_transaction("FinchTest", "500")
-      request("https://httpstat.us/500")
+      request("https://httpbin.org/status/500")
     end)
     |> Task.await()
 
     span_events = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
 
-    external_span = TestHelper.find_event(span_events, "External/httpstat.us/Finch/GET")
+    external_span = TestHelper.find_event(span_events, "External/httpbin.org/Finch/GET")
 
-    assert external_span[:"http.url"] == "https://httpstat.us/500"
+    assert external_span[:"http.url"] == "https://httpbin.org/status/500"
     assert external_span[:"response.status"] == 500
   end
 
@@ -73,7 +73,7 @@ defmodule NewRelic.Telemetry.FinchTest do
     {:ok, pid} =
       Task.start(fn ->
         NewRelic.start_transaction("FinchTest", "Exception")
-        request("https://httpstat.us/200", :exception)
+        request("https://httpbin.org/status/200", :exception)
       end)
 
     Process.monitor(pid)
@@ -81,9 +81,9 @@ defmodule NewRelic.Telemetry.FinchTest do
 
     span_events = TestHelper.gather_harvest(Collector.SpanEvent.Harvester)
 
-    external_span = TestHelper.find_event(span_events, "External/httpstat.us/Finch/GET")
+    external_span = TestHelper.find_event(span_events, "External/httpbin.org/Finch/GET")
 
-    assert external_span[:"http.url"] == "https://httpstat.us/200"
+    assert external_span[:"http.url"] == "https://httpbin.org/status/200"
     assert external_span[:error] == true
     assert external_span[:"error.message"] =~ "Oops"
   end


### PR DESCRIPTION
This PR tweaks the harvest shutdown process so that it can handle situations where the harvester has already shut down. This can happen during application shutdown when the agent's manual shutdown process is underway.

Closes #511 
Closes https://github.com/newrelic/elixir_agent/issues/538

Thanks @sgessa for starting this in https://github.com/newrelic/elixir_agent/pull/534