### PR TITLE
Handle errors in cpu_sup

### DIFF
--- a/lib/new_relic/os_mon.ex
+++ b/lib/new_relic/os_mon.ex
@@ -16,7 +16,11 @@ defmodule NewRelic.OsMon do
 
   def util() do
     when_enabled(fn ->
-      :cpu_sup.util()
+      case :cpu_sup.util() do
+        {:error, _} -> nil
+        0 -> nil
+        val -> val
+      end
     end)
   end
 


### PR DESCRIPTION
As per [the docs](https://www.erlang.org/doc/apps/os_mon/cpu_sup.html#util/0), `cpu_sup` can return an error tuple, or `0` if it's not started. Handle these cases to prevent it bubbling up to the metric harvester, causing an ArgumentError.