### PR TITLE
Fix incorrect spec for report_custom_metric

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -376,7 +376,7 @@ defmodule NewRelic do
   NewRelic.report_custom_metric("My/Metric", 123)
   ```
   """
-  @spec report_custom_event(name :: String.t(), value :: number()) :: any()
+  @spec report_custom_metric(name :: String.t(), value :: number()) :: any()
   defdelegate report_custom_metric(name, value),
     to: NewRelic.Harvest.Collector.Metric.Harvester
 


### PR DESCRIPTION
A small fix for type spec declaration incorrectly referencing `report_custom_event/2` instead of `report_custom_metric/2` (probably a copy-paste error).