### PR TITLE
Flatten attributes always, not just transaction

### DIFF
--- a/lib/new_relic.ex
+++ b/lib/new_relic.ex
@@ -248,10 +248,16 @@ defmodule NewRelic do
   Useful for reporting additional information about work being done in, for example,
   a function being traced with `@trace`
 
+  Reporting nested data structures is supported by auto-flattening them
+  into a list of key-value pairs, the same way `add_attributes/1` does.
+
   ## Example
 
   ```elixir
   NewRelic.add_span_attributes(some: "attribute")
+
+  NewRelic.add_span_attributes(map: %{foo: "bar"})
+    # "map.foo" => "bar"
   ```
   """
   @spec add_span_attributes(attributes :: Keyword.t()) :: any()
@@ -337,10 +343,16 @@ defmodule NewRelic do
   @doc """
   Report a Custom event to NRDB.
 
+  Reporting nested data structures is supported by auto-flattening them
+  into a list of key-value pairs, the same way `add_attributes/1` does.
+
   ## Example
 
   ```elixir
   NewRelic.report_custom_event("EventType", %{"foo" => "bar"})
+
+  NewRelic.report_custom_event("EventType", %{map: %{foo: "bar"}})
+    # "map.foo" => "bar"
   ```
   """
   @spec report_custom_event(type :: String.t(), event :: map()) :: any()

--- a/lib/new_relic/distributed_trace.ex
+++ b/lib/new_relic/distributed_trace.ex
@@ -265,9 +265,15 @@ defmodule NewRelic.DistributedTrace do
   end
 
   def add_span_attributes(attrs) do
+    flattened =
+      attrs
+      |> Enum.to_list()
+      |> NewRelic.Util.deep_flatten()
+      |> Map.new()
+
     Process.put(
       :nr_current_span_attrs,
-      Map.merge(get_span_attrs(), Map.new(attrs))
+      Map.merge(get_span_attrs(), flattened)
     )
 
     :ok

--- a/lib/new_relic/harvest/collector/custom_event/harvester.ex
+++ b/lib/new_relic/harvest/collector/custom_event/harvester.ex
@@ -76,7 +76,10 @@ defmodule NewRelic.Harvest.Collector.CustomEvent.Harvester do
 
   defp process(event) do
     event
+    |> Enum.to_list()
+    |> NewRelic.Util.deep_flatten()
     |> NewRelic.Util.coerce_attributes()
+    |> Map.new()
     |> Map.merge(NewRelic.Config.automatic_attributes())
   end
 

--- a/test/custom_event_test.exs
+++ b/test/custom_event_test.exs
@@ -114,6 +114,24 @@ defmodule CustomEventTest do
     assert TestHelper.find_metric(metrics, "Supportability/Elixir/Collector/HarvestSize/CustomEventData")
   end
 
+  test "Flatten nested attribute values" do
+    TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
+
+    NewRelic.report_custom_event("CustomEventTest", %{
+      name: "nested",
+      map: %{foo: "bar", baz: "qux"},
+      list: ["a", "b"]
+    })
+
+    events = TestHelper.gather_harvest(Collector.CustomEvent.Harvester)
+    event = TestHelper.find_event(events, "nested")
+
+    assert event["map.foo"] == "bar"
+    assert event["map.baz"] == "qux"
+    assert event["list.0"] == "a"
+    assert event["list.1"] == "b"
+  end
+
   test "Handle non-serializable attribute values" do
     TestHelper.restart_harvest_cycle(Collector.CustomEvent.HarvestCycle)
 

--- a/test/span_event_test.exs
+++ b/test/span_event_test.exs
@@ -116,6 +116,8 @@ defmodule SpanEventTest do
 
       NewRelic.span "another.span", with: "an attribute" do
         NewRelic.add_span_attributes(inside: "attribute!")
+        NewRelic.add_span_attributes(nested: %{foo: "bar", baz: "qux"})
+        NewRelic.add_span_attributes(list: ["a", "b"])
         Process.sleep(5)
       end
 
@@ -192,6 +194,10 @@ defmodule SpanEventTest do
     assert another_span[:category] == "generic"
     assert another_span[:with] == "an attribute"
     assert another_span[:inside] == "attribute!"
+    assert another_span["nested.foo"] == "bar"
+    assert another_span["nested.baz"] == "qux"
+    assert another_span["list.0"] == "a"
+    assert another_span["list.1"] == "b"
 
     single_span = TestHelper.find_event(span_events, "single.span")
 


### PR DESCRIPTION
This PR "deep flattens" attribues on Spans and Custom Events the same way we do for Transactions 