### PR TITLE
Safely access :request_method on bandit start events

### DIFF
--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -619,7 +619,7 @@ defmodule NewRelic.Transaction.Complete do
       transaction_name: Util.metric_join(["WebTransaction", tx_attrs.name]),
       agent_attributes: %{
         http_response_code: tx_attrs[:status],
-        request_method: tx_attrs.request_method
+        request_method: tx_attrs[:request_method]
       },
       user_attributes:
         Map.merge(attributes, %{


### PR DESCRIPTION
82a0b1e added a path in which [:bandit, :server, :start] events missing `Plug.Conn` could propagate downstream without the `:request_id` attribute.

A dot-style accessor for `:request_method` downstream causes processes to crash, reporting the error from the New Relic Agent rather than the bandit error which caused the initial event.
