### PR TITLE
Lower log level for shutdown msg

### DIFF
--- a/lib/new_relic/harvest/harvest_cycle.ex
+++ b/lib/new_relic/harvest/harvest_cycle.ex
@@ -52,7 +52,7 @@ defmodule NewRelic.Harvest.HarvestCycle do
 
         receive do
           {:DOWN, _ref, _, ^harvester, _reason} ->
-            NewRelic.log(:warning, "Completed shutdown #{inspect(harvest_cycle)}")
+            NewRelic.log(:debug, "Completed shutdown #{inspect(harvest_cycle)}")
         end
     end
   end


### PR DESCRIPTION
Lowers the shutdown log message from `warning` to `debug` since this is normal part of application behavior, not something of concern.