### PR TITLE
Improve Distributed Tracing error reporting

### DIFF
--- a/lib/new_relic/error/reporter/crash_report.ex
+++ b/lib/new_relic/error/reporter/crash_report.ex
@@ -42,43 +42,48 @@ defmodule NewRelic.Error.Reporter.CrashReport do
 
   def report_error(:process, report) do
     {kind, exception, stacktrace} = parse_error_info(report[:error_info])
+    already_reported? = {kind, exception, List.first(stacktrace)} == report[:dictionary][:nr_error_explicitly_reported]
 
-    {exception_type, exception_reason, exception_stacktrace} =
-      Util.Error.normalize(kind, exception, stacktrace, report[:initial_call])
+    if already_reported? do
+      :ignore
+    else
+      {exception_type, exception_reason, exception_stacktrace} =
+        Util.Error.normalize(kind, exception, stacktrace, report[:initial_call])
 
-    process_name = parse_process_name(report[:registered_name], stacktrace)
-    expected = parse_error_expected(exception)
-    automatic_attributes = NewRelic.Config.automatic_attributes()
+      process_name = parse_process_name(report[:registered_name], stacktrace)
+      expected = parse_error_expected(exception)
+      automatic_attributes = NewRelic.Config.automatic_attributes()
 
-    Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
-      timestamp: System.system_time(:millisecond) / 1_000,
-      error_type: exception_type,
-      message: exception_reason,
-      expected: expected,
-      stack_trace: exception_stacktrace,
-      transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name
-        })
-    })
+      Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
+        timestamp: System.system_time(:millisecond) / 1_000,
+        error_type: exception_type,
+        message: exception_reason,
+        expected: expected,
+        stack_trace: exception_stacktrace,
+        transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
+        user_attributes:
+          Map.merge(automatic_attributes, %{
+            process: process_name
+          })
+      })
 
-    Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
-      timestamp: System.system_time(:millisecond) / 1_000,
-      error_class: exception_type,
-      error_message: exception_reason,
-      expected: expected,
-      transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name,
-          stacktrace: Enum.join(exception_stacktrace, "\n")
-        })
-    })
+      Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
+        timestamp: System.system_time(:millisecond) / 1_000,
+        error_class: exception_type,
+        error_message: exception_reason,
+        expected: expected,
+        transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
+        user_attributes:
+          Map.merge(automatic_attributes, %{
+            process: process_name,
+            stacktrace: Enum.join(exception_stacktrace, "\n")
+          })
+      })
 
-    unless expected do
-      NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
-      NewRelic.report_metric(:error, error_count: 1)
+      unless expected do
+        NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
+        NewRelic.report_metric(:error, error_count: 1)
+      end
     end
   end
 

--- a/lib/new_relic/transaction/reporter.ex
+++ b/lib/new_relic/transaction/reporter.ex
@@ -101,7 +101,8 @@ defmodule NewRelic.Transaction.Reporter do
     :ok
   end
 
-  def error(%{kind: _kind, reason: _reason, stack: _stack} = error) do
+  def error(%{kind: kind, reason: reason, stack: stack} = error) do
+    Process.put(:nr_error_explicitly_reported, {kind, reason, List.first(stack)})
     Transaction.Sidecar.add(error: true, transaction_error: {:error, error})
   end
 

--- a/lib/new_relic/transaction/sidecar.ex
+++ b/lib/new_relic/transaction/sidecar.ex
@@ -196,10 +196,7 @@ defmodule NewRelic.Transaction.Sidecar do
     attributes =
       with {reason, stack} when reason != :shutdown <- down_reason,
            false <- match?(%{expected: true}, reason) do
-        Map.merge(state.attributes, %{
-          root_process_error: true,
-          transaction_error: {:error, %{kind: :exit, reason: reason, stack: stack}}
-        })
+        Map.put(state.attributes, :transaction_error, {:error, %{kind: :exit, reason: reason, stack: stack}})
       else
         _ -> state.attributes
       end


### PR DESCRIPTION
This PR updates Distributed Tracing (specifically "Spansaction") error reporting so that
* Error details show up in the Distributed Tracing UI
* We don't double report errors that are both reported manually in `telemetry` instrumentation and caught by the error logger filter
